### PR TITLE
fix: chat history file search and forward to contacts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
         applicationId appId
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 31
-        versionName "1.3.0"
+        versionCode 32
+        versionName "1.3.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/wkbase/src/main/java/com/chat/base/msgcontent/WKFileContent.java
+++ b/wkbase/src/main/java/com/chat/base/msgcontent/WKFileContent.java
@@ -94,6 +94,12 @@ public class WKFileContent extends WKMediaMessageContent implements Parcelable {
     }
 
     @Override
+    public String getSearchableWord() {
+        String prefix = WKBaseApplication.getInstance().getContext().getString(R.string.last_message_file);
+        return name != null ? prefix + name : prefix;
+    }
+
+    @Override
     public String getDisplayContent() {
         return WKBaseApplication.getInstance().getContext().getString(R.string.last_message_file);
     }

--- a/wkim/src/main/java/com/xinbida/wukongim/db/MsgDbManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/MsgDbManager.java
@@ -1190,22 +1190,20 @@ public class MsgDbManager {
         if (TextUtils.isEmpty(channelID) || contentTypes == null || contentTypes.length == 0) {
             return null;
         }
-        String whereStr = "";
-        for (int contentType : contentTypes) {
-            if (TextUtils.isEmpty(whereStr)) {
-                whereStr = String.valueOf(contentType);
-            } else {
-                whereStr = "," + contentType;
-            }
+        StringBuilder whereBuilder = new StringBuilder();
+        for (int i = 0; i < contentTypes.length; i++) {
+            if (i > 0) whereBuilder.append(",");
+            whereBuilder.append(contentTypes[i]);
         }
+        String inClause = whereBuilder.toString();
         Object[] args;
         String sql;
         if (oldestOrderSeq <= 0) {
-            args = new Object[]{channelID, channelType, whereStr};
-            sql = "select * from (select " + messageCols + "," + extraCols + " from " + message + " left join " + messageExtra + " on " + message + ".message_id= " + messageExtra + ".message_id where " + message + ".channel_id=? and " + message + ".channel_type=? and " + message + ".type<>0 and " + message + ".type<>99 and " + message + ".type in (?)) where is_deleted=0 and revoke=0 order by order_seq desc limit 0," + limit;
+            args = new Object[]{channelID, channelType};
+            sql = "select * from (select " + messageCols + "," + extraCols + " from " + message + " left join " + messageExtra + " on " + message + ".message_id= " + messageExtra + ".message_id where " + message + ".channel_id=? and " + message + ".channel_type=? and " + message + ".type<>0 and " + message + ".type<>99 and " + message + ".type in (" + inClause + ")) where is_deleted=0 and revoke=0 order by order_seq desc limit 0," + limit;
         } else {
-            args = new Object[]{channelID, channelType, oldestOrderSeq, whereStr};
-            sql = "select * from (select " + messageCols + "," + extraCols + " from " + message + " left join " + messageExtra + " on " + message + ".message_id= " + messageExtra + ".message_id where " + message + ".channel_id=? and " + message + ".channel_type=? and " + message + ".order_seq<? and " + message + ".type<>0 and " + message + ".type<>99 and " + message + ".type in (?)) where is_deleted=0 and revoke=0 order by order_seq desc limit 0," + limit;
+            args = new Object[]{channelID, channelType, oldestOrderSeq};
+            sql = "select * from (select " + messageCols + "," + extraCols + " from " + message + " left join " + messageExtra + " on " + message + ".message_id= " + messageExtra + ".message_id where " + message + ".channel_id=? and " + message + ".channel_type=? and " + message + ".order_seq<? and " + message + ".type<>0 and " + message + ".type<>99 and " + message + ".type in (" + inClause + ")) where is_deleted=0 and revoke=0 order by order_seq desc limit 0," + limit;
         }
         List<WKMsg> wkMsgs = new ArrayList<>();
         try (Cursor cursor = WKIMApplication

--- a/wkim/src/main/java/com/xinbida/wukongim/db/MsgDbManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/MsgDbManager.java
@@ -1121,7 +1121,8 @@ public class MsgDbManager {
                 " m.client_seq else ''END client_seq, CASE count(*) WHEN 1 THEN m.searchable_word else '' end searchable_word," +
                 " CASE count(*) WHEN 1 THEN m.order_seq ELSE 0 END order_seq " +
                 "from " + channel + " c LEFT JOIN " + message + " m ON m.channel_id = c.channel_id and " +
-                "m.channel_type = c.channel_type WHERE m.is_deleted=0 and searchable_word LIKE ? GROUP BY " +
+                "m.channel_type = c.channel_type LEFT JOIN " + messageExtra + " e ON m.message_id = e.message_id " +
+                "WHERE m.is_deleted=0 and IFNULL(e.revoke,0)=0 and searchable_word LIKE ? GROUP BY " +
                 "c.channel_id, c.channel_type ORDER BY m.created_at DESC limit 100";
         Cursor cursor = WKIMApplication.getInstance().getDbHelper().rawQuery(sql, new Object[]{"%" + searchKey + "%"});
         if (cursor == null) {

--- a/wkuikit/src/main/AndroidManifest.xml
+++ b/wkuikit/src/main/AndroidManifest.xml
@@ -105,6 +105,7 @@
         <activity android:name="com.chat.uikit.chat.search.member.SearchWithMemberActivity" />
         <activity android:name="com.chat.uikit.chat.search.date.SearchWithDateActivity" />
         <activity android:name="com.chat.uikit.chat.search.image.SearchWithImgActivity" />
+        <activity android:name="com.chat.uikit.chat.search.file.SearchWithFileActivity" />
 
         <service
             android:name="com.chat.uikit.AliveJobService"

--- a/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
+++ b/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
@@ -699,6 +699,20 @@ public class WKUIKitApplication {
             return null;
         });
 
+        // 搜索消息按文件搜索
+        EndpointManager.getInstance().setMethod("search_message_with_file", EndpointCategory.wkSearchChatContent, 97, object -> {
+            if (object instanceof WKChannel) {
+                return new SearchChatContentMenu(WKBaseApplication.getInstance().getContext().getString(R.string.uikit_search_for_file), (channelID, channelType) -> {
+                    Intent intent = new Intent(WKBaseApplication.getInstance().getContext(), com.chat.uikit.chat.search.file.SearchWithFileActivity.class);
+                    intent.putExtra("channel_id", ((WKChannel) object).channelID);
+                    intent.putExtra("channel_type", ((WKChannel) object).channelType);
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    WKBaseApplication.getInstance().getContext().startActivity(intent);
+                });
+            }
+            return null;
+        });
+
     }
 
     public void sendChooseChatBack(List<WKChannel> list) {
@@ -1006,4 +1020,5 @@ public class WKUIKitApplication {
         sureTv.setTextColor(ContextCompat.getColor(context, R.color.colorAccent));
 
     }
+
 }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChooseChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChooseChatActivity.java
@@ -31,6 +31,8 @@ import androidx.annotation.NonNull;
 
 import com.chat.base.base.WKBaseActivity;
 import com.chat.base.config.WKConfig;
+import com.chat.base.endpoint.EndpointManager;
+import com.chat.base.endpoint.entity.ChooseContactsMenu;
 import com.chat.base.msgitem.WKChannelMemberRole;
 import com.chat.base.ui.components.SegmentTabView;
 import com.chat.base.utils.SoftKeyboardUtils;
@@ -40,7 +42,6 @@ import com.chat.uikit.WKUIKitApplication;
 import com.chat.uikit.category.CategoryEntity;
 import com.chat.uikit.category.CategoryModel;
 import com.chat.uikit.chat.adapter.ChooseChatAdapter;
-import com.chat.uikit.contacts.ChooseContactsActivity;
 import com.chat.uikit.databinding.ActChooseChatLayoutBinding;
 import com.chat.uikit.message.MsgModel;
 import com.chat.uikit.thread.service.ThreadModel;
@@ -160,10 +161,23 @@ public class ChooseChatActivity extends WKBaseActivity<ActChooseChatLayoutBindin
         initAdapter(wkVBinding.recyclerView, chooseChatAdapter);
 
         wkVBinding.createTv.setOnClickListener(v -> {
-            Intent intent = new Intent(this, ChooseContactsActivity.class);
-            if (WKUIKitApplication.getInstance().getMessageContentList() != null)
-                intent.putParcelableArrayListExtra("msgContentList", (ArrayList<? extends Parcelable>) WKUIKitApplication.getInstance().getMessageContentList());
-            startActivity(intent);
+            ChooseContactsMenu contactsMenu = new ChooseContactsMenu(9, true, false, null, selectedList -> {
+                if (WKReader.isNotEmpty(selectedList)) {
+                    if (isChoose && WKUIKitApplication.getInstance().getMessageContentList() != null) {
+                        WKUIKitApplication.getInstance().showChatConfirmDialog(this, selectedList, WKUIKitApplication.getInstance().getMessageContentList(), new WKUIKitApplication.IShowChatConfirm() {
+                            @Override
+                            public void onBack(@NonNull List<WKChannel> list, @NonNull List<com.xinbida.wukongim.msgmodel.WKMessageContent> messageContentList) {
+                                WKUIKitApplication.getInstance().sendChooseChatBack(list);
+                                finish();
+                            }
+                        });
+                    } else {
+                        WKUIKitApplication.getInstance().sendChooseChatBack(selectedList);
+                        finish();
+                    }
+                }
+            });
+            EndpointManager.getInstance().invoke("choose_contacts", contactsMenu);
         });
 
         segmentTabView = new SegmentTabView(this,

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/SearchMessageAdapter.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/SearchMessageAdapter.kt
@@ -18,6 +18,8 @@ package com.chat.uikit.chat.search
 
 import android.os.Build
 import android.text.Html
+import android.view.View
+import android.widget.ImageView
 import android.widget.TextView
 import com.chad.library.adapter.base.BaseQuickAdapter
 import com.chad.library.adapter.base.viewholder.BaseViewHolder
@@ -26,6 +28,7 @@ import com.chat.base.msgitem.WKContentType
 import com.chat.base.ui.components.AvatarView
 import com.chat.base.utils.WKTimeUtils
 import com.chat.uikit.R
+import com.chat.uikit.chat.provider.WKFileProvider
 import com.chat.uikit.search.remote.GlobalAdapter
 
 class SearchMessageAdapter :
@@ -46,11 +49,22 @@ class SearchMessageAdapter :
             holder.setText(R.id.nameTv, Html.fromHtml(item.channel.getHtmlName()))
         }
         val contentTv = holder.getView<TextView>(R.id.contentTv)
+        val fileTagIv = holder.getView<ImageView>(R.id.fileTagIv)
+        val type = item.getContentType()
+
+        if (type == WKContentType.WK_FILE) {
+            fileTagIv.visibility = View.VISIBLE
+            val extension = item.payload["extension"] as? String ?: ""
+            val fileName = item.payload["name"] as? String ?: ""
+            WKFileProvider.setFileIcon(fileTagIv, extension, fileName)
+        } else {
+            fileTagIv.visibility = View.GONE
+        }
+
         val rawContent = item.payload["content"]
         if (rawContent is String && rawContent.isNotEmpty() && !rawContent.contains("<mark>")) {
             contentTv.text = GlobalAdapter.highlightKeyword(rawContent, keyword)
         } else {
-            val type = item.getContentType()
             if (type == WKContentType.WK_TEXT) {
                 contentTv.text = Html.fromHtml(item.getHtmlText(), Html.FROM_HTML_MODE_LEGACY)
             } else if (type == WKContentType.WK_FILE) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchFileEntity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchFileEntity.java
@@ -1,0 +1,21 @@
+package com.chat.uikit.chat.search.file;
+
+import com.chad.library.adapter.base.entity.MultiItemEntity;
+import com.chat.base.entity.GlobalMessage;
+
+public class SearchFileEntity implements MultiItemEntity {
+    public static final int TYPE_FILE = 0;
+    public static final int TYPE_DATE_HEADER = 1;
+
+    public int itemType;
+    public GlobalMessage message;
+    public String date;
+    public String fileName;
+    public String extension;
+    public long fileSize;
+
+    @Override
+    public int getItemType() {
+        return itemType;
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchFileEntity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchFileEntity.java
@@ -2,6 +2,7 @@ package com.chat.uikit.chat.search.file;
 
 import com.chad.library.adapter.base.entity.MultiItemEntity;
 import com.chat.base.entity.GlobalMessage;
+import com.xinbida.wukongim.msgmodel.WKMessageContent;
 
 public class SearchFileEntity implements MultiItemEntity {
     public static final int TYPE_FILE = 0;
@@ -9,6 +10,7 @@ public class SearchFileEntity implements MultiItemEntity {
 
     public int itemType;
     public GlobalMessage message;
+    public WKMessageContent originalContent;
     public String date;
     public String fileName;
     public String extension;

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchWithFileActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchWithFileActivity.java
@@ -149,7 +149,9 @@ public class SearchWithFileActivity extends WKBaseActivity<ActSearchMsgFileLayou
     }
 
     private void forward(SearchFileEntity entity) {
-        WKMessageContent content = entity.message.getMessageModel();
+        WKMessageContent content = entity.originalContent != null
+                ? entity.originalContent
+                : entity.message.getMessageModel();
         if (content == null) return;
 
         EndpointManager.getInstance().invoke(EndpointSID.showChooseChatView,
@@ -192,6 +194,7 @@ public class SearchWithFileActivity extends WKBaseActivity<ActSearchMsgFileLayou
                         entity.fileName = fileContent.name != null ? fileContent.name : "";
                         entity.extension = fileContent.extension != null ? fileContent.extension : "";
                         entity.fileSize = fileContent.size;
+                        entity.originalContent = fileContent;
 
                         GlobalMessage gm = new GlobalMessage();
                         gm.setMessage_seq(msg.messageSeq);

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchWithFileActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchWithFileActivity.java
@@ -177,6 +177,7 @@ public class SearchWithFileActivity extends WKBaseActivity<ActSearchMsgFileLayou
                     .searchMsgWithChannelAndContentTypes(channelID, channelType, 0, 200, new int[]{WKContentType.WK_FILE});
             if (WKReader.isNotEmpty(localMsgs)) {
                 for (WKMsg msg : localMsgs) {
+                    if (com.chat.base.space.SpaceFilter.shouldSkipMessageForSpace(msg)) continue;
                     if (msg.baseContentMsgModel instanceof WKFileContent fileContent) {
                         // 按文件名过滤
                         if (!TextUtils.isEmpty(searchKeyword) && fileContent.name != null
@@ -276,14 +277,13 @@ public class SearchWithFileActivity extends WKBaseActivity<ActSearchMsgFileLayou
     }
 
     private void addDateHeaderIfNeeded(List<SearchFileEntity> list, String date) {
+        String lastDate = null;
         if (WKReader.isNotEmpty(list)) {
-            if (!list.get(list.size() - 1).date.equals(date)) {
-                SearchFileEntity header = new SearchFileEntity();
-                header.date = date;
-                header.itemType = SearchFileEntity.TYPE_DATE_HEADER;
-                list.add(header);
-            }
-        } else {
+            lastDate = list.get(list.size() - 1).date;
+        } else if (WKReader.isNotEmpty(adapter.getData())) {
+            lastDate = adapter.getData().get(adapter.getData().size() - 1).date;
+        }
+        if (!date.equals(lastDate)) {
             SearchFileEntity header = new SearchFileEntity();
             header.date = date;
             header.itemType = SearchFileEntity.TYPE_DATE_HEADER;

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchWithFileActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchWithFileActivity.java
@@ -132,6 +132,8 @@ public class SearchWithFileActivity extends WKBaseActivity<ActSearchMsgFileLayou
                     page = 1;
                     seenSeqs.clear();
                     adapter.setList(new ArrayList<>());
+                    wkVBinding.refreshLayout.setEnableLoadMore(true);
+                    wkVBinding.nodataTv.setVisibility(View.GONE);
                     getData();
                 }, 300);
             }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchWithFileActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchWithFileActivity.java
@@ -51,6 +51,8 @@ public class SearchWithFileActivity extends WKBaseActivity<ActSearchMsgFileLayou
     private SearchWithFileAdapter adapter;
     private int page = 1;
     private String searchKeyword = "";
+    private final Set<Long> seenSeqs = new HashSet<>();
+    private final android.os.Handler searchHandler = new android.os.Handler(android.os.Looper.getMainLooper());
 
     @Override
     protected ActSearchMsgFileLayoutBinding getViewBinding() {
@@ -125,9 +127,13 @@ public class SearchWithFileActivity extends WKBaseActivity<ActSearchMsgFileLayou
             @Override
             public void afterTextChanged(Editable editable) {
                 searchKeyword = editable.toString().trim();
-                page = 1;
-                adapter.setList(new ArrayList<>());
-                getData();
+                searchHandler.removeCallbacksAndMessages(null);
+                searchHandler.postDelayed(() -> {
+                    page = 1;
+                    seenSeqs.clear();
+                    adapter.setList(new ArrayList<>());
+                    getData();
+                }, 300);
             }
         });
     }
@@ -163,7 +169,6 @@ public class SearchWithFileActivity extends WKBaseActivity<ActSearchMsgFileLayou
     private void getData() {
         // 本地搜索：按类型查出所有文件消息
         List<SearchFileEntity> localFileEntities = new ArrayList<>();
-        Set<Long> seenSeqs = new HashSet<>();
 
         if (page == 1) {
             List<WKMsg> localMsgs = WKIM.getInstance().getMsgManager()

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchWithFileActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchWithFileActivity.java
@@ -1,0 +1,285 @@
+package com.chat.uikit.chat.search.file;
+
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.LinearLayoutManager;
+
+import com.chat.base.base.WKBaseActivity;
+import com.chat.base.endpoint.EndpointManager;
+import com.chat.base.endpoint.EndpointSID;
+import com.chat.base.endpoint.entity.ChatChooseContacts;
+import com.chat.base.endpoint.entity.ChatViewMenu;
+import com.chat.base.endpoint.entity.ChooseChatMenu;
+import com.chat.base.entity.GlobalMessage;
+import com.chat.base.entity.GlobalSearchReq;
+import com.chat.base.msgitem.WKContentType;
+import com.chat.base.search.GlobalSearchModel;
+import com.chat.base.utils.SoftKeyboardUtils;
+import com.chat.base.utils.WKReader;
+import com.chat.base.utils.WKTimeUtils;
+import com.chat.base.views.pinnedsectionitemdecoration.PinnedHeaderItemDecoration;
+import com.chat.uikit.R;
+import com.chat.uikit.databinding.ActSearchMsgFileLayoutBinding;
+import com.google.android.material.snackbar.Snackbar;
+import com.scwang.smart.refresh.layout.api.RefreshLayout;
+import com.scwang.smart.refresh.layout.listener.OnRefreshLoadMoreListener;
+import com.xinbida.wukongim.WKIM;
+import com.xinbida.wukongim.entity.WKChannel;
+import com.xinbida.wukongim.entity.WKChannelType;
+import com.xinbida.wukongim.entity.WKMsg;
+import com.xinbida.wukongim.msgmodel.WKMessageContent;
+
+import com.chat.base.msgcontent.WKFileContent;
+import com.chat.base.net.HttpResponseCode;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class SearchWithFileActivity extends WKBaseActivity<ActSearchMsgFileLayoutBinding> {
+    private String channelID;
+    private byte channelType;
+    private SearchWithFileAdapter adapter;
+    private int page = 1;
+    private String searchKeyword = "";
+
+    @Override
+    protected ActSearchMsgFileLayoutBinding getViewBinding() {
+        return ActSearchMsgFileLayoutBinding.inflate(getLayoutInflater());
+    }
+
+    @Override
+    protected void setTitle(TextView titleTv) {
+        titleTv.setText(R.string.uikit_search_for_file);
+    }
+
+    @Override
+    protected void initPresenter() {
+        channelID = getIntent().getStringExtra("channel_id");
+        channelType = getIntent().getByteExtra("channel_type", WKChannelType.PERSONAL);
+    }
+
+    @Override
+    protected void initView() {
+        PinnedHeaderItemDecoration headerDecoration = new PinnedHeaderItemDecoration.Builder(
+                SearchFileEntity.TYPE_DATE_HEADER).enableDivider(false).create();
+        wkVBinding.recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new SearchWithFileAdapter(new SearchWithFileAdapter.IClick() {
+            @Override
+            public void onClick(SearchFileEntity entity) {
+                showInChat(entity.message);
+            }
+
+            @Override
+            public void onForward(SearchFileEntity entity) {
+                forward(entity);
+            }
+        });
+        wkVBinding.recyclerView.setAdapter(adapter);
+        wkVBinding.recyclerView.addItemDecoration(headerDecoration);
+    }
+
+    @Override
+    protected void initListener() {
+        getData();
+
+        wkVBinding.refreshLayout.setEnableRefresh(false);
+        wkVBinding.refreshLayout.setOnRefreshLoadMoreListener(new OnRefreshLoadMoreListener() {
+            @Override
+            public void onLoadMore(@NonNull RefreshLayout refreshLayout) {
+                page++;
+                getData();
+            }
+
+            @Override
+            public void onRefresh(@NonNull RefreshLayout refreshLayout) {
+            }
+        });
+
+        wkVBinding.searchEt.setImeOptions(EditorInfo.IME_ACTION_SEARCH);
+        wkVBinding.searchEt.setOnEditorActionListener((v, actionId, event) -> {
+            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                SoftKeyboardUtils.getInstance().hideSoftKeyboard(this);
+                return true;
+            }
+            return false;
+        });
+        wkVBinding.searchEt.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable editable) {
+                searchKeyword = editable.toString().trim();
+                page = 1;
+                adapter.setList(new ArrayList<>());
+                getData();
+            }
+        });
+    }
+
+    private void showInChat(GlobalMessage msg) {
+        long orderSeq = WKIM.getInstance().getMsgManager().getMessageOrderSeq(
+                msg.getMessage_seq(),
+                msg.getChannel().getChannel_id(),
+                msg.getChannel().getChannel_type()
+        );
+        EndpointManager.getInstance().invoke(EndpointSID.chatView,
+                new ChatViewMenu(this, channelID, channelType, orderSeq, false));
+    }
+
+    private void forward(SearchFileEntity entity) {
+        WKMessageContent content = entity.message.getMessageModel();
+        if (content == null) return;
+
+        EndpointManager.getInstance().invoke(EndpointSID.showChooseChatView,
+                new ChooseChatMenu(new ChatChooseContacts(list -> {
+                    if (WKReader.isNotEmpty(list)) {
+                        for (WKChannel channel : list) {
+                            WKIM.getInstance().getMsgManager().send(content, channel);
+                        }
+                        ViewGroup viewGroup = (ViewGroup) findViewById(android.R.id.content).getRootView();
+                        Snackbar.make(viewGroup, getString(R.string.is_forward), 1000)
+                                .setAction("", v -> {})
+                                .show();
+                    }
+                }), content));
+    }
+
+    private void getData() {
+        // 本地搜索：按类型查出所有文件消息
+        List<SearchFileEntity> localFileEntities = new ArrayList<>();
+        Set<Long> seenSeqs = new HashSet<>();
+
+        if (page == 1) {
+            List<WKMsg> localMsgs = WKIM.getInstance().getMsgManager()
+                    .searchMsgWithChannelAndContentTypes(channelID, channelType, 0, 200, new int[]{WKContentType.WK_FILE});
+            if (WKReader.isNotEmpty(localMsgs)) {
+                for (WKMsg msg : localMsgs) {
+                    if (msg.baseContentMsgModel instanceof WKFileContent fileContent) {
+                        // 按文件名过滤
+                        if (!TextUtils.isEmpty(searchKeyword) && fileContent.name != null
+                                && !fileContent.name.toLowerCase().contains(searchKeyword.toLowerCase())) {
+                            continue;
+                        }
+                        if (!seenSeqs.add((long) msg.messageSeq)) continue;
+
+                        String date = WKTimeUtils.getInstance().time2YearMonth(msg.timestamp * 1000);
+                        addDateHeaderIfNeeded(localFileEntities, date);
+
+                        SearchFileEntity entity = new SearchFileEntity();
+                        entity.date = date;
+                        entity.itemType = SearchFileEntity.TYPE_FILE;
+                        entity.fileName = fileContent.name != null ? fileContent.name : "";
+                        entity.extension = fileContent.extension != null ? fileContent.extension : "";
+                        entity.fileSize = fileContent.size;
+
+                        GlobalMessage gm = new GlobalMessage();
+                        gm.setMessage_seq(msg.messageSeq);
+                        gm.setFrom_uid(msg.fromUID != null ? msg.fromUID : "");
+                        gm.setTimestamp(msg.timestamp);
+                        gm.setClient_msg_no(msg.clientMsgNO != null ? msg.clientMsgNO : "");
+                        com.chat.base.entity.GlobalChannel gc = new com.chat.base.entity.GlobalChannel();
+                        gc.setChannel_id(channelID);
+                        gc.setChannel_type(channelType);
+                        gm.setChannel(gc);
+                        java.util.HashMap<String, Object> payloadMap = new java.util.HashMap<>();
+                        payloadMap.put("type", msg.type);
+                        payloadMap.put("name", entity.fileName);
+                        payloadMap.put("extension", entity.extension);
+                        payloadMap.put("size", entity.fileSize);
+                        gm.setPayload(payloadMap);
+                        entity.message = gm;
+
+                        localFileEntities.add(entity);
+                    }
+                }
+            }
+        }
+
+        // API 搜索
+        ArrayList<Integer> contentType = new ArrayList<>();
+        contentType.add(WKContentType.WK_FILE);
+        GlobalSearchReq req = new GlobalSearchReq(1, searchKeyword, channelID, channelType,
+                "", "", contentType, page, 20, 0, 0);
+        GlobalSearchModel.INSTANCE.search(req, (code, s, globalSearch) -> {
+            wkVBinding.refreshLayout.finishLoadMore();
+            wkVBinding.refreshLayout.finishRefresh();
+
+            List<SearchFileEntity> merged = new ArrayList<>(localFileEntities);
+
+            if (code == HttpResponseCode.success && globalSearch != null && WKReader.isNotEmpty(globalSearch.messages)) {
+                for (GlobalMessage msg : globalSearch.messages) {
+                    if (!seenSeqs.add(msg.getMessage_seq())) continue;
+
+                    WKMessageContent content = msg.getMessageModel();
+                    if (content == null) continue;
+
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> payload = (Map<String, Object>) msg.getPayload();
+                    if (payload == null) continue;
+
+                    String date = WKTimeUtils.getInstance().time2YearMonth(msg.getTimestamp() * 1000);
+                    addDateHeaderIfNeeded(merged, date);
+
+                    SearchFileEntity entity = new SearchFileEntity();
+                    entity.date = date;
+                    entity.itemType = SearchFileEntity.TYPE_FILE;
+                    entity.message = msg;
+                    entity.fileName = payload.get("name") instanceof String ? (String) payload.get("name") : "";
+                    entity.extension = payload.get("extension") instanceof String ? (String) payload.get("extension") : "";
+                    Object sizeObj = payload.get("size");
+                    entity.fileSize = sizeObj instanceof Number ? ((Number) sizeObj).longValue() : 0;
+                    merged.add(entity);
+                }
+            }
+
+            if (merged.isEmpty()) {
+                wkVBinding.refreshLayout.finishLoadMoreWithNoMoreData();
+                if (page == 1) {
+                    wkVBinding.refreshLayout.setEnableLoadMore(false);
+                    wkVBinding.nodataTv.setVisibility(View.VISIBLE);
+                    adapter.setList(new ArrayList<>());
+                }
+            } else {
+                wkVBinding.nodataTv.setVisibility(View.GONE);
+                if (page == 1) {
+                    adapter.setList(merged);
+                } else {
+                    adapter.addData(merged);
+                }
+            }
+            return null;
+        });
+    }
+
+    private void addDateHeaderIfNeeded(List<SearchFileEntity> list, String date) {
+        if (WKReader.isNotEmpty(list)) {
+            if (!list.get(list.size() - 1).date.equals(date)) {
+                SearchFileEntity header = new SearchFileEntity();
+                header.date = date;
+                header.itemType = SearchFileEntity.TYPE_DATE_HEADER;
+                list.add(header);
+            }
+        } else {
+            SearchFileEntity header = new SearchFileEntity();
+            header.date = date;
+            header.itemType = SearchFileEntity.TYPE_DATE_HEADER;
+            list.add(header);
+        }
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchWithFileAdapter.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/file/SearchWithFileAdapter.java
@@ -1,0 +1,54 @@
+package com.chat.uikit.chat.search.file;
+
+import android.widget.ImageView;
+
+import com.chad.library.adapter.base.BaseMultiItemQuickAdapter;
+import com.chad.library.adapter.base.viewholder.BaseViewHolder;
+import com.chat.base.entity.PopupMenuItem;
+import com.chat.base.utils.WKDialogUtils;
+import com.chat.base.utils.WKTimeUtils;
+import com.chat.uikit.R;
+import com.chat.uikit.chat.provider.WKFileProvider;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class SearchWithFileAdapter extends BaseMultiItemQuickAdapter<SearchFileEntity, BaseViewHolder> {
+    private final IClick iClick;
+
+    SearchWithFileAdapter(IClick iClick) {
+        super();
+        this.iClick = iClick;
+        addItemType(SearchFileEntity.TYPE_FILE, R.layout.item_search_msg_file_layout);
+        addItemType(SearchFileEntity.TYPE_DATE_HEADER, R.layout.item_search_msg_img_date_layout);
+    }
+
+    @Override
+    protected void convert(@NotNull BaseViewHolder holder, SearchFileEntity entity) {
+        if (entity.getItemType() == SearchFileEntity.TYPE_DATE_HEADER) {
+            holder.setText(R.id.dateTv, entity.date);
+        } else {
+            holder.setText(R.id.fileNameTv, entity.fileName);
+            holder.setText(R.id.fileSizeTv, WKFileProvider.formatFileSize(entity.fileSize));
+            holder.setText(R.id.fileTimeTv,
+                    WKTimeUtils.getInstance().getTimeString(entity.message.getTimestamp() * 1000));
+
+            ImageView fileIconIv = holder.getView(R.id.fileIconIv);
+            WKFileProvider.setFileIcon(fileIconIv, entity.extension, entity.fileName);
+
+            List<PopupMenuItem> list = new ArrayList<>();
+            list.add(new PopupMenuItem(getContext().getString(R.string.forward), R.mipmap.msg_forward,
+                    () -> iClick.onForward(entity)));
+            list.add(new PopupMenuItem(getContext().getString(R.string.uikit_go_to_chat_item), R.mipmap.msg_message,
+                    () -> iClick.onClick(entity)));
+            WKDialogUtils.getInstance().setViewLongClickPopup(holder.itemView, list);
+        }
+    }
+
+    public interface IClick {
+        void onClick(SearchFileEntity entity);
+        void onForward(SearchFileEntity entity);
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchImgEntity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchImgEntity.java
@@ -18,6 +18,7 @@ package com.chat.uikit.chat.search.image;
 
 import com.chad.library.adapter.base.entity.MultiItemEntity;
 import com.chat.base.entity.GlobalMessage;
+import com.xinbida.wukongim.msgmodel.WKMessageContent;
 
 /**
  * 3/23/21 10:31 AM
@@ -26,6 +27,7 @@ import com.chat.base.entity.GlobalMessage;
 public class SearchImgEntity implements MultiItemEntity {
     public int itemType;
     public GlobalMessage message;
+    public WKMessageContent originalContent;
     public String url;
     public String date;
 //    public String clientMsgNo;

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchWithImgActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchWithImgActivity.java
@@ -37,6 +37,7 @@ import com.chat.base.entity.GlobalSearchReq;
 import com.chat.base.entity.ImagePopupBottomSheetItem;
 import com.chat.base.foldable.PaneMetrics;
 import com.chat.base.msgitem.WKContentType;
+import com.chat.base.net.HttpResponseCode;
 import com.chat.base.search.GlobalSearchModel;
 import com.chat.base.ui.Theme;
 import com.chat.base.utils.AndroidUtilities;
@@ -56,12 +57,16 @@ import com.xinbida.wukongim.entity.WKChannel;
 import com.xinbida.wukongim.entity.WKChannelType;
 import com.xinbida.wukongim.entity.WKMsg;
 import com.xinbida.wukongim.msgmodel.WKImageContent;
+import com.xinbida.wukongim.msgmodel.WKMediaMessageContent;
 import com.xinbida.wukongim.msgmodel.WKMessageContent;
+import com.xinbida.wukongim.msgmodel.WKVideoContent;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * 3/23/21 10:07 AM
@@ -80,7 +85,7 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
 
     @Override
     protected void setTitle(TextView titleTv) {
-        titleTv.setText(R.string.image);
+        titleTv.setText(R.string.uikit_search_for_image);
     }
 
     @Override
@@ -244,73 +249,143 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
     }
 
     private void getData() {
+        // 本地搜索
+        List<SearchImgEntity> localEntities = new ArrayList<>();
+        Set<Long> seenSeqs = new HashSet<>();
+
+        if (page == 1) {
+            List<WKMsg> localMsgs = WKIM.getInstance().getMsgManager()
+                    .searchMsgWithChannelAndContentTypes(channelID, channelType, 0, 200,
+                            new int[]{WKContentType.WK_IMAGE, WKContentType.WK_VIDEO});
+            if (WKReader.isNotEmpty(localMsgs)) {
+                for (WKMsg msg : localMsgs) {
+                    if (msg.baseContentMsgModel == null) continue;
+                    if (!seenSeqs.add((long) msg.messageSeq)) continue;
+
+                    String showUrl = "";
+                    if (msg.baseContentMsgModel instanceof WKImageContent imgContent) {
+                        if (!TextUtils.isEmpty(imgContent.localPath) && new File(imgContent.localPath).exists()) {
+                            showUrl = imgContent.localPath;
+                        }
+                        if (TextUtils.isEmpty(showUrl)) {
+                            showUrl = WKApiConfig.getShowUrl(imgContent.url);
+                        }
+                    } else if (msg.baseContentMsgModel instanceof WKVideoContent videoContent) {
+                        if (!TextUtils.isEmpty(videoContent.coverLocalPath) && new File(videoContent.coverLocalPath).exists()) {
+                            showUrl = videoContent.coverLocalPath;
+                        }
+                        if (TextUtils.isEmpty(showUrl) && !TextUtils.isEmpty(videoContent.cover)) {
+                            showUrl = WKApiConfig.getShowUrl(videoContent.cover);
+                        }
+                    }
+                    if (TextUtils.isEmpty(showUrl)) continue;
+
+                    String date = WKTimeUtils.getInstance().time2YearMonth(msg.timestamp * 1000);
+                    addDateHeaderIfNeeded(localEntities, date);
+
+                    SearchImgEntity entity = new SearchImgEntity();
+                    entity.date = date;
+                    entity.url = showUrl;
+
+                    GlobalMessage gm = new GlobalMessage();
+                    gm.setMessage_seq((long) msg.messageSeq);
+                    gm.setFrom_uid(msg.fromUID != null ? msg.fromUID : "");
+                    gm.setTimestamp(msg.timestamp);
+                    gm.setClient_msg_no(msg.clientMsgNO != null ? msg.clientMsgNO : "");
+                    com.chat.base.entity.GlobalChannel gc = new com.chat.base.entity.GlobalChannel();
+                    gc.setChannel_id(channelID);
+                    gc.setChannel_type(channelType);
+                    gm.setChannel(gc);
+                    HashMap<String, Object> payloadMap = new HashMap<>();
+                    payloadMap.put("type", msg.type);
+                    gm.setPayload(payloadMap);
+                    entity.message = gm;
+
+                    localEntities.add(entity);
+                }
+            }
+        }
+
+        // API 搜索
         ArrayList<Integer> contentType = new ArrayList<>();
         contentType.add(WKContentType.WK_IMAGE);
+        contentType.add(WKContentType.WK_VIDEO);
         GlobalSearchReq req = new GlobalSearchReq(1, "", channelID, channelType, "", "", contentType, page, 20, 0, 0);
         GlobalSearchModel.INSTANCE.search(req, (code, s, globalSearch) -> {
             wkVBinding.refreshLayout.finishLoadMore();
             wkVBinding.refreshLayout.finishRefresh();
-            if (WKReader.isNotEmpty(globalSearch.messages)) {
-                List<SearchImgEntity> fileEntityList = new ArrayList<>();
-                // 构造数据
+
+            List<SearchImgEntity> merged = new ArrayList<>(localEntities);
+
+            if (code == HttpResponseCode.success && globalSearch != null && WKReader.isNotEmpty(globalSearch.messages)) {
                 for (GlobalMessage msg : globalSearch.messages) {
+                    if (!seenSeqs.add(msg.getMessage_seq())) continue;
+
                     WKMessageContent content = msg.getMessageModel();
-                    if (content == null) {
-                        continue;
-                    }
-                    WKImageContent msgModel = null;
-                    if (content instanceof WKImageContent) {
-                        msgModel = (WKImageContent) content;
-                    }
-                    if (msgModel == null) {
-                        continue;
-                    }
-                    String date = WKTimeUtils.getInstance().time2YearMonth(msg.getTimestamp() * 1000);
-                    if (WKReader.isNotEmpty(fileEntityList)) {
-                        if (!fileEntityList.get(fileEntityList.size() - 1).date.equals(date)) {
-                            SearchImgEntity entity = new SearchImgEntity();
-                            entity.date = date;
-                            entity.itemType = 1;
-                            fileEntityList.add(entity);
+                    if (content == null) continue;
+
+                    String showUrl = "";
+                    if (content instanceof WKImageContent imgModel) {
+                        if (!TextUtils.isEmpty(imgModel.localPath) && new File(imgModel.localPath).exists()) {
+                            showUrl = imgModel.localPath;
+                        }
+                        if (TextUtils.isEmpty(showUrl)) {
+                            showUrl = WKApiConfig.getShowUrl(imgModel.url);
+                        }
+                    } else if (content instanceof WKVideoContent videoModel) {
+                        if (!TextUtils.isEmpty(videoModel.coverLocalPath) && new File(videoModel.coverLocalPath).exists()) {
+                            showUrl = videoModel.coverLocalPath;
+                        }
+                        if (TextUtils.isEmpty(showUrl) && !TextUtils.isEmpty(videoModel.cover)) {
+                            showUrl = WKApiConfig.getShowUrl(videoModel.cover);
                         }
                     } else {
-                        SearchImgEntity entity = new SearchImgEntity();
-                        entity.date = date;
-                        entity.itemType = 1;
-                        fileEntityList.add(entity);
+                        continue;
                     }
+                    if (TextUtils.isEmpty(showUrl)) continue;
+
+                    String date = WKTimeUtils.getInstance().time2YearMonth(msg.getTimestamp() * 1000);
+                    addDateHeaderIfNeeded(merged, date);
+
                     SearchImgEntity entity = new SearchImgEntity();
                     entity.date = date;
                     entity.message = msg;
-
-                    String showUrl = "";
-                    if (!TextUtils.isEmpty(msgModel.localPath)) {
-                        File file = new File(msgModel.localPath);
-                        if (file.exists()) {
-                            showUrl = msgModel.localPath;
-                        }
-                    }
-                    if (TextUtils.isEmpty(showUrl)) {
-                        showUrl = WKApiConfig.getShowUrl(msgModel.url);
-                    }
                     entity.url = showUrl;
-                    fileEntityList.add(entity);
+                    merged.add(entity);
                 }
-                if (WKReader.isNotEmpty(adapter.getData())) {
-                    SearchImgEntity entity = adapter.getData().get(adapter.getData().size() - 1);
-                    if (entity.date.equals(fileEntityList.get(0).date)) {
-                        fileEntityList.remove(0);
-                    }
-                }
-                adapter.addData(fileEntityList);
-            } else {
+            }
+
+            if (merged.isEmpty()) {
                 wkVBinding.refreshLayout.finishLoadMoreWithNoMoreData();
                 if (page == 1) {
                     wkVBinding.refreshLayout.setEnableLoadMore(false);
                     wkVBinding.nodataTv.setVisibility(View.VISIBLE);
                 }
+            } else {
+                wkVBinding.nodataTv.setVisibility(View.GONE);
+                if (page == 1) {
+                    adapter.setList(merged);
+                } else {
+                    adapter.addData(merged);
+                }
             }
             return null;
         });
+    }
+
+    private void addDateHeaderIfNeeded(List<SearchImgEntity> list, String date) {
+        if (WKReader.isNotEmpty(list)) {
+            if (!list.get(list.size() - 1).date.equals(date)) {
+                SearchImgEntity header = new SearchImgEntity();
+                header.date = date;
+                header.itemType = 1;
+                list.add(header);
+            }
+        } else {
+            SearchImgEntity header = new SearchImgEntity();
+            header.date = date;
+            header.itemType = 1;
+            list.add(header);
+        }
     }
 }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchWithImgActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchWithImgActivity.java
@@ -262,6 +262,7 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
                             new int[]{WKContentType.WK_IMAGE, WKContentType.WK_VIDEO});
             if (WKReader.isNotEmpty(localMsgs)) {
                 for (WKMsg msg : localMsgs) {
+                    if (com.chat.base.space.SpaceFilter.shouldSkipMessageForSpace(msg)) continue;
                     if (msg.baseContentMsgModel == null) continue;
                     if (!seenSeqs.add((long) msg.messageSeq)) continue;
 
@@ -378,14 +379,13 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
     }
 
     private void addDateHeaderIfNeeded(List<SearchImgEntity> list, String date) {
+        String lastDate = null;
         if (WKReader.isNotEmpty(list)) {
-            if (!list.get(list.size() - 1).date.equals(date)) {
-                SearchImgEntity header = new SearchImgEntity();
-                header.date = date;
-                header.itemType = 1;
-                list.add(header);
-            }
-        } else {
+            lastDate = list.get(list.size() - 1).date;
+        } else if (WKReader.isNotEmpty(adapter.getData())) {
+            lastDate = adapter.getData().get(adapter.getData().size() - 1).date;
+        }
+        if (!date.equals(lastDate)) {
             SearchImgEntity header = new SearchImgEntity();
             header.date = date;
             header.itemType = 1;

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchWithImgActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchWithImgActivity.java
@@ -77,6 +77,7 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
     private byte channelType;
     private SearchWithImgAdapter adapter;
     private int page = 1;
+    private final Set<Long> seenSeqs = new HashSet<>();
 
     @Override
     protected ActSearchMsgImgLayoutBinding getViewBinding() {
@@ -251,9 +252,9 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
     private void getData() {
         // 本地搜索
         List<SearchImgEntity> localEntities = new ArrayList<>();
-        Set<Long> seenSeqs = new HashSet<>();
 
         if (page == 1) {
+            seenSeqs.clear();
             List<WKMsg> localMsgs = WKIM.getInstance().getMsgManager()
                     .searchMsgWithChannelAndContentTypes(channelID, channelType, 0, 200,
                             new int[]{WKContentType.WK_IMAGE, WKContentType.WK_VIDEO});

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchWithImgActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchWithImgActivity.java
@@ -205,7 +205,7 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
                 msg.getChannel().getChannel_id(),
                 msg.getChannel().getChannel_type()
         );
-        EndpointManager.getInstance().invoke(EndpointSID.chatView, new ChatViewMenu(SearchWithImgActivity.this, channelID, WKChannelType.GROUP, orderSeq, false));
+        EndpointManager.getInstance().invoke(EndpointSID.chatView, new ChatViewMenu(SearchWithImgActivity.this, channelID, channelType, orderSeq, false));
     }
 
 

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchWithImgActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchWithImgActivity.java
@@ -231,7 +231,9 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
     }
 
     private void forward(SearchImgEntity entity) {
-        WKMessageContent finalWKMessageContent = entity.message.getMessageModel();
+        WKMessageContent finalWKMessageContent = entity.originalContent != null
+                ? entity.originalContent
+                : entity.message.getMessageModel();
         if (finalWKMessageContent == null) {
             return;
         }
@@ -287,6 +289,7 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
                     SearchImgEntity entity = new SearchImgEntity();
                     entity.date = date;
                     entity.url = showUrl;
+                    entity.originalContent = msg.baseContentMsgModel;
 
                     GlobalMessage gm = new GlobalMessage();
                     gm.setMessage_seq((long) msg.messageSeq);

--- a/wkuikit/src/main/res/layout/act_search_msg_file_layout.xml
+++ b/wkuikit/src/main/res/layout/act_search_msg_file_layout.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/homeColor"
+    android:orientation="vertical">
+
+    <include layout="@layout/wk_title_bar_layout" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/radian_normal_layout"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:layout_width="25dp"
+            android:layout_height="25dp"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="15dp"
+            android:layout_marginEnd="5dp"
+            android:src="@mipmap/ic_ab_search" />
+
+        <EditText
+            android:id="@+id/searchEt"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:background="@null"
+            android:hint="@string/uikit_search_for_file"
+            android:imeOptions="actionSearch"
+            android:inputType="text"
+            android:maxLines="1"
+            android:singleLine="true"
+            android:textColor="@color/colorDark"
+            android:textColorHint="@color/color999"
+            android:textSize="@dimen/font_size_14" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/nodataTv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="30dp"
+        android:text="@string/nodata"
+        android:textColor="@color/color999"
+        android:visibility="gone" />
+
+    <com.scwang.smart.refresh.layout.SmartRefreshLayout
+        android:id="@+id/refreshLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/transparent"
+        app:srlEnableFooterFollowWhenLoadFinished="true"
+        app:srlEnableScrollContentWhenLoaded="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/transparent"
+            android:gravity="center">
+
+            <com.chat.base.ui.components.CommonLoadingView
+                android:id="@+id/spin_kit"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_gravity="center" />
+        </LinearLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/transparent"
+            android:visibility="visible" />
+
+        <com.scwang.smart.refresh.footer.ClassicsFooter
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/homeColor"
+            app:srlTextNothing="@string/refresh_footer" />
+    </com.scwang.smart.refresh.layout.SmartRefreshLayout>
+</LinearLayout>

--- a/wkuikit/src/main/res/layout/item_global_message_layout.xml
+++ b/wkuikit/src/main/res/layout/item_global_message_layout.xml
@@ -42,14 +42,29 @@
                 android:textSize="@dimen/font_size_14" />
         </LinearLayout>
 
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/contentTv"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:ellipsize="end"
-            android:lines="1"
-            android:maxLines="1"
-            android:textColor="@color/popupTextColor"
-            android:textSize="@dimen/font_size_14" />
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:id="@+id/fileTagIv"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_marginEnd="4dp"
+                android:src="@drawable/ic_file_document"
+                android:visibility="gone" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/contentTv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:lines="1"
+                android:maxLines="1"
+                android:textColor="@color/popupTextColor"
+                android:textSize="@dimen/font_size_14" />
+        </LinearLayout>
     </LinearLayout>
 </LinearLayout>

--- a/wkuikit/src/main/res/layout/item_search_message_type_layout.xml
+++ b/wkuikit/src/main/res/layout/item_search_message_type_layout.xml
@@ -10,7 +10,13 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:layout_margin="10dp"
-        android:padding="10dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginBottom="10dp"
+        android:maxLines="1"
+        android:singleLine="true"
+        android:paddingStart="6dp"
+        android:paddingTop="10dp"
+        android:paddingEnd="6dp"
+        android:paddingBottom="10dp"
         android:textSize="14sp" />
 </LinearLayout>

--- a/wkuikit/src/main/res/layout/item_search_msg_file_layout.xml
+++ b/wkuikit/src/main/res/layout/item_search_msg_file_layout.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/layoutBg"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="16dp"
+    android:paddingTop="12dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="12dp">
+
+    <ImageView
+        android:id="@+id/fileIconIv"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:src="@drawable/ic_file_document" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/fileNameTv"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="middle"
+            android:maxLines="1"
+            android:singleLine="true"
+            android:textColor="@color/colorDark"
+            android:textSize="@dimen/font_size_16" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:orientation="horizontal">
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/fileSizeTv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/color999"
+                android:textSize="@dimen/font_size_12" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:text="·"
+                android:textColor="@color/color999"
+                android:textSize="@dimen/font_size_12" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/fileTimeTv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/color999"
+                android:textSize="@dimen/font_size_12" />
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/wkuikit/src/main/res/values-en/strings.xml
+++ b/wkuikit/src/main/res/values-en/strings.xml
@@ -305,7 +305,8 @@
     <string name="uikit_today">Today</string>
     <string name="uikit_search_for_date">Date</string>
     <string name="uikit_go_to_chat_item">Go to chat</string>
-    <string name="uikit_search_for_image">Image</string>
+    <string name="uikit_search_for_image">Photos &amp; Videos</string>
+    <string name="uikit_search_for_file">File</string>
     <string name="contacts_section_group_chat">Groups</string>
     <string name="contacts_section_added_ai">Added AI</string>
     <string name="contacts_all">All</string>

--- a/wkuikit/src/main/res/values/strings.xml
+++ b/wkuikit/src/main/res/values/strings.xml
@@ -308,7 +308,8 @@
     <string name="uikit_today">今天</string>
     <string name="uikit_search_for_date">日期</string>
     <string name="uikit_go_to_chat_item">定位到聊天</string>
-    <string name="uikit_search_for_image">图片</string>
+    <string name="uikit_search_for_image">图片与视频</string>
+    <string name="uikit_search_for_file">文件</string>
 
     <string name="space_title">Space</string>
     <string name="space_create">创建 Space</string>


### PR DESCRIPTION
## Summary
- Add file search entry in chat history search (alongside members, photos, date)
- Add local DB search for images/videos/files (previously API-only, showed empty results)
- Fix forward messages to contacts: "create new chat" button now properly handles contact selection callback
- Rename "图片" to "图片与视频", add video support in image search
- Add file icon badge in keyword search results for file type messages
- Fix SQL IN clause bug in `searchWithChannelAndContentTypes`
- Override `WKFileContent.getSearchableWord()` to return `[文件]+filename` for global search

## Test plan
- [ ] Open chat → search chat history → verify "图片与视频", "文件", "群成员", "日期" all display in one row
- [ ] Click "图片与视频" → verify images and videos are listed
- [ ] Click "文件" → verify files are listed with icon, name, size, time
- [ ] Type filename in file search → verify filtering works
- [ ] Global search → type a filename → verify file result shows with `[文件]` prefix and file icon
- [ ] Forward message → click "创建新的聊天" → select a contact → confirm → verify message is forwarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)