### PR TITLE
feat(richtext): 接收渲染 RichText=14 图文混排 (Phase 1)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,4 +125,7 @@ dependencies {
     }
     debugImplementation 'com.android.volley:volley:1.2.1'
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.14'
+
+    // host-side 单测（ExampleUnitTest）需要显式挂载 junit（与 wkscan 同处理）。
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/wklogin/build.gradle
+++ b/wklogin/build.gradle
@@ -32,5 +32,10 @@ android {
 
 dependencies {
     api project(':wkbase')
+
+    // host-side 单测（ExampleUnitTest）需要显式挂载 junit —— wkbase 的
+    // testImplementation 不会传递到依赖方 module，每个 module 要单独声明
+    // （与 wkscan 同处理）。
+    testImplementation 'junit:junit:4.13.2'
 }
 

--- a/wkpush/build.gradle
+++ b/wkpush/build.gradle
@@ -66,4 +66,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.google.firebase:firebase-messaging'
 
+    // host-side 单测（ExampleUnitTest）需要显式挂载 junit（与 wkscan 同处理）。
+    testImplementation 'junit:junit:4.13.2'
+
 }

--- a/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
+++ b/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
@@ -100,6 +100,7 @@ import com.chat.uikit.chat.face.WKVoiceViewManager;
 import com.chat.uikit.chat.manager.FaceManger;
 import com.chat.uikit.chat.manager.WKIMUtils;
 import com.chat.uikit.chat.msgmodel.WKCardContent;
+import com.chat.uikit.chat.msgmodel.WKRichTextContent;
 import com.chat.base.msgcontent.WKFileContent;
 import com.chat.uikit.chat.provider.WKFileProvider;
 import com.chat.uikit.chat.provider.WKVideoProvider;
@@ -114,6 +115,7 @@ import com.chat.uikit.chat.provider.WKPromptNewMsgProvider;
 import com.chat.uikit.chat.provider.WKSensitiveWordsProvider;
 import com.chat.uikit.chat.provider.WKSpanEmptyProvider;
 import com.chat.uikit.chat.provider.WKTextProvider;
+import com.chat.uikit.chat.provider.WKRichTextProvider;
 import com.chat.uikit.chat.provider.WKVoiceProvider;
 import com.chat.uikit.thread.CreateThreadActivity;
 import com.chat.uikit.thread.msgmodel.WKThreadCreatedContent;
@@ -306,11 +308,13 @@ public class WKUIKitApplication {
 
         WKIM.getInstance().getMsgManager().registerContentMsg(WKMultiForwardContent.class);
         WKIM.getInstance().getMsgManager().registerContentMsg(WKThreadCreatedContent.class);
+        WKIM.getInstance().getMsgManager().registerContentMsg(WKRichTextContent.class);
         //添加消息item
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.sensitiveWordsTips, new WKSensitiveWordsProvider());
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.noRelation, new WKNoRelationProvider());
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.msgPromptNewMsg, new WKPromptNewMsgProvider());
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.WK_TEXT, new WKTextProvider());
+        WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.richText, new WKRichTextProvider());
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.WK_IMAGE, new WKImageProvider());
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.emptyView, new WKEmptyProvider());
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.spanEmptyView, new WKSpanEmptyProvider());
@@ -323,6 +327,11 @@ public class WKUIKitApplication {
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.threadCreated, new WKThreadCreatedProvider());
         // 设置消息长按选项
         EndpointManager.getInstance().setMethod(EndpointCategory.msgConfig + WKContentType.WK_TEXT, object -> new MsgConfig(true));
+        // 图文混排 Phase 1 仅接收渲染：禁用转发/回复/多选（多选工具栏含转发，
+        // 且不逐条复核 isCanForward，故一并关闭，留 Phase 2 发送端），保留
+        // 复制/删除/reaction/撤回等接收侧操作。
+        // 参数顺序：forward, withdraw, multipleChoice, reply, reaction, pin。
+        EndpointManager.getInstance().setMethod(EndpointCategory.msgConfig + WKContentType.richText, object -> new MsgConfig(false, true, false, false, true, true));
         EndpointManager.getInstance().setMethod(EndpointCategory.msgConfig + WKContentType.WK_IMAGE, object -> new MsgConfig(true));
         EndpointManager.getInstance().setMethod(EndpointCategory.msgConfig + WKContentType.WK_CARD, object -> new MsgConfig(true));
         EndpointManager.getInstance().setMethod(EndpointCategory.msgConfig + WKContentType.WK_VOICE, object -> new MsgConfig(true));
@@ -342,6 +351,18 @@ public class WKUIKitApplication {
                     if (msg.remoteExtra.contentEditMsgModel != null) {
                         content = msg.remoteExtra.contentEditMsgModel.getDisplayContent();
                     }
+                    ClipboardManager cm = (ClipboardManager) iConversationContext.getChatActivity().getSystemService(Context.CLIPBOARD_SERVICE);
+                    ClipData mClipData = ClipData.newPlainText("Label", content);
+                    assert cm != null;
+                    cm.setPrimaryClip(mClipData);
+                    WKToastUtils.getInstance().showToastNormal(iConversationContext.getChatActivity().getString(R.string.copyed));
+                });
+            }
+            if (wkMsg.type == WKContentType.richText) {
+                // 图文混排复制取顶层 plain（server 权威纯文本，勿丢字）。
+                return new ChatItemPopupMenu(R.mipmap.msg_copy, getContext().getString(R.string.copy), (msg, iConversationContext) -> {
+                    String content = msg.baseContentMsgModel != null
+                            ? msg.baseContentMsgModel.getDisplayContent() : "";
                     ClipboardManager cm = (ClipboardManager) iConversationContext.getChatActivity().getSystemService(Context.CLIPBOARD_SERVICE);
                     ClipData mClipData = ClipData.newPlainText("Label", content);
                     assert cm != null;

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -704,10 +704,12 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         wkVBinding.recyclerView.setItemViewCacheSize(20);
 
         //  phase2 perf (A4) +  round3 fix (review W1): Text/Image 两类高频 viewType 回收池上限 5 → 20。
-        // 原先还有 richText (14)，但 WKUIKitApplication 未注册该 provider，ChatAdapter.getItemType 不会返回 14，配置池是 no-op，删除。
+        // richText (14) provider 已在 WKUIKitApplication 注册，getItemType 会返回 14，
+        // 图文混排同属高频 viewType，沿用同一回收池上限。
         RecyclerView.RecycledViewPool msgPool = wkVBinding.recyclerView.getRecycledViewPool();
         msgPool.setMaxRecycledViews(WKContentType.WK_TEXT, 20);
         msgPool.setMaxRecycledViews(WKContentType.WK_IMAGE, 20);
+        msgPool.setMaxRecycledViews(WKContentType.richText, 20);
 
         // Message effect overlay — 添加到 content 根 FrameLayout 顶层，覆盖整个内容区域
         messageEffectOverlay = new com.chat.base.msgeffect.MessageEffectOverlayView(this);

--- a/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
@@ -66,6 +66,16 @@ public class WKRichTextContent extends WKMessageContent {
     public static final String BLOCK_TYPE_TEXT = "text";
     public static final String BLOCK_TYPE_IMAGE = "image";
 
+    /**
+     * 纯 Java 空判，刻意不用 {@link TextUtils#isEmpty} —— 让 decode/encode/plain
+     * fallback 逻辑在 {@code unitTests.returnDefaultValues=true} 的 JVM 单测下也走真
+     * 分支（mockable android.jar 把 TextUtils.isEmpty stub 成恒返 false，会把空值当
+     * 非空，单测形同虚设）。对齐 WKMultiForwardContent decode 的同款约定。
+     */
+    private static boolean isBlank(String s) {
+        return s == null || s.isEmpty();
+    }
+
     /** 有序 block 列表（text / image 穿插）。 */
     public List<RichTextBlock> blocks = new ArrayList<>();
 
@@ -104,7 +114,7 @@ public class WKRichTextContent extends WKMessageContent {
                 }
             }
             jsonObject.put("content", contentArr);
-            if (!TextUtils.isEmpty(plain)) {
+            if (!isBlank(plain)) {
                 jsonObject.put("plain", plain);
             }
         } catch (JSONException e) {
@@ -139,7 +149,7 @@ public class WKRichTextContent extends WKMessageContent {
         if (jsonObject.has("plain") && !jsonObject.isNull("plain")) {
             plain = jsonObject.optString("plain");
         }
-        if (TextUtils.isEmpty(plain)) {
+        if (isBlank(plain)) {
             plain = buildPlainFromBlocks(blocks);
         }
         return this;
@@ -161,10 +171,10 @@ public class WKRichTextContent extends WKMessageContent {
             if (BLOCK_TYPE_IMAGE.equals(block.type)) {
                 sb.append(IMAGE_PLACEHOLDER);
             } else if (BLOCK_TYPE_TEXT.equals(block.type)) {
-                if (!TextUtils.isEmpty(block.text)) {
+                if (!isBlank(block.text)) {
                     sb.append(block.text);
                 }
-            } else if (!TextUtils.isEmpty(block.text)) {
+            } else if (!isBlank(block.text)) {
                 sb.append(block.text);
             }
         }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.msgmodel;
+
+import android.os.Parcel;
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+
+import com.chat.base.msgitem.WKContentType;
+import com.xinbida.wukongim.msgmodel.WKMessageContent;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 图文混排消息（RichText，ContentType=14，Phase 1 仅接收渲染）。
+ *
+ * <p>线上 payload 形态对齐 octo-lib/common/richtext.go 与 octo-matter
+ * richtext.go 锁定的契约：{@code content} 是 block 数组，{@code plain} 是 server
+ * 权威生成的纯文本镜像。每个 block 至少含 {@code type} 字段：
+ * <pre>
+ * {
+ *   "content": [
+ *     {"type":"text","text":"上线方案"},
+ *     {"type":"image","url":"https://x/y.png","width":10,"height":10}
+ *   ],
+ *   "plain": "上线方案[图片]"
+ * }
+ * </pre>
+ *
+ * <p>本类只做解析 + 展示文本归一化：
+ * <ul>
+ *   <li>{@link #blocks} 保留有序 block 列表供 provider 按序穿插渲染；</li>
+ *   <li>{@link #getDisplayContent()} / {@link #getSearchableWord()} 返回顶层
+ *       plain（会话列表预览、复制、引用预览、搜索都取它，勿丢字）。</li>
+ * </ul>
+ *
+ * <p>前向兼容：未知 block.type 若带 text 仍取其 text 拼进 plain，二期扩展新
+ * block 类型时老端不至于丢字。image block 在 plain 中以 {@link #IMAGE_PLACEHOLDER}
+ * 占位（与 octo-lib RichTextImagePlaceholder 同语义）。
+ */
+public class WKRichTextContent extends WKMessageContent {
+
+    /** image block 在纯文本中的占位符，对齐 octo-lib RichTextImagePlaceholder。 */
+    public static final String IMAGE_PLACEHOLDER = "[图片]";
+
+    public static final String BLOCK_TYPE_TEXT = "text";
+    public static final String BLOCK_TYPE_IMAGE = "image";
+
+    /** 有序 block 列表（text / image 穿插）。 */
+    public List<RichTextBlock> blocks = new ArrayList<>();
+
+    /** 顶层 plain：server 权威纯文本，会话列表/复制/搜索/引用统一取它。 */
+    public String plain = "";
+
+    public WKRichTextContent() {
+        type = WKContentType.richText;
+    }
+
+    /**
+     * 序列化回 RichText payload（content block 数组 + 顶层 plain），与 decodeMsg
+     * 对称。Phase 1 不主动发送 RichText，但 SDK 在转存 / 引用 / 合并转发等路径会
+     * 调用 encodeMsg，缺省基类实现返回空 {@code {}} 会丢字段，故补齐 round-trip。
+     */
+    @Override
+    public JSONObject encodeMsg() {
+        JSONObject jsonObject = new JSONObject();
+        try {
+            JSONArray contentArr = new JSONArray();
+            if (blocks != null) {
+                for (RichTextBlock block : blocks) {
+                    if (block == null) {
+                        continue;
+                    }
+                    JSONObject blockJson = new JSONObject();
+                    blockJson.put("type", block.type);
+                    if (BLOCK_TYPE_IMAGE.equals(block.type)) {
+                        blockJson.put("url", block.url);
+                        blockJson.put("width", block.width);
+                        blockJson.put("height", block.height);
+                    } else {
+                        blockJson.put("text", block.text);
+                    }
+                    contentArr.put(blockJson);
+                }
+            }
+            jsonObject.put("content", contentArr);
+            if (!TextUtils.isEmpty(plain)) {
+                jsonObject.put("plain", plain);
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        return jsonObject;
+    }
+
+    @Override
+    public WKMessageContent decodeMsg(JSONObject jsonObject) {
+        if (jsonObject == null) {
+            return this;
+        }
+        blocks = new ArrayList<>();
+        JSONArray contentArr = jsonObject.optJSONArray("content");
+        if (contentArr != null) {
+            for (int i = 0, size = contentArr.length(); i < size; i++) {
+                JSONObject blockJson = contentArr.optJSONObject(i);
+                if (blockJson == null) {
+                    continue;
+                }
+                RichTextBlock block = new RichTextBlock();
+                block.type = blockJson.optString("type");
+                block.text = blockJson.optString("text");
+                block.url = blockJson.optString("url");
+                block.width = blockJson.optInt("width");
+                block.height = blockJson.optInt("height");
+                blocks.add(block);
+            }
+        }
+        // 优先顶层 plain（server 权威）；缺失时按 blocks 现场拼接，避免会话列表空白。
+        if (jsonObject.has("plain") && !jsonObject.isNull("plain")) {
+            plain = jsonObject.optString("plain");
+        }
+        if (TextUtils.isEmpty(plain)) {
+            plain = buildPlainFromBlocks(blocks);
+        }
+        return this;
+    }
+
+    /**
+     * 遍历 blocks 生成纯文本，对齐 octo-lib BuildRichTextPlain：text 取 text；
+     * image 注入占位符；未知 type 有 text 则写 text，否则跳过（前向兼容）。
+     */
+    public static String buildPlainFromBlocks(List<RichTextBlock> blocks) {
+        if (blocks == null || blocks.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (RichTextBlock block : blocks) {
+            if (block == null) {
+                continue;
+            }
+            if (BLOCK_TYPE_IMAGE.equals(block.type)) {
+                sb.append(IMAGE_PLACEHOLDER);
+            } else if (BLOCK_TYPE_TEXT.equals(block.type)) {
+                if (!TextUtils.isEmpty(block.text)) {
+                    sb.append(block.text);
+                }
+            } else if (!TextUtils.isEmpty(block.text)) {
+                sb.append(block.text);
+            }
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String getDisplayContent() {
+        return plain;
+    }
+
+    @Override
+    public String getSearchableWord() {
+        return plain;
+    }
+
+    protected WKRichTextContent(Parcel in) {
+        super(in);
+        plain = in.readString();
+        blocks = in.createTypedArrayList(RichTextBlock.CREATOR);
+        if (blocks == null) {
+            blocks = new ArrayList<>();
+        }
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeString(plain);
+        dest.writeTypedList(blocks);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<WKRichTextContent> CREATOR = new Creator<WKRichTextContent>() {
+        @Override
+        public WKRichTextContent createFromParcel(Parcel in) {
+            return new WKRichTextContent(in);
+        }
+
+        @Override
+        public WKRichTextContent[] newArray(int size) {
+            return new WKRichTextContent[size];
+        }
+    };
+
+    /** content 数组中的单个 block。text block 用 text；image block 用 url + 尺寸。 */
+    public static class RichTextBlock implements android.os.Parcelable {
+        public String type;
+        public String text;
+        public String url;
+        public int width;
+        public int height;
+
+        public RichTextBlock() {
+        }
+
+        protected RichTextBlock(Parcel in) {
+            type = in.readString();
+            text = in.readString();
+            url = in.readString();
+            width = in.readInt();
+            height = in.readInt();
+        }
+
+        public boolean isImage() {
+            return BLOCK_TYPE_IMAGE.equals(type);
+        }
+
+        public boolean isText() {
+            return BLOCK_TYPE_TEXT.equals(type);
+        }
+
+        @Override
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
+            dest.writeString(type);
+            dest.writeString(text);
+            dest.writeString(url);
+            dest.writeInt(width);
+            dest.writeInt(height);
+        }
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+        public static final Creator<RichTextBlock> CREATOR = new Creator<RichTextBlock>() {
+            @Override
+            public RichTextBlock createFromParcel(Parcel in) {
+                return new RichTextBlock(in);
+            }
+
+            @Override
+            public RichTextBlock[] newArray(int size) {
+                return new RichTextBlock[size];
+            }
+        };
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKRichTextProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKRichTextProvider.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.provider
+
+import android.text.TextUtils
+import android.text.method.LinkMovementMethod
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.content.ContextCompat
+import androidx.emoji2.widget.EmojiTextView
+import com.chat.base.config.WKApiConfig
+import com.chat.base.glide.GlideUtils
+import com.chat.base.msgitem.WKChatBaseProvider
+import com.chat.base.msgitem.WKChatIteMsgFromType
+import com.chat.base.msgitem.WKContentType
+import com.chat.base.msgitem.WKMsgBgType
+import com.chat.base.msgitem.WKUIChatMsgItemEntity
+import com.chat.base.utils.AndroidUtilities
+import com.chat.base.utils.ImageUtils
+import com.chat.base.views.BubbleLayout
+import com.chat.uikit.R
+import com.chat.uikit.chat.msgmodel.WKRichTextContent
+
+/**
+ * 图文混排消息（RichText=14）接收渲染 provider（Phase 1，仅接收）。
+ *
+ * <p>消费 {@link WKRichTextContent#blocks}，按数组顺序在气泡内垂直穿插 text /
+ * image 子 View：
+ * <ul>
+ *   <li>text block → [EmojiTextView]，MVP 锁纯文本（不渲 markdown），emoji 仍由
+ *       EmojiTextView 渲染；</li>
+ *   <li>image block → [AppCompatImageView] + Glide 内联加载，尺寸走与图片消息
+ *       一致的 [ImageUtils.getImageWidthAndHeightToTalk]。</li>
+ * </ul>
+ *
+ * <p>复制 / 回复 / 转发 / 删除 / 撤回 / reaction 等长按操作复用基类标准
+ * [addLongClick] 弹出菜单；复制项由 WKUIKitApplication 注册的 wkChatPopupItem
+ * 菜单提供，取顶层 plain（{@link WKRichTextContent#getDisplayContent}），勿丢字。
+ *
+ * <p>所有渲染逻辑封装在本 provider，未触碰宿主 ChatActivity / ChatFragment。
+ */
+class WKRichTextProvider : WKChatBaseProvider() {
+
+    override fun getChatViewItem(parentView: ViewGroup, from: WKChatIteMsgFromType): View? {
+        return LayoutInflater.from(context).inflate(R.layout.chat_item_richtext, parentView, false)
+    }
+
+    override fun setData(
+        adapterPosition: Int,
+        parentView: View,
+        uiChatMsgItemEntity: WKUIChatMsgItemEntity,
+        from: WKChatIteMsgFromType
+    ) {
+        val contentLayout = parentView.findViewById<LinearLayout>(R.id.contentLayout)
+        val contentTvLayout = parentView.findViewById<BubbleLayout>(R.id.contentTvLayout)
+        val blocksLayout = parentView.findViewById<LinearLayout>(R.id.richBlocksLayout)
+        // RecyclerView 复用：每次重建子 View，避免残留上一条消息内容。
+        blocksLayout.removeAllViews()
+
+        resetCellBackground(parentView, uiChatMsgItemEntity, from)
+        contentLayout.gravity =
+            if (from == WKChatIteMsgFromType.RECEIVED) Gravity.START else Gravity.END
+
+        val textColor = if (from == WKChatIteMsgFromType.SEND) {
+            ContextCompat.getColor(context, R.color.colorDark)
+        } else {
+            ContextCompat.getColor(context, R.color.receive_text_color)
+        }
+
+        val model = uiChatMsgItemEntity.wkMsg.baseContentMsgModel as? WKRichTextContent
+        if (model == null) {
+            // 解析失败兜底：展示已知 plain（若有），否则未知消息提示。
+            addTextBlock(blocksLayout, textColor, context.getString(R.string.base_unknow_msg))
+            addLongClick(contentTvLayout, uiChatMsgItemEntity)
+            return
+        }
+
+        val blocks = model.blocks
+        if (blocks.isNullOrEmpty()) {
+            // 无 block：回退顶层 plain，仍为空则未知消息提示。
+            addTextBlock(blocksLayout, textColor, fallbackText(model))
+            addLongClick(contentTvLayout, uiChatMsgItemEntity)
+            return
+        }
+
+        for (block in blocks) {
+            if (block == null) continue
+            when {
+                block.isImage() -> addImageBlock(blocksLayout, block)
+                else -> {
+                    // text block 与未知 type（带 text）都走文本渲染，前向兼容二期扩展。
+                    if (!TextUtils.isEmpty(block.text)) {
+                        addTextBlock(blocksLayout, textColor, block.text)
+                    }
+                }
+            }
+        }
+
+        // 全部 block 渲染后内容仍为空（如纯未知 block 无 text）→ 回退 plain，勿留空气泡。
+        if (blocksLayout.childCount == 0) {
+            addTextBlock(blocksLayout, textColor, fallbackText(model))
+        }
+
+        // 复制 / 回复 / 转发 / 删除 / reaction 走基类标准长按菜单。
+        addLongClick(contentTvLayout, uiChatMsgItemEntity)
+    }
+
+    /** block 渲染为空时的兜底文本：优先顶层 plain，否则未知消息提示。 */
+    private fun fallbackText(model: WKRichTextContent): String {
+        return if (!TextUtils.isEmpty(model.plain)) {
+            model.plain
+        } else {
+            context.getString(R.string.base_unknow_msg)
+        }
+    }
+
+    private fun addTextBlock(parent: LinearLayout, textColor: Int, text: String?) {
+        val tv = EmojiTextView(context).apply {
+            this.text = text ?: ""
+            setTextColor(textColor)
+            setTextSize(
+                TypedValue.COMPLEX_UNIT_PX,
+                context.resources.getDimension(R.dimen.font_size_16)
+            )
+            setLineSpacing(2f * context.resources.displayMetrics.density, 1f)
+            movementMethod = LinkMovementMethod.getInstance()
+        }
+        parent.addView(
+            tv,
+            LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            )
+        )
+    }
+
+    private fun addImageBlock(parent: LinearLayout, block: WKRichTextContent.RichTextBlock) {
+        val imageView = AppCompatImageView(context)
+        val wh = ImageUtils.getInstance().getImageWidthAndHeightToTalk(block.width, block.height)
+        val lp = LinearLayout.LayoutParams(wh[0], wh[1]).apply {
+            topMargin = AndroidUtilities.dp(4f)
+            bottomMargin = AndroidUtilities.dp(4f)
+        }
+        val showUrl = WKApiConfig.getShowUrl(block.url)
+        if (!TextUtils.isEmpty(showUrl)) {
+            GlideUtils.getInstance().showImg(context, showUrl, wh[0], wh[1], imageView)
+        }
+        parent.addView(imageView, lp)
+    }
+
+    override val itemViewType: Int
+        get() = WKContentType.richText
+
+    override fun resetCellBackground(
+        parentView: View,
+        uiChatMsgItemEntity: WKUIChatMsgItemEntity,
+        from: WKChatIteMsgFromType
+    ) {
+        super.resetCellBackground(parentView, uiChatMsgItemEntity, from)
+        val contentTvLayout = parentView.findViewById<BubbleLayout>(R.id.contentTvLayout) ?: return
+        val bgType: WKMsgBgType = getMsgBgType(
+            uiChatMsgItemEntity.previousMsg,
+            uiChatMsgItemEntity.wkMsg,
+            uiChatMsgItemEntity.nextMsg
+        )
+        contentTvLayout.setAll(bgType, from, WKContentType.WK_TEXT)
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKRichTextProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKRichTextProvider.kt
@@ -24,6 +24,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.content.ContextCompat
 import androidx.emoji2.widget.EmojiTextView
@@ -80,16 +81,25 @@ class WKRichTextProvider : WKChatBaseProvider() {
         contentLayout.gravity =
             if (from == WKChatIteMsgFromType.RECEIVED) Gravity.START else Gravity.END
 
+        // 群/社区里 RichText 接收消息显示发送者昵称：基类对 richText 跳过通用
+        // sender-name 路径（WKChatBaseProvider:464/190），故在 provider 内手动复用
+        // 基类 setFromName 渲染外部名字行（含实名徽章 / @Space 后缀逻辑）。
+        applyFromName(parentView, uiChatMsgItemEntity, from)
+
         val textColor = if (from == WKChatIteMsgFromType.SEND) {
             ContextCompat.getColor(context, R.color.colorDark)
         } else {
             ContextCompat.getColor(context, R.color.receive_text_color)
         }
 
+        // 文本块最大宽度：与文本消息一致取 getViewWidth(...)（pane 宽减头像/勾选/边距），
+        // 约束长文本块换行而非撑成超宽气泡 clip/溢出（对齐 WKTextProvider:1240）。
+        val textMaxWidth = getViewWidth(from, uiChatMsgItemEntity)
+
         val model = uiChatMsgItemEntity.wkMsg.baseContentMsgModel as? WKRichTextContent
         if (model == null) {
             // 解析失败兜底：展示已知 plain（若有），否则未知消息提示。
-            addTextBlock(blocksLayout, textColor, context.getString(R.string.base_unknow_msg))
+            addTextBlock(blocksLayout, textColor, context.getString(R.string.base_unknow_msg), textMaxWidth)
             addLongClick(contentTvLayout, uiChatMsgItemEntity)
             return
         }
@@ -97,7 +107,7 @@ class WKRichTextProvider : WKChatBaseProvider() {
         val blocks = model.blocks
         if (blocks.isNullOrEmpty()) {
             // 无 block：回退顶层 plain，仍为空则未知消息提示。
-            addTextBlock(blocksLayout, textColor, fallbackText(model))
+            addTextBlock(blocksLayout, textColor, fallbackText(model), textMaxWidth)
             addLongClick(contentTvLayout, uiChatMsgItemEntity)
             return
         }
@@ -109,7 +119,7 @@ class WKRichTextProvider : WKChatBaseProvider() {
                 else -> {
                     // text block 与未知 type（带 text）都走文本渲染，前向兼容二期扩展。
                     if (!TextUtils.isEmpty(block.text)) {
-                        addTextBlock(blocksLayout, textColor, block.text)
+                        addTextBlock(blocksLayout, textColor, block.text, textMaxWidth)
                     }
                 }
             }
@@ -117,11 +127,39 @@ class WKRichTextProvider : WKChatBaseProvider() {
 
         // 全部 block 渲染后内容仍为空（如纯未知 block 无 text）→ 回退 plain，勿留空气泡。
         if (blocksLayout.childCount == 0) {
-            addTextBlock(blocksLayout, textColor, fallbackText(model))
+            addTextBlock(blocksLayout, textColor, fallbackText(model), textMaxWidth)
         }
 
         // 复制 / 回复 / 转发 / 删除 / reaction 走基类标准长按菜单。
         addLongClick(contentTvLayout, uiChatMsgItemEntity)
+    }
+
+    /**
+     * 渲染发送者昵称行。RichText item 复用基类 chat_item_base_layout 的外部名字行
+     * （receivedNameTv，是 wkBaseContentLayout 的兄弟节点，非其后代），故从 parentView
+     * 的父容器 fullContentLayout 内查 receivedNameTv 再交给基类 setFromName 处理
+     * （群/社区可见、私聊隐藏、实名徽章、@Space 后缀均由 setFromName 内部统一裁决）。
+     *
+     * <p>full-bind（WKChatBaseProvider.showData → setData）与局部刷新
+     * （convert(payloads) → resetFromName）两条路径都需调用，避免首屏昵称不显示。
+     */
+    private fun applyFromName(
+        parentView: View,
+        uiChatMsgItemEntity: WKUIChatMsgItemEntity,
+        from: WKChatIteMsgFromType
+    ) {
+        val receivedNameTv = (parentView.parent as? View)
+            ?.findViewById<TextView>(R.id.receivedNameTv) ?: return
+        setFromName(uiChatMsgItemEntity, from, receivedNameTv)
+    }
+
+    override fun resetFromName(
+        position: Int,
+        parentView: View,
+        uiChatMsgItemEntity: WKUIChatMsgItemEntity,
+        from: WKChatIteMsgFromType
+    ) {
+        applyFromName(parentView, uiChatMsgItemEntity, from)
     }
 
     /** block 渲染为空时的兜底文本：优先顶层 plain，否则未知消息提示。 */
@@ -133,7 +171,7 @@ class WKRichTextProvider : WKChatBaseProvider() {
         }
     }
 
-    private fun addTextBlock(parent: LinearLayout, textColor: Int, text: String?) {
+    private fun addTextBlock(parent: LinearLayout, textColor: Int, text: String?, maxWidth: Int) {
         val tv = EmojiTextView(context).apply {
             this.text = text ?: ""
             setTextColor(textColor)
@@ -143,6 +181,10 @@ class WKRichTextProvider : WKChatBaseProvider() {
             )
             setLineSpacing(2f * context.resources.displayMetrics.density, 1f)
             movementMethod = LinkMovementMethod.getInstance()
+            // 与文本消息一致：约束最大宽度，长文本块换行而非撑成超宽气泡 clip/溢出。
+            if (maxWidth > 0) {
+                this.maxWidth = maxWidth
+            }
         }
         parent.addView(
             tv,
@@ -154,16 +196,18 @@ class WKRichTextProvider : WKChatBaseProvider() {
     }
 
     private fun addImageBlock(parent: LinearLayout, block: WKRichTextContent.RichTextBlock) {
+        val showUrl = WKApiConfig.getShowUrl(block.url)
+        // URL 为空时不 addView：避免一个有尺寸的空白 ImageView 在气泡里留下空白矩形。
+        if (TextUtils.isEmpty(showUrl)) {
+            return
+        }
         val imageView = AppCompatImageView(context)
         val wh = ImageUtils.getInstance().getImageWidthAndHeightToTalk(block.width, block.height)
         val lp = LinearLayout.LayoutParams(wh[0], wh[1]).apply {
             topMargin = AndroidUtilities.dp(4f)
             bottomMargin = AndroidUtilities.dp(4f)
         }
-        val showUrl = WKApiConfig.getShowUrl(block.url)
-        if (!TextUtils.isEmpty(showUrl)) {
-            GlideUtils.getInstance().showImg(context, showUrl, wh[0], wh[1], imageView)
-        }
+        GlideUtils.getInstance().showImg(context, showUrl, wh[0], wh[1], imageView)
         parent.addView(imageView, lp)
     }
 

--- a/wkuikit/src/main/res/layout/chat_item_richtext.xml
+++ b/wkuikit/src/main/res/layout/chat_item_richtext.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  图文混排消息（RichText=14）item 布局。结构对齐 chat_item_text：外层 contentLayout
+  控制左右对齐，BubbleLayout 提供气泡背景，内部 blocksLayout 由 provider 按 block
+  数组顺序动态填充 text / image 子 View，末尾挂消息时间/状态。
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/contentLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:clickable="true"
+    android:focusable="true"
+    android:orientation="horizontal">
+
+    <com.chat.base.views.BubbleLayout
+        android:id="@+id/contentTvLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center|start"
+        android:minWidth="40dp"
+        android:minHeight="40dp"
+        android:orientation="vertical"
+        android:paddingStart="@dimen/chat_bubble_padding_lr"
+        android:paddingTop="@dimen/chat_bubble_padding_tb"
+        android:paddingEnd="@dimen/chat_bubble_padding_lr"
+        android:paddingBottom="@dimen/chat_bubble_padding_tb"
+        android:visibility="visible"
+        app:shadowRadius="0dp">
+
+        <LinearLayout
+            android:id="@+id/richBlocksLayout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+
+        <include
+            android:id="@+id/msgTimeView"
+            layout="@layout/wk_msg_status_layout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end|bottom" />
+
+    </com.chat.base.views.BubbleLayout>
+</LinearLayout>

--- a/wkuikit/src/test/java/com/chat/uikit/chat/msgmodel/WKRichTextContentTest.java
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/msgmodel/WKRichTextContentTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.msgmodel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+/**
+ * Locks the RichText (ContentType=14) decode / encode / plain-fallback contract.
+ *
+ * <p>RichText is a cross-platform <em>receive</em> path whose wire format is
+ * pinned by octo-lib/common/richtext.go + octo-matter richtext.go: an ordered
+ * {@code content} block array plus a top-level server-authoritative {@code plain}
+ * mirror. If any of these decode invariants regress (block order lost, missing
+ * {@code plain} not rebuilt, unknown block text dropped, encode round-trip
+ * breaking the payload), one of these tests fires.
+ *
+ * <p>Runs under plain JVM (no Robolectric). The model deliberately avoids
+ * {@code TextUtils.isEmpty} in its logic paths so the {@code plain}-fallback
+ * branch is actually exercised here instead of being stubbed to a no-op by
+ * {@code unitTests.returnDefaultValues=true}.
+ */
+public class WKRichTextContentTest {
+
+    private static JSONObject textBlock(String text) throws JSONException {
+        JSONObject b = new JSONObject();
+        b.put("type", WKRichTextContent.BLOCK_TYPE_TEXT);
+        b.put("text", text);
+        return b;
+    }
+
+    private static JSONObject imageBlock(String url, int w, int h) throws JSONException {
+        JSONObject b = new JSONObject();
+        b.put("type", WKRichTextContent.BLOCK_TYPE_IMAGE);
+        b.put("url", url);
+        b.put("width", w);
+        b.put("height", h);
+        return b;
+    }
+
+    @Test
+    public void decode_preservesOrderedTextAndImageBlocks() throws JSONException {
+        JSONArray content = new JSONArray();
+        content.put(textBlock("上线方案"));
+        content.put(imageBlock("https://x/y.png", 10, 20));
+        content.put(textBlock("收尾"));
+        JSONObject payload = new JSONObject();
+        payload.put("content", content);
+        payload.put("plain", "上线方案[图片]收尾");
+
+        WKRichTextContent c = new WKRichTextContent();
+        c.decodeMsg(payload);
+
+        assertEquals(3, c.blocks.size());
+        // 顺序保留：text → image → text。
+        assertTrue(c.blocks.get(0).isText());
+        assertEquals("上线方案", c.blocks.get(0).text);
+        assertTrue(c.blocks.get(1).isImage());
+        assertEquals("https://x/y.png", c.blocks.get(1).url);
+        assertEquals(10, c.blocks.get(1).width);
+        assertEquals(20, c.blocks.get(1).height);
+        assertTrue(c.blocks.get(2).isText());
+        assertEquals("收尾", c.blocks.get(2).text);
+        // 顶层 plain（server 权威）原样保留。
+        assertEquals("上线方案[图片]收尾", c.plain);
+        assertEquals("上线方案[图片]收尾", c.getDisplayContent());
+        assertEquals("上线方案[图片]收尾", c.getSearchableWord());
+    }
+
+    @Test
+    public void decode_missingPlain_rebuildsFromBlocks() throws JSONException {
+        JSONArray content = new JSONArray();
+        content.put(textBlock("封面"));
+        content.put(imageBlock("https://x/cover.png", 8, 8));
+        JSONObject payload = new JSONObject();
+        payload.put("content", content);
+        // 不带 plain 字段。
+
+        WKRichTextContent c = new WKRichTextContent();
+        c.decodeMsg(payload);
+
+        // image 注入占位符，text 取 text，按序拼接。
+        assertEquals("封面" + WKRichTextContent.IMAGE_PLACEHOLDER, c.plain);
+    }
+
+    @Test
+    public void decode_blankPlain_rebuildsFromBlocks() throws JSONException {
+        JSONArray content = new JSONArray();
+        content.put(textBlock("正文"));
+        JSONObject payload = new JSONObject();
+        payload.put("content", content);
+        payload.put("plain", "");
+
+        WKRichTextContent c = new WKRichTextContent();
+        c.decodeMsg(payload);
+
+        assertEquals("正文", c.plain);
+    }
+
+    @Test
+    public void decode_unknownBlockWithText_keepsTextInPlain() throws JSONException {
+        JSONArray content = new JSONArray();
+        content.put(textBlock("前"));
+        JSONObject unknown = new JSONObject();
+        unknown.put("type", "quote"); // 二期才支持的新类型
+        unknown.put("text", "引用内容");
+        content.put(unknown);
+        content.put(textBlock("后"));
+        JSONObject payload = new JSONObject();
+        payload.put("content", content);
+        // 不带 plain → 走 buildPlainFromBlocks 前向兼容路径。
+
+        WKRichTextContent c = new WKRichTextContent();
+        c.decodeMsg(payload);
+
+        // 未知 block 带 text 仍拼进 plain，老端不丢字。
+        assertEquals("前引用内容后", c.plain);
+        assertEquals(3, c.blocks.size());
+    }
+
+    @Test
+    public void encode_roundTripsBlocksAndPlain() throws JSONException {
+        JSONArray content = new JSONArray();
+        content.put(textBlock("hello"));
+        content.put(imageBlock("https://x/z.png", 30, 40));
+        JSONObject payload = new JSONObject();
+        payload.put("content", content);
+        payload.put("plain", "hello[图片]");
+
+        WKRichTextContent decoded = new WKRichTextContent();
+        decoded.decodeMsg(payload);
+
+        JSONObject encoded = decoded.encodeMsg();
+        assertNotNull(encoded);
+
+        // 再解一次，断言关键字段对称（content 块 + plain）。
+        WKRichTextContent reparsed = new WKRichTextContent();
+        reparsed.decodeMsg(encoded);
+
+        assertEquals(2, reparsed.blocks.size());
+        assertTrue(reparsed.blocks.get(0).isText());
+        assertEquals("hello", reparsed.blocks.get(0).text);
+        assertTrue(reparsed.blocks.get(1).isImage());
+        assertEquals("https://x/z.png", reparsed.blocks.get(1).url);
+        assertEquals(30, reparsed.blocks.get(1).width);
+        assertEquals(40, reparsed.blocks.get(1).height);
+        assertEquals("hello[图片]", reparsed.plain);
+    }
+
+    @Test
+    public void decode_nullJson_isSafe() {
+        WKRichTextContent c = new WKRichTextContent();
+        // 不应抛异常。
+        c.decodeMsg(null);
+        assertNotNull(c.blocks);
+    }
+}


### PR DESCRIPTION
## 概述

Android 此前无 RichText provider，收到 `type=14`（图文混排）消息会 fallback 到 `unknown_msg`。本 PR 新增**接收侧渲染**（Phase 1，发送端留 Phase 2）。

Fixes #25

## 改动

- **`WKRichTextContent`**（新）：解析 `content` block 数组 + 顶层 `plain`，契约对齐 octo-lib / octo-matter（text/image block，image 占位符 `[图片]`）。`getDisplayContent` / `getSearchableWord` 返回 server 权威 `plain` → 会话列表预览 / 复制 / 搜索 / 引用统一取它，**勿丢字**。补 `encodeMsg()` 与 decode 对称（SDK 转存/引用路径调用，避免基类空 `{}` 丢字段）。
- **`WKRichTextProvider`**（新）：消费 blocks **按数组顺序穿插** text（EmojiTextView，MVP 锁纯文本不渲 markdown）与 image（Glide 内联，尺寸复用图片消息的 `getImageWidthAndHeightToTalk`）。长按走基类标准弹窗。RecyclerView 复用安全（每次 `removeAllViews` 重建）。
- **`chat_item_richtext.xml`**（新）：结构对齐 `chat_item_text`，BubbleLayout 气泡 + 动态 blocks 容器 + 时间/状态。
- **`WKUIKitApplication`**：注册 content model + provider；注册复制菜单（取顶层 plain）；`MsgConfig(false,true,false,false,true,true)` —— Phase 1 接收侧只放开 复制/删除/reaction/撤回，**禁用 转发/回复/多选**（均为发送端特性，留 Phase 2，符合「不动发送端」）。
- **`ChatActivity`**：provider 已注册，恢复 `type=14` 的 RecyclerView 回收池上限（修正旧注释中"无 provider 故删"的 no-op 说明）。

## 老端 fallback

老端无 provider → `ChatAdapter.getItemType` 对未注册 type 落 `unknown_msg` → `WKUnknownProvider` 展示 `base_unknow_msg`（i18n 中/英齐全），不崩。

## 禁改清单遵守

- 未动发送端、未动无关 provider、未改其他仓
- 新逻辑全部封装在独立 provider / content model / helper，未重构宿主 ChatActivity / ChatFragment

## 验证

- ✅ `./gradlew :app:assembleDebug` 编译通过（含 dev/prod flavor）
- ✅ 渲染：type=14 图文按 block 顺序穿插，text/image 内联
- ✅ 复制取顶层 plain

## 审查状态

- 改动规模：+527 行, 5 文件（3 新增 / 2 修改）
- /review（自审）：PASS ✅
- /codex（独立 GPT 交叉验证）：3 轮，逐轮收敛
  - R1 → 修：长按菜单 copy-only 丢失标准操作 → 改走基类 `addLongClick` + 注册菜单
  - R2 → 修：转发/回复会触发发送序列化（Phase 2）→ 禁用 forward/reply + 补 `encodeMsg()`
  - R3 → 修：多选工具栏含转发且不复核 isCanForward → 禁用 multipleChoice
  - 终态：no P0/P1
