### PR TITLE
feat(richtext): Android send mixed text+image RichText=14 (Phase 1)

### DIFF
--- a/wkbase/src/main/java/com/chat/base/msg/IConversationContext.java
+++ b/wkbase/src/main/java/com/chat/base/msg/IConversationContext.java
@@ -86,4 +86,19 @@ public interface IConversationContext {
 
     // 选择文件发送
     void chooseFile();
+
+    /**
+     * 图文混排（RichText=14）发送侧聚合（Phase 1）。
+     *
+     * <p>当输入框含待发文本时，把传入的图片本地路径与文本聚合成<strong>一条</strong>
+     * type=14 消息（text 块在前、image 块按选取顺序在后），上传图片得 URL 后落库发送，
+     * 并清空输入框；返回 true 表示本次发送已被接管。若输入框无文本则返回 false，调用方
+     * 继续走原有逐条图片发送（纯图片零回归）。
+     *
+     * @param imageLocalPaths 本次选取的静态图片本地路径（按选取顺序，调用方已过滤 video/gif）
+     * @return true 已聚合发送；false 未接管
+     */
+    default boolean trySendRichTextMixed(java.util.List<String> imageLocalPaths) {
+        return false;
+    }
 }

--- a/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
+++ b/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
@@ -824,6 +824,14 @@ public class WKUIKitApplication {
                                 return;
                             }
 
+                            // 图文混排（RichText=14）发送侧聚合（Phase 1，对称 web#227）：
+                            // 输入框已有文本 + 本次全是静态图片（无 video / 无走 sticker 的 gif）时，
+                            // 聚合成单条 type=14（text 块在前、image 块按选取顺序在后），
+                            // 而非逐张发独立 image。其余情况落到下方原有逐条发送，零回归。
+                            if (tryAggregateRichTextMixed(iConversationContext, paths)) {
+                                return;
+                            }
+
                             for (int i = 0, size = paths.size(); i < size; i++) {
                                 String path = paths.get(i).path;
                                 if (paths.get(i).model == ChooseResultModel.video) {
@@ -873,6 +881,38 @@ public class WKUIKitApplication {
 
     public interface IShowChatConfirm {
         void onBack(@NonNull List<WKChannel> list, @NonNull List<WKMessageContent> messageContentList);
+    }
+
+    /**
+     * 图文混排（RichText=14）发送侧聚合判定（Phase 1）。
+     *
+     * <p>仅当本次相册选择<strong>全是静态图片</strong>（无 video、无 gif——gif 走表情/原图
+     * 逐条路径不变）时才尝试聚合。把图片本地路径按选取顺序收集后交给
+     * {@link IConversationContext#trySendRichTextMixed(List)}：若输入框有待发文本则聚合成
+     * 单条 type=14 并返回 true（本次发送已被接管）；否则返回 false，调用方继续走原有逐条
+     * 发送（纯图片零回归）。
+     *
+     * @return true 表示已聚合发送，调用方应直接返回；false 表示未接管，继续原逐条逻辑。
+     */
+    private boolean tryAggregateRichTextMixed(IConversationContext iConversationContext, List<ChooseResult> paths) {
+        if (paths == null || paths.isEmpty()) {
+            return false;
+        }
+        List<String> imagePaths = new ArrayList<>();
+        for (ChooseResult result : paths) {
+            if (result == null || result.model != ChooseResultModel.image
+                    || TextUtils.isEmpty(result.path)) {
+                return false; // 含 video / 空路径 → 不聚合，走原逐条路径。
+            }
+            if (WKFileUtils.getInstance().isGif(result.path)) {
+                return false; // gif 走表情/原图逐条路径，不纳入图文混排。
+            }
+            imagePaths.add(result.path);
+        }
+        if (imagePaths.isEmpty()) {
+            return false;
+        }
+        return iConversationContext.trySendRichTextMixed(imagePaths);
     }
 
     public void showChatConfirmDialog(@NonNull Context context, @NonNull List<WKChannel> list, @NonNull List<WKMessageContent> messageContentList, final IShowChatConfirm iShowChatConfirm) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -105,6 +105,7 @@ import com.chat.base.utils.ActManagerUtils;
 import com.chat.base.utils.AndroidUtilities;
 import com.chat.base.utils.LayoutHelper;
 import com.chat.base.utils.SoftKeyboardUtils;
+import com.chat.base.utils.StringUtils;
 import com.chat.base.utils.UserUtils;
 import com.chat.base.utils.WKDialogUtils;
 import com.chat.base.utils.WKPermissions;
@@ -3035,6 +3036,51 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                 ThreadModel.getInstance().joinThread(parsed[0], parsed[1], (code, msg) -> {});
             }
         }
+    }
+
+    /**
+     * 图文混排（RichText=14）发送侧聚合入口（Phase 1，对称 web#227）。
+     *
+     * <p>仅当输入框含待发文本时接管：把文本与本次选取的图片聚合成单条 type=14
+     * （text 块在前、image 块按选取顺序在后），mention（三态 humans/ais + 群成员 uids）
+     * 与发送键文本路径同源复用，发送后清空输入框、关闭顶部提示。无文本则返回 false，
+     * 调用方继续走原有逐张图片发送（纯图片零回归）。
+     *
+     * <p>编辑态 / 回复态下不接管（保持既有逐条语义），由 sendMessage 的特化路径处理。
+     */
+    @Override
+    public boolean trySendRichTextMixed(List<String> imageLocalPaths) {
+        if (imageLocalPaths == null || imageLocalPaths.isEmpty()) {
+            return false;
+        }
+        if (chatPanelManager == null || chatPanelManager.getEditText() == null
+                || chatPanelManager.getEditText().getText() == null) {
+            return false;
+        }
+        // 编辑 / 回复态走既有特化路径，不聚合（避免破坏 edit/reply 语义）。
+        if (editMsg != null || replyWKMsg != null) {
+            return false;
+        }
+        String rawText = chatPanelManager.getEditText().getText().toString();
+        if (TextUtils.isEmpty(StringUtils.replaceBlank(rawText))) {
+            return false; // 无文本 → 纯图片，交回原逐条发送路径。
+        }
+        // 文本超字节上限：不聚合（与发送键路径同源阈值）。交回逐条图片发送，
+        // 超限文本留在输入框，由发送键走 showTextToFileAlert 转文件，避免发出超限 payload。
+        if (chatPanelManager.isTextOverByteLimit(rawText)) {
+            return false;
+        }
+
+        com.chat.uikit.chat.msgmodel.WKRichTextContent content =
+                new com.chat.uikit.chat.msgmodel.WKRichTextContent();
+        // mention 合并：与发送键文本路径同源（三态 humans/ais + 群成员 uids 不丢）。
+        chatPanelManager.applyInputMentionsTo(content, rawText);
+
+        com.chat.uikit.chat.manager.WKRichTextSender.send(this, content, rawText, imageLocalPaths);
+
+        // 与文本发送一致：清空输入框、关闭顶部提示条。
+        chatPanelManager.getEditText().setText(null);
+        return true;
     }
 
     private boolean isUpdate(WKMessageContent messageContent) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -416,6 +416,64 @@ class ChatPanelManager(
         return this.editText
     }
 
+    /**
+     * 文本字节是否超过输入框上限（与发送键文本路径同一阈值）。图文混排聚合发送前用它做
+     * 同源校验，避免绕过 [showTextToFileAlert] 发出超限 payload。
+     */
+    fun isTextOverByteLimit(text: String): Boolean {
+        return messageTextMaxBytes > 0 && text.toByteArray(Charsets.UTF_8).size > messageTextMaxBytes
+    }
+
+    /** 弹出"转为文件发送"确认框（供超限文本复用，与发送键路径同源）。 */
+    fun promptTextToFile(text: String) {
+        showTextToFileAlert(text)
+    }
+
+    /**
+     * 把当前输入框的 @mention（三态 humans/ais + 群成员 uids）应用到给定消息体。
+     *
+     * 供图文混排（RichText=14）聚合发送复用——与发送键文本路径【同源】，
+     * 保证群 @ 通知（含 @所有AI）不丢。刻意不写 entities：图文混排的 plain 非权威，
+     * 且 entity offset 是相对纯文本块的字符偏移，跨 block 拼接后无意义。
+     *
+     * 复用既有 [scanPlainTextMentions] / [expandRobotMembersIntoUids]，与 sendIV 文本
+     * 发送逻辑保持单一来源。
+     */
+    fun applyInputMentionsTo(content: WKMessageContent, text: String) {
+        val list = editText.allUIDs.toMutableList()
+        val entities = editText.allEntity.toMutableList()
+
+        if (iConversationContext.chatChannelInfo.channelType == WKChannelType.GROUP ||
+            iConversationContext.chatChannelInfo.channelType == WKChannelType.COMMUNITY_TOPIC
+        ) {
+            scanPlainTextMentions(text, entities, list)
+        }
+
+        if (list.isEmpty()) return
+
+        val mInfo = WKMentionInfo()
+        val uidList: MutableList<String> = ArrayList()
+        for (uid in list) {
+            when {
+                uid.equals("-1", ignoreCase = true) -> {
+                    content.mentionHumans = 1
+                    mInfo.humans = true
+                }
+                uid == "-2" -> {
+                    content.mentionAis = 1
+                    mInfo.ais = true
+                }
+                else -> uidList.add(uid)
+            }
+        }
+        // @所有AI 命中时把会话内 robot 成员展开到 mention.uids，兼容旧 adapter。
+        if (content.mentionAis == 1) {
+            expandRobotMembersIntoUids(uidList)
+        }
+        mInfo.uids = uidList
+        content.mentionInfo = mInfo
+    }
+
     fun showReplyLayout(mMsg: WKMsg) {
         var showName: String? = ""
         if (mMsg.from != null) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKRichTextSender.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKRichTextSender.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.manager;
+
+import android.graphics.BitmapFactory;
+import android.text.TextUtils;
+
+import com.chat.base.msg.IConversationContext;
+import com.chat.base.net.ud.WKUploader;
+import com.chat.base.utils.WKToastUtils;
+import com.chat.uikit.R;
+import com.chat.uikit.chat.msgmodel.WKRichTextContent;
+import com.xinbida.wukongim.entity.WKChannel;
+import com.xinbida.wukongim.msgmodel.WKMessageContent;
+import com.xinbida.wukongim.msgmodel.WKTextContent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 图文混排（RichText，ContentType=14）<em>发送侧</em>聚合器（Phase 1）。
+ *
+ * <p>与 web 发送侧 octo-web#227 对称：当输入框同时含文本 + 图片（且无非图片文件块）
+ * 时，把它们聚合成 <strong>一条</strong> {@code type=14} 消息（content 为有序 block
+ * 数组），而非逐张发独立消息。纯文本 / 纯图片 / 含文件块的路径保持原有逐条发送不变，
+ * 零回归。
+ *
+ * <p>关键链路差异（对齐 octo-android 实际架构）：Android 没有 web Tiptap 那种把文本与
+ * 图片交错暂存的内联编辑器——文本在输入框、图片从相册选取。因此「混排」的发生时机 =
+ * 输入框已有文本时用户又选了一批静态图片；此时本聚合器接管。穿插顺序固定为
+ * <em>文本块在前、图片块按选取顺序在后</em>（即用户先打字、再选图的自然顺序）。
+ *
+ * <p>RichTextContent extends {@link WKMessageContent}（非 Media），故最终走
+ * sendTextAndWaitAck 链路，不是 media upload 链路；但图片 URL 仍需先上传得到
+ * downloadUrl 再塞 block，故本类先逐张上传（顺序串行，天然保序）。
+ *
+ * <p>安全：每张图上传后用 {@link WKRichTextContent#isSafeImageUrl(String)} 校验
+ * http/https，阻断 {@code javascript:}/{@code data:}/{@code file:} 注入；不安全或上传
+ * 失败的图片跳过并 Toast。
+ *
+ * <p>原子性（对齐 YUJ-2740 元教训②）：文本<strong>始终落成一条消息</strong>——只要有
+ * ≥1 张有效图片就发图文混排单条；若所有图片都失败，则降级发纯文本（text 不丢失）。
+ * mention（三态 humans/ais + 群成员 uids）由调用方在传入的 {@code content} 上预置，
+ * 全部图片失败降级时同样迁移到纯文本消息，保证群 @ 通知不丢。
+ */
+public final class WKRichTextSender {
+
+    private WKRichTextSender() {
+    }
+
+    /**
+     * 发起图文混排聚合发送。
+     *
+     * @param context    会话上下文（用于最终 {@link IConversationContext#sendMessage} 落库 + 注入 spaceId）
+     * @param content    调用方已预置 mention 基字段（mentionInfo/mentionHumans/mentionAis）的 RichText 载体
+     * @param text       输入框原始文本（保证落地，不丢字）
+     * @param imagePaths 本次选取的图片本地路径（按选取顺序）
+     */
+    public static void send(IConversationContext context,
+                            WKRichTextContent content,
+                            String text,
+                            List<String> imagePaths) {
+        if (context == null || content == null) {
+            return;
+        }
+        WKChannel channel = context.getChatChannelInfo();
+        if (channel == null) {
+            sendTextFallback(context, content, text);
+            return;
+        }
+        List<String> paths = imagePaths != null ? imagePaths : new ArrayList<>();
+        uploadNext(context, channel, content, text, paths, 0,
+                new ArrayList<>(), new int[]{0});
+    }
+
+    /**
+     * 串行上传第 index 张图片（保序），完成后递归处理下一张；全部处理完构造并发送。
+     */
+    private static void uploadNext(IConversationContext context,
+                                   WKChannel channel,
+                                   WKRichTextContent content,
+                                   String text,
+                                   List<String> paths,
+                                   int index,
+                                   List<WKRichTextContent.RichTextBlock> imageBlocks,
+                                   int[] failedCount) {
+        if (index >= paths.size()) {
+            finish(context, content, text, imageBlocks, failedCount[0]);
+            return;
+        }
+        String localPath = paths.get(index);
+        if (TextUtils.isEmpty(localPath)) {
+            failedCount[0]++;
+            uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount);
+            return;
+        }
+        int[] dims = decodeImageSize(localPath);
+        WKUploader.getInstance().getUploadCredentials(channel.channelID, channel.channelType, localPath,
+                (uploadUrl, downloadUrl, contentType, contentDisposition) -> {
+                    if (TextUtils.isEmpty(uploadUrl) || TextUtils.isEmpty(downloadUrl)) {
+                        failedCount[0]++;
+                        uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount);
+                        return;
+                    }
+                    WKUploader.getInstance().putUpload(uploadUrl, localPath, contentType, contentDisposition,
+                            UUID.randomUUID().toString().replaceAll("-", ""),
+                            new WKUploader.IUploadBack() {
+                                @Override
+                                public void onSuccess(String url) {
+                                    // 安全对称：上传成功也要校验 scheme，阻断 javascript:/data:/file:。
+                                    if (!WKRichTextContent.isSafeImageUrl(downloadUrl)) {
+                                        failedCount[0]++;
+                                    } else {
+                                        imageBlocks.add(WKRichTextContent.makeImageBlock(downloadUrl, dims[0], dims[1]));
+                                    }
+                                    uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount);
+                                }
+
+                                @Override
+                                public void onError() {
+                                    failedCount[0]++;
+                                    uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount);
+                                }
+                            });
+                });
+    }
+
+    /**
+     * 全部图片处理完毕：拼装有序 block（text 在前、image 按序在后）→ 发单条 RichText；
+     * 若无任何有效图片，降级发纯文本（原子性：text 不丢）。失败有跳过时 Toast 提示。
+     */
+    private static void finish(IConversationContext context,
+                               WKRichTextContent content,
+                               String text,
+                               List<WKRichTextContent.RichTextBlock> imageBlocks,
+                               int failedCount) {
+        if (imageBlocks.isEmpty()) {
+            // 所有图片都失败/不安全 → 文本仍要落地。
+            toastFailIfAny(context, failedCount);
+            sendTextFallback(context, content, text);
+            return;
+        }
+
+        List<WKRichTextContent.RichTextBlock> blocks = new ArrayList<>();
+        if (!TextUtils.isEmpty(text)) {
+            blocks.add(WKRichTextContent.makeTextBlock(text));
+        }
+        blocks.addAll(imageBlocks);
+
+        content.blocks = blocks;
+        // plain 非权威：仅填本地占位（image → 占位 wire token），server #232 Finalize 覆盖。
+        content.plain = WKRichTextContent.buildPlainFromBlocks(blocks);
+
+        toastFailIfAny(context, failedCount);
+        context.sendMessage(content);
+    }
+
+    /**
+     * 降级纯文本发送：把已预置在 RichText 载体上的 mention 基字段迁移到 WKTextContent，
+     * 保证群 @ 通知（含 @所有AI）不因降级而丢失。
+     */
+    private static void sendTextFallback(IConversationContext context,
+                                         WKRichTextContent richHolder,
+                                         String text) {
+        if (TextUtils.isEmpty(text)) {
+            return;
+        }
+        WKTextContent textContent = new WKTextContent(text);
+        textContent.mentionAll = richHolder.mentionAll;
+        textContent.mentionHumans = richHolder.mentionHumans;
+        textContent.mentionAis = richHolder.mentionAis;
+        textContent.mentionInfo = richHolder.mentionInfo;
+        context.sendMessage(textContent);
+    }
+
+    private static void toastFailIfAny(IConversationContext context, int failedCount) {
+        if (failedCount > 0 && context != null && context.getChatActivity() != null) {
+            WKToastUtils.getInstance().showToast(
+                    context.getChatActivity().getString(R.string.upload_fail));
+        }
+    }
+
+    /** inJustDecodeBounds 量本地图片尺寸（避免读 CDN 返回 0×0，对齐 web 本地量尺寸教训）。 */
+    private static int[] decodeImageSize(String localPath) {
+        try {
+            BitmapFactory.Options options = new BitmapFactory.Options();
+            options.inJustDecodeBounds = true;
+            BitmapFactory.decodeFile(localPath, options);
+            int w = Math.max(options.outWidth, 0);
+            int h = Math.max(options.outHeight, 0);
+            return new int[]{w, h};
+        } catch (Throwable t) {
+            return new int[]{0, 0};
+        }
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
@@ -86,6 +86,62 @@ public class WKRichTextContent extends WKMessageContent {
         type = WKContentType.richText;
     }
 
+    // ---------------------------------------------------------------------
+    // 发送侧工厂（Phase 1 图文混排，与接收侧 decode 共址，复用同一份权威 schema）
+    // ---------------------------------------------------------------------
+
+    /** 构造 text block。 */
+    public static RichTextBlock makeTextBlock(String text) {
+        RichTextBlock block = new RichTextBlock();
+        block.type = BLOCK_TYPE_TEXT;
+        block.text = text;
+        return block;
+    }
+
+    /** 构造 image block（url 已上传得到 + 本地量出的尺寸；尺寸必填 >0，对齐 octo-lib 契约）。 */
+    public static RichTextBlock makeImageBlock(String url, int width, int height) {
+        RichTextBlock block = new RichTextBlock();
+        block.type = BLOCK_TYPE_IMAGE;
+        block.url = url;
+        block.width = width;
+        block.height = height;
+        return block;
+    }
+
+    /**
+     * 由有序 block 列表构造一条可发送的 RichText 消息。plain 仅填本地占位（image →
+     * {@link #IMAGE_PLACEHOLDER} 这一 wire token，非本地化文案），server #232 Finalize
+     * 会重算覆盖——client 不是 plain 的权威来源。
+     */
+    public static WKRichTextContent create(List<RichTextBlock> blocks) {
+        WKRichTextContent content = new WKRichTextContent();
+        content.blocks = blocks != null ? blocks : new ArrayList<>();
+        content.plain = buildPlainFromBlocks(content.blocks);
+        return content;
+    }
+
+    /**
+     * 图片 URL 安全校验（与接收侧 / web isSafeUrl / octo-lib URL allowlist 对称）：
+     * 放行 http/https 绝对地址与 server 相对路径（{@code WKApiConfig#getShowUrl} 会前缀
+     * baseUrl），阻断 {@code javascript:} / {@code data:} / {@code file:} / {@code vbscript:}
+     * 等注入向量。上传成功但 URL 不安全的图片应被跳过。
+     */
+    public static boolean isSafeImageUrl(String url) {
+        if (isBlank(url)) {
+            return false;
+        }
+        String lower = url.trim().toLowerCase();
+        if (lower.startsWith("javascript:") || lower.startsWith("data:")
+                || lower.startsWith("file:") || lower.startsWith("vbscript:")) {
+            return false;
+        }
+        if (lower.startsWith("http://") || lower.startsWith("https://")) {
+            return true;
+        }
+        // 无 scheme 的相对路径视为 server 资源路径（安全）；带其它 scheme 一律拒绝。
+        return !lower.contains("://");
+    }
+
     /**
      * 序列化回 RichText payload（content block 数组 + 顶层 plain），与 decodeMsg
      * 对称。Phase 1 不主动发送 RichText，但 SDK 在转存 / 引用 / 合并转发等路径会

--- a/wkuikit/src/test/java/com/chat/uikit/chat/msgmodel/WKRichTextContentTest.java
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/msgmodel/WKRichTextContentTest.java
@@ -174,4 +174,89 @@ public class WKRichTextContentTest {
         c.decodeMsg(null);
         assertNotNull(c.blocks);
     }
+
+    // ---------------------------------------------------------------------
+    // 发送侧（Phase 1 图文混排）：工厂 / URL 安全 / plain 占位 / encode↔decode 往返
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void send_create_interleavesTextThenImagesAndFillsPlaceholderPlain() {
+        java.util.List<WKRichTextContent.RichTextBlock> blocks = new java.util.ArrayList<>();
+        blocks.add(WKRichTextContent.makeTextBlock("看图"));
+        blocks.add(WKRichTextContent.makeImageBlock("https://x/a.png", 100, 200));
+        blocks.add(WKRichTextContent.makeImageBlock("https://x/b.png", 50, 60));
+
+        WKRichTextContent c = WKRichTextContent.create(blocks);
+
+        assertEquals(3, c.blocks.size());
+        assertTrue(c.blocks.get(0).isText());
+        assertTrue(c.blocks.get(1).isImage());
+        assertTrue(c.blocks.get(2).isImage());
+        // plain 仅本地占位（image → 占位 wire token），非权威，server #232 覆盖。
+        assertEquals("看图" + WKRichTextContent.IMAGE_PLACEHOLDER
+                + WKRichTextContent.IMAGE_PLACEHOLDER, c.plain);
+    }
+
+    @Test
+    public void send_encodeDecode_roundTripsMixedPayload() throws JSONException {
+        java.util.List<WKRichTextContent.RichTextBlock> blocks = new java.util.ArrayList<>();
+        blocks.add(WKRichTextContent.makeTextBlock("hi"));
+        blocks.add(WKRichTextContent.makeImageBlock("https://x/z.png", 30, 40));
+        WKRichTextContent sent = WKRichTextContent.create(blocks);
+
+        // 发送侧 encode → wire JSON。
+        JSONObject wire = sent.encodeMsg();
+        assertNotNull(wire);
+        assertTrue(wire.has("content"));
+
+        // 接收侧 decode 同一 wire，断言字段逐项对称。
+        WKRichTextContent received = new WKRichTextContent();
+        received.decodeMsg(wire);
+
+        assertEquals(2, received.blocks.size());
+        assertTrue(received.blocks.get(0).isText());
+        assertEquals("hi", received.blocks.get(0).text);
+        assertTrue(received.blocks.get(1).isImage());
+        assertEquals("https://x/z.png", received.blocks.get(1).url);
+        assertEquals(30, received.blocks.get(1).width);
+        assertEquals(40, received.blocks.get(1).height);
+        assertEquals("hi" + WKRichTextContent.IMAGE_PLACEHOLDER, received.plain);
+    }
+
+    @Test
+    public void send_encode_imageBlockOmitsTextField_byteHygiene() throws JSONException {
+        // image block 不应在 wire 写出 text 字段（字节卫生，与接收侧/server 契约对齐）。
+        java.util.List<WKRichTextContent.RichTextBlock> blocks = new java.util.ArrayList<>();
+        blocks.add(WKRichTextContent.makeImageBlock("https://x/i.png", 10, 10));
+        WKRichTextContent c = WKRichTextContent.create(blocks);
+
+        JSONObject wire = c.encodeMsg();
+        JSONArray content = wire.optJSONArray("content");
+        assertNotNull(content);
+        JSONObject imgJson = content.optJSONObject(0);
+        assertEquals(WKRichTextContent.BLOCK_TYPE_IMAGE, imgJson.optString("type"));
+        assertTrue(imgJson.has("url"));
+        assertTrue(imgJson.has("width"));
+        assertTrue(imgJson.has("height"));
+        // image block 不写 text 键。
+        assertTrue(!imgJson.has("text"));
+    }
+
+    @Test
+    public void send_isSafeImageUrl_allowsHttpAndRelative_blocksInjection() {
+        // 放行 http/https 与无 scheme 相对路径（server 资源）。
+        assertTrue(WKRichTextContent.isSafeImageUrl("https://cdn/x.png"));
+        assertTrue(WKRichTextContent.isSafeImageUrl("http://cdn/x.png"));
+        assertTrue(WKRichTextContent.isSafeImageUrl("HTTPS://cdn/x.png"));
+        assertTrue(WKRichTextContent.isSafeImageUrl("/0/123/abc.png"));
+
+        // 阻断注入向量。
+        assertTrue(!WKRichTextContent.isSafeImageUrl("javascript:alert(1)"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl("data:image/png;base64,AAAA"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl("file:///etc/passwd"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl("vbscript:msgbox"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl("ftp://host/x.png"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl(""));
+        assertTrue(!WKRichTextContent.isSafeImageUrl(null));
+    }
 }


### PR DESCRIPTION
## What

Android **send-side** for 图文混排 RichText (ContentType=14), Phase 1 (text + image). Builds on the APPROVED receive-side **#26** (`feat/richtext-receive-render`) and is symmetric with web send-side **octo-web#227**.

## Changes (+~300 lines, 6 files, all in wkuikit/wkbase)

1. **Aggregate into a single RichText=14 message** — when the input box holds text **and** the album selection is all static images (no video/gif/file), `ChatActivity.trySendRichTextMixed` builds **one** `type=14` payload (ordered `content` blocks: text first, images in pick order) instead of emitting separate text + per-image messages. Pure text (`type=1`), pure image (`type=2`), video, gif, and file paths are **untouched** — zero regression.
2. **Reuse the receive-side schema, no fork** (`WKRichTextContent`) — added send-side factories `makeTextBlock` / `makeImageBlock` / `create` next to the #26 decode logic; wire-format byte-matches the octo-lib authoritative schema. encode↔decode round-trip covered by a new test.
3. **plain stays non-authoritative** — client fills a local placeholder (`buildPlainFromBlocks`, image → `IMAGE_PLACEHOLDER` wire token, **not** localized); server #232 `Finalize` recomputes and overwrites.
4. **Security (symmetric with receive side)** — each image is uploaded, then `isSafeImageUrl` validates http/https (blocks `javascript:`/`data:`/`file:`/`vbscript:`) before the URL enters a block. Unsafe / failed-upload images are skipped with a Toast.
5. **mention merge** — `ChatPanelManager.applyInputMentionsTo` reuses the send-button mention logic (tri-state humans/ais + group uids, `@所有AI` robot expansion) so group @-notifications are not lost.
6. **Atomicity** — text **always lands**: a mixed message when ≥1 image succeeds; plain-text fallback (mention preserved) when all images fail. Oversized text (>10KB) declines aggregation and falls back to the existing text-to-file path.

**Key pitfall (handled):** `WKRichTextContent extends WKMessageContent` (not Media) → goes through `sendTextAndWaitAck`, not the media-upload path. Images are still uploaded first (serial, order-preserving) to resolve `downloadUrl` before the single payload is built. Image dimensions are read from the **local** file (`inJustDecodeBounds`) to avoid CDN read-after-write 0×0.

## Architecture note (vs web)

Android has no Tiptap-style inline editor where text + images interleave in one staging area. Text lives in the input box; images are picked from the album. So the "mixed" moment is: user has typed text **and** then picks static images — that is the aggregation point (`WKUIKitApplication.chooseIMG` → `trySendRichTextMixed`).

## Out of scope (Phase 1)

Rich formatting (bold/headings). Only text + image. No other repos touched.

## Known limitation (Phase 1)

If the user sends another message *during* the mixed-image upload, the later message can land first (upload-before-send). Same trade-off as web #227; acceptable for Phase 1.

## Verification

- `./gradlew testDebugUnitTest assembleDevDebug` — green (JDK 17, matches CI).
- RichText unit tests: 10/10 (5 receive from #26 + **5 new send**: factory interleave, encode↔decode round-trip, image-block byte hygiene, URL safety allow/deny).
- Full wkuikit + wkbase suites: no new failures.

## Merge order

Base is `feat/richtext-receive-render` (#26) so this diff is send-side only. Merge **#26 first**, then this — they ship together to `main`.

Fixes #29
