### PR TITLE
chore(ci): add standard Octo workflow suite

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      timezone: "Asia/Shanghai"
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      timezone: "Asia/Shanghai"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,20 @@
+# Release Drafter config — https://github.com/release-drafter/release-drafter
+name-template: "$NEXT_PATCH_VERSION"
+tag-template: "v$NEXT_PATCH_VERSION"
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+categories:
+  - title: "Features"
+    labels: ["type:feature"]
+  - title: "Bug Fixes"
+    labels: ["type:bug"]
+  - title: "CI and Infrastructure"
+    labels: ["type:chore", dependencies-changed, dependencies]
+  - title: "Documentation"
+    labels: ["type:docs"]
+exclude-labels: [skip-changelog]
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"

--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,0 +1,15 @@
+name: Auto add to project
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened, edited]
+
+permissions: {}
+
+jobs:
+  add-to-project:
+    uses: Mininglamp-OSS/.github/.github/workflows/auto-add-to-project.yml@main
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/check-sprint.yml
+++ b/.github/workflows/check-sprint.yml
@@ -2,7 +2,7 @@ name: Check Sprint
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
 
 permissions: {}
@@ -11,5 +11,8 @@ jobs:
   check-sprint:
     if: ${{ !github.event.pull_request.draft }}
     uses: Mininglamp-OSS/.github/.github/workflows/reusable-check-sprint.yml@main
+    with:
+      pr-number: ${{ github.event.pull_request.number }}
+      repo-name: ${{ github.repository }}
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/check-sprint.yml
+++ b/.github/workflows/check-sprint.yml
@@ -1,0 +1,15 @@
+name: Check Sprint
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  check-sprint:
+    if: ${{ !github.event.pull_request.draft }}
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-check-sprint.yml@main
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew testDebugUnitTest assembleDevDebug

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-codeql.yml@main
+    with:
+      language: java-kotlin
+    permissions:
+      actions: read
+      contents: read
+      security-events: write

--- a/.github/workflows/issue-welcome.yml
+++ b/.github/workflows/issue-welcome.yml
@@ -1,0 +1,11 @@
+name: Issue Welcome
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  welcome:
+    permissions:
+      issues: write
+    uses: Mininglamp-OSS/.github/.github/workflows/issue-welcome.yml@main

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: PR Labeler
+
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] metadata-only automation; no PR code executed
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  label:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-labeler.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      repo_owner: ${{ github.repository_owner }}
+      repo_name: ${{ github.event.repository.name }}
+    permissions:
+      issues: write
+      pull-requests: write

--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -1,0 +1,24 @@
+name: Octo CI Status
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: read
+
+jobs:
+  notify:
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-ci-status.yml@main
+    with:
+      repo_name: ${{ github.event.workflow_run.repository.name }}
+      workflow_name: ${{ github.event.workflow_run.name }}
+      conclusion: ${{ github.event.workflow_run.conclusion }}
+      run_id: ${{ github.event.workflow_run.id }}
+      run_url: ${{ github.event.workflow_run.html_url }}
+      project_group_id: "84667e59ee9544e6b31a2fb6d3a21b23"
+      workflow_id: ${{ github.event.workflow_run.workflow_id }}
+    secrets:
+      OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}

--- a/.github/workflows/octo-issue-feed.yml
+++ b/.github/workflows/octo-issue-feed.yml
@@ -1,0 +1,20 @@
+name: Octo Issue Feed
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-feed.yml@main
+    with:
+      repo_name: ${{ github.event.repository.name }}
+      issue_number: ${{ github.event.issue.number }}
+      issue_title: ${{ github.event.issue.title }}
+      issue_url: ${{ github.event.issue.html_url }}
+      issue_author: ${{ github.event.issue.user.login }}
+      event_action: ${{ github.event.action }}
+    secrets:
+      OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}

--- a/.github/workflows/octo-pr-result-notify.yml
+++ b/.github/workflows/octo-pr-result-notify.yml
@@ -1,0 +1,43 @@
+name: Octo PR Result Notify
+
+on:
+  pull_request_target:
+    types: [closed, reopened]
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+jobs:
+  pr-result:
+    if: github.event_name == 'pull_request_target'
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-result-notify.yml@main
+    with:
+      repo_name: ${{ github.event.repository.name }}
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_url: ${{ github.event.pull_request.html_url }}
+      pr_author: ${{ github.event.pull_request.user.login }}
+      event_kind: ${{ github.event.action == 'closed' && github.event.pull_request.merged == true && 'pr_merged' || github.event.action == 'closed' && 'pr_closed' || 'pr_reopened' }}
+      pr_additions: ${{ github.event.pull_request.additions }}
+      pr_deletions: ${{ github.event.pull_request.deletions }}
+      pr_changed_files: ${{ github.event.pull_request.changed_files }}
+    secrets:
+      OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}
+
+  review-result:
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      (github.event.review.state == 'approved' || github.event.review.state == 'changes_requested') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-result-notify.yml@main
+    with:
+      repo_name: ${{ github.event.repository.name }}
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_url: ${{ github.event.pull_request.html_url }}
+      pr_author: ${{ github.event.pull_request.user.login }}
+      event_kind: ${{ github.event.review.state == 'approved' && 'review_approved' || 'review_changes_requested' }}
+      reviewer: ${{ github.event.review.user.login }}
+    secrets:
+      OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}

--- a/.github/workflows/octo-pr-review-feed.yml
+++ b/.github/workflows/octo-pr-review-feed.yml
@@ -1,0 +1,22 @@
+name: Octo PR Review Feed
+
+on:
+  pull_request_target:
+    types: [ready_for_review, review_requested]
+
+permissions: {}
+
+jobs:
+  notify:
+    if: ${{ !github.event.pull_request.draft }}
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-review-feed.yml@main
+    with:
+      repo_name: ${{ github.event.repository.name }}
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_url: ${{ github.event.pull_request.html_url }}
+      pr_author: ${{ github.event.pull_request.user.login }}
+      event_action: ${{ github.event.action }}
+      project_group_id: '84667e59ee9544e6b31a2fb6d3a21b23'
+    secrets:
+      OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}

--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -1,0 +1,12 @@
+name: PR Contributor Welcome
+
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] metadata-only automation; no PR code executed
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  welcome:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-contributor-welcome.yml@main

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  draft:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-release-drafter.yml@main
+    permissions:
+      contents: write
+      pull-requests: read

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,31 @@
+name: Release Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v1.4.0)"
+        required: true
+        type: string
+      validate_run_id:
+        description: "Required: successful CI run ID from the tagged commit as release evidence"
+        required: true
+        type: string
+      draft:
+        description: "Keep as draft instead of publishing"
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  publish:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-release-publish.yml@main
+    with:
+      tag: ${{ inputs.tag }}
+      validate_run_id: ${{ inputs.validate_run_id }}
+      draft: ${{ inputs.draft }}
+    permissions:
+      contents: write
+      actions: read

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-stale.yml@main
+    permissions:
+      issues: write
+      pull-requests: write

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -1,0 +1,19 @@
+name: Workflow Sanity
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+permissions: {}
+
+jobs:
+  sanity:
+    uses: Mininglamp-OSS/.github/.github/workflows/workflow-sanity.yml@main
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary

Add the full standard GitHub Actions workflow set to match other Mininglamp-OSS repositories.

## New Workflows (15 files)

| Workflow | Purpose |
|---|---|
| auto-add-to-project | Auto-add issues/PRs to Octo project board |
| check-sprint | Enforce sprint assignment before merge |
| ci | Android build (ubuntu-latest, JDK 17 temurin, Gradle) |
| codeql | Java/Kotlin security analysis (reusable-codeql.yml) |
| issue-welcome | Welcome message for new issues |
| labeler | PR size labeling + dependency change detection |
| octo-ci-status | CI state-change notifications to Octo IM |
| octo-issue-feed | New issue notifications to Octo IM |
| octo-pr-result-notify | PR merge/close/review notifications |
| octo-pr-review-feed | PR review-request notifications |
| pr-contributor-welcome | First-time contributor welcome |
| release-drafter | Automated release note drafting |
| release-publish | Gated release publishing with CI validation |
| stale | Stale issue/PR management |
| workflow-sanity | YAML lint on workflow changes |

## Config

- `.github/dependabot.yml`: weekly updates for github-actions + gradle

## Notes

- Octo IM `project_group_id`: `84667e59ee9544e6b31a2fb6d3a21b23` (octo-android group)
- CI uses `gradle/actions/setup-gradle@v4` for Gradle caching