### PR TITLE
fix(ci): use custom build command for CodeQL to avoid release signing failure

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,7 @@ jobs:
     uses: Mininglamp-OSS/.github/.github/workflows/reusable-codeql.yml@main
     with:
       language: java-kotlin
+      build-command: ./gradlew assembleDevDebug
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Problem

CodeQL autobuild runs `./gradlew assemble` which builds **all** variants including release. The release variant requires `app/release.jks` for signing (`validateSigningDevRelease`), which is not available in CI.

This has been failing on every run since the CodeQL workflow was added — both on main and PRs.

**Error:**
```
Keystore file '/home/runner/work/octo-android/octo-android/app/release.jks' not found for signing config 'release'.
```

## Fix

Pass `build-command: ./gradlew assembleDevDebug` to the reusable CodeQL workflow, matching the existing CI workflow's build target. This skips release signing entirely while still providing full Kotlin/Java source for CodeQL analysis.

## Verification

- CI workflow (`ci.yml`) already uses `assembleDevDebug` successfully
- The reusable workflow supports `build-command` input to override autobuild