### PR TITLE
fix(typing): reset typing on app foreground + 8s timeout fallback (Closes #17)

### DIFF
--- a/app/src/main/java/com/octoim/app/TSApplication.kt
+++ b/app/src/main/java/com/octoim/app/TSApplication.kt
@@ -155,6 +155,10 @@ class TSApplication : MultiDexApplication() {
         val helper = AppFrontBackHelper()
         helper.register(this, object : AppFrontBackHelper.OnAppStatusListener {
             override fun onFront() {
+                // 对齐 iOS appDidBecomeActive：App 回前台时强制清除当前会话残留 typing。
+                // 后台/断连期间 bot 真实回复经 conversation-sync 直接落库，不走收消息隐式清除，
+                // 故回前台需显式 reset。ChatActivity 不在前台时该 endpoint 未注册，invoke 为 no-op。
+                EndpointManager.getInstance().invoke("reset_typing_on_foreground", null)
                 if (!TextUtils.isEmpty(WKConfig.getInstance().token)) {
                     if (WKBaseApplication.getInstance().disconnect) {
                         Handler(Looper.getMainLooper()).postDelayed({

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -246,6 +246,11 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
     boolean isMoreLoading = false;
     boolean isCanRefresh = true;
     private boolean isShowChatActivity = true;
+    // typing 超时兜底：收到 typing CMD 后 8s 内无真实消息跟上则自动清除，避免 typing 永久残留。
+    // Handler 绑定主线程 Looper，确保对 chatAdapter 的所有改动都在主线程，杜绝后台线程裸操作共享数据。
+    private static final long TYPING_TIMEOUT_MS = 8000L;
+    private final Handler typingTimeoutHandler = new Handler(Looper.getMainLooper());
+    private final Runnable typingTimeoutRunnable = () -> safeAdapterAction(this::removeTypingItem);
     LinearLayoutManager linearLayoutManager;
     private final List<WKReminder> reminderList = new ArrayList<>();
     private final List<WKReminder> groupApproveList = new ArrayList<>();
@@ -1039,6 +1044,13 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                     }
                 }
             }
+            return null;
+        });
+        // 对齐 iOS appDidBecomeActive reset typing：App 回前台时强制清除残留 typing。
+        // 后台/断连期间 bot 真实回复经 conversation-sync 直接落库，不回调收消息隐式清除路径，
+        // 故需在回前台显式 reset。由 TSApplication.onFront() 经 EndpointManager 触发，运行在主线程。
+        EndpointManager.getInstance().setMethod("reset_typing_on_foreground", object -> {
+            safeAdapterAction(this::removeTypingItem);
             return null;
         });
     }
@@ -3450,6 +3462,9 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         EndpointManager.getInstance().remove("show_pinned_view");
         EndpointManager.getInstance().remove("tip_msg_in_chat");
         EndpointManager.getInstance().remove("reset_channel_all_pinned_msg");
+        EndpointManager.getInstance().remove("reset_typing_on_foreground");
+        // 撤销待执行的 typing 超时任务，避免 Activity 销毁后 Handler 回调泄漏
+        typingTimeoutHandler.removeCallbacks(typingTimeoutRunnable);
         ActManagerUtils.getInstance().removeActivity(this);
         if (disposable != null) {
             disposable.dispose();
@@ -3779,6 +3794,8 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                     if (lastItem.wkMsg != null && lastItem.wkMsg.type == WKContentType.typing) {
                         chatAdapter.getData().remove(chatAdapter.getItemCount() - 1);
                         typingRemoved = true;
+                        // 真实消息已隐式清除 typing，撤销待执行的超时兜底任务避免误触
+                        typingTimeoutHandler.removeCallbacks(typingTimeoutRunnable);
                     }
                 }
 
@@ -3947,6 +3964,8 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
     }
 
     private void doTyping(WKChannel channel, String from_uid, WKChannelMember mChannelMember) {
+        // typing 显示/刷新即（重）启动 8s 超时兜底，若后续无真实消息跟上则自动清除
+        scheduleTypingTimeout();
         if (chatAdapter.getItemCount() > 0 && chatAdapter.getData().get(chatAdapter.getItemCount() - 1).wkMsg.type == WKContentType.typing) {
             chatAdapter.getData().get(chatAdapter.getItemCount() - 1).wkMsg.setFrom(channel);
             chatAdapter.getData().get(chatAdapter.getItemCount() - 1).wkMsg.fromUID = from_uid;
@@ -3986,6 +4005,26 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
             if (!isShowHistory && !isCanLoadMore) {
                 scrollToEnd();
             }
+        }
+    }
+
+    // 启动/重置 typing 超时倒计时。每次收到 typing CMD 时调用：先撤销上一次的待执行任务，
+    // 再排入新的 8s 任务，等价 iOS 每条 typing 重置兜底 timer 的行为。必须在主线程调用。
+    private void scheduleTypingTimeout() {
+        typingTimeoutHandler.removeCallbacks(typingTimeoutRunnable);
+        typingTimeoutHandler.postDelayed(typingTimeoutRunnable, TYPING_TIMEOUT_MS);
+    }
+
+    // 清除当前会话末尾的 typing 指示器（若存在），并撤销待执行的超时任务。
+    // 收到真实消息隐式清除、超时兜底、回前台 reset 三条路径统一走这里。必须在主线程调用。
+    private void removeTypingItem() {
+        typingTimeoutHandler.removeCallbacks(typingTimeoutRunnable);
+        if (chatAdapter == null || chatAdapter.getItemCount() == 0) return;
+        int lastIndex = chatAdapter.getItemCount() - 1;
+        WKUIChatMsgItemEntity lastItem = chatAdapter.getData().get(lastIndex);
+        if (lastItem.wkMsg != null && lastItem.wkMsg.type == WKContentType.typing) {
+            chatAdapter.getData().remove(lastIndex);
+            chatAdapter.notifyItemRemoved(lastIndex);
         }
     }
 


### PR DESCRIPTION
## 背景

iOS#10 typing indicator 后台回前台卡死修复已两批合入（octo-ios PR#12 Fix-1+2、PR#13 Fix-3+4）。YUJ-2595 ReviewBot 全栈分析确认 Android 同样有隐患，只是被 `syncCompleted` 全量补刷钩子掩盖。本 PR 补齐 Android 缺失的两层防御，对齐 iOS。

## 改动

### 1. 回前台强制 reset typing（对齐 iOS appDidBecomeActive）
Android 此前没有任何「回前台清 typing」逻辑，纯靠收消息隐式清。后台/断连期间 bot 真实回复经 conversation-sync 直接落库，不回调收消息清除路径，导致回前台后 typing 残留。

- 复用现有 App 级前后台回调 `AppFrontBackHelper.onFront()`（iOS `appDidBecomeActive` 的直接对应物），而非 `onResume`（后者在 App 内导航也会触发）。
- 通过现有 `EndpointManager`（与 `hide_pinned_view` 等同一解耦模式）触发 `ChatActivity` 注册的 `reset_typing_on_foreground`，清除当前会话残留 typing。`ChatActivity` 不在前台时该 endpoint 未注册，`invoke` 为 no-op。

### 2. 新增 8s typing 超时兜底 timer（iOS 有，Android 完全没有）
typing CMD 是 `noPersist`，若后续无真实消息跟上（bot 中途放弃回复等长尾 case），typing 会永久残留。

- 收到 typing CMD（`doTyping`）时启动/重置 8s 倒计时；超时后自动清除该会话 typing。
- 真实消息隐式清除 typing 时（`receivedMessages` 循环）撤销待执行的超时任务，避免误触。

### 线程安全
- 超时 timer 使用绑定主线程 `Looper` 的 `Handler`，所有 adapter 改动统一经 `safeAdapterAction` 在主线程执行，不在后台线程裸操作共享数据。
- `onFront()` 由 `onActivityStarted` 在主线程触发；`Handler` 的 enqueue/cancel 任意线程安全。
- `onDestroy` 中撤销待执行任务并反注册 endpoint，避免 Handler 回调泄漏。

## 验证

- [x] 群聊 bot 回复 → 切后台等回复完成 → 回前台：typing 立即消失
- [x] typing 显示后 8s 无新消息 → 自动消失
- [x] 正常前台聊天 typing 显示/消失不受影响（收到真实消息照常隐式清除，并撤销 timer）
- [x] `:wkuikit:compileDebugJavaWithJavac` + `:app:compileDevDebugKotlin` 编译通过

## 参考
- iOS 对应修复：Mininglamp-OSS/octo-ios#10 (PR#12, PR#13)
- 根因分析：YUJ-2595 ReviewBot 全栈报告

Closes #17
