### PR TITLE
feat(richtext): Android send mixed text+image RichText=14 (Phase 1)

### DIFF
--- a/wkbase/src/main/java/com/chat/base/msg/IConversationContext.java
+++ b/wkbase/src/main/java/com/chat/base/msg/IConversationContext.java
@@ -86,4 +86,19 @@ public interface IConversationContext {
 
     // 选择文件发送
     void chooseFile();
+
+    /**
+     * 图文混排（RichText=14）发送侧聚合（Phase 1）。
+     *
+     * <p>当输入框含待发文本时，把传入的图片本地路径与文本聚合成<strong>一条</strong>
+     * type=14 消息（text 块在前、image 块按选取顺序在后），上传图片得 URL 后落库发送，
+     * 并清空输入框；返回 true 表示本次发送已被接管。若输入框无文本则返回 false，调用方
+     * 继续走原有逐条图片发送（纯图片零回归）。
+     *
+     * @param imageLocalPaths 本次选取的静态图片本地路径（按选取顺序，调用方已过滤 video/gif）
+     * @return true 已聚合发送；false 未接管
+     */
+    default boolean trySendRichTextMixed(java.util.List<String> imageLocalPaths) {
+        return false;
+    }
 }

--- a/wkbase/src/main/java/com/chat/base/msg/IConversationContext.java
+++ b/wkbase/src/main/java/com/chat/base/msg/IConversationContext.java
@@ -101,4 +101,20 @@ public interface IConversationContext {
     default boolean trySendRichTextMixed(java.util.List<String> imageLocalPaths) {
         return false;
     }
+
+    /**
+     * 图文混排（RichText=14）发送 in-flight 期间的重复发送拦截（YUJ-2872 🔴）。
+     *
+     * <p>一条混排发送在等图片异步上传完成期间，被消费的文本仍留在输入框（YUJ-2832 崩溃
+     * 恢复语义）。若用户此时手动点发送键，会把<strong>同一段</strong>可见文本作为一条独立
+     * 纯文本消息单发出去 → 重复文本消息 + 之后那条 RichText。本方法返回 true 表示候选发送
+     * 文本与 in-flight 混排消费的文本完全相同，发送键路径应吞掉这次点击；文本被改动（即
+     * 用户的新意图）或无 in-flight 时返回 false（放行）。
+     *
+     * @param candidateText 发送键将要发出的文本
+     * @return true 表示是 in-flight 混排发送的重复，应拦截；false 表示放行
+     */
+    default boolean isPendingRichTextDuplicate(String candidateText) {
+        return false;
+    }
 }

--- a/wkbase/src/main/java/com/chat/base/msg/IConversationContext.java
+++ b/wkbase/src/main/java/com/chat/base/msg/IConversationContext.java
@@ -31,6 +31,21 @@ public interface IConversationContext {
     //发送消息到当前会话
     void sendMessage(WKMessageContent wkMessageContent);
 
+    /**
+     * 发送消息到<strong>指定</strong>频道（YUJ-2872 🔴 跨频道路由）。用于<em>延迟入队</em>
+     * 场景：图文混排发送在等图片异步上传期间，承载它的 Activity 可能已被复用切到别的频道
+     * （{@code ChatActivity.onNewIntent} 改写了 mutable 的 channelId/channelType）。若此时
+     * 回调仍走 {@link #sendMessage} 读 mutable 字段，消息会被错投到当前频道（用 A 频道凭证
+     * 上传的图片落到 B 频道 = 隐私/路由 bug）。调用方应在发起时<strong>捕获</strong>目标频道
+     * （{@link #getChatChannelInfo()}），入队时传回这里按捕获的频道落库，不受字段变更影响。
+     *
+     * <p>默认实现委派回 {@link #sendMessage}（无跨频道语义的实现保持原行为）。
+     */
+    default void sendMessageToChannel(WKMessageContent wkMessageContent,
+                                      com.xinbida.wukongim.entity.WKChannel channel) {
+        sendMessage(wkMessageContent);
+    }
+
     //获取当前会话到频道信息
     WKChannel getChatChannelInfo();
 

--- a/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
+++ b/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
@@ -824,6 +824,14 @@ public class WKUIKitApplication {
                                 return;
                             }
 
+                            // 图文混排（RichText=14）发送侧聚合（Phase 1，对称 web#227）：
+                            // 输入框已有文本 + 本次全是静态图片（无 video / 无走 sticker 的 gif）时，
+                            // 聚合成单条 type=14（text 块在前、image 块按选取顺序在后），
+                            // 而非逐张发独立 image。其余情况落到下方原有逐条发送，零回归。
+                            if (tryAggregateRichTextMixed(iConversationContext, paths)) {
+                                return;
+                            }
+
                             for (int i = 0, size = paths.size(); i < size; i++) {
                                 String path = paths.get(i).path;
                                 if (paths.get(i).model == ChooseResultModel.video) {
@@ -873,6 +881,38 @@ public class WKUIKitApplication {
 
     public interface IShowChatConfirm {
         void onBack(@NonNull List<WKChannel> list, @NonNull List<WKMessageContent> messageContentList);
+    }
+
+    /**
+     * 图文混排（RichText=14）发送侧聚合判定（Phase 1）。
+     *
+     * <p>仅当本次相册选择<strong>全是静态图片</strong>（无 video、无 gif——gif 走表情/原图
+     * 逐条路径不变）时才尝试聚合。把图片本地路径按选取顺序收集后交给
+     * {@link IConversationContext#trySendRichTextMixed(List)}：若输入框有待发文本则聚合成
+     * 单条 type=14 并返回 true（本次发送已被接管）；否则返回 false，调用方继续走原有逐条
+     * 发送（纯图片零回归）。
+     *
+     * @return true 表示已聚合发送，调用方应直接返回；false 表示未接管，继续原逐条逻辑。
+     */
+    private boolean tryAggregateRichTextMixed(IConversationContext iConversationContext, List<ChooseResult> paths) {
+        if (paths == null || paths.isEmpty()) {
+            return false;
+        }
+        List<String> imagePaths = new ArrayList<>();
+        for (ChooseResult result : paths) {
+            if (result == null || result.model != ChooseResultModel.image
+                    || TextUtils.isEmpty(result.path)) {
+                return false; // 含 video / 空路径 → 不聚合，走原逐条路径。
+            }
+            if (WKFileUtils.getInstance().isGif(result.path)) {
+                return false; // gif 走表情/原图逐条路径，不纳入图文混排。
+            }
+            imagePaths.add(result.path);
+        }
+        if (imagePaths.isEmpty()) {
+            return false;
+        }
+        return iConversationContext.trySendRichTextMixed(imagePaths);
     }
 
     public void showChatConfirmDialog(@NonNull Context context, @NonNull List<WKChannel> list, @NonNull List<WKMessageContent> messageContentList, final IShowChatConfirm iShowChatConfirm) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -3073,6 +3073,16 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         if (TextUtils.isEmpty(StringUtils.replaceBlank(rawText))) {
             return false; // 无文本 → 纯图片，交回原逐条发送路径。
         }
+        // 重复发送拦截 · 相册再选图路径（YUJ-2872 🔴 defect b，对称发送键拦截）：
+        // 一条混排发送 in-flight 期间，被消费的文本仍留在输入框（YUJ-2832 崩溃恢复）。
+        // 若用户此时再开相册选第二批图，本方法会再次读到同一段留存文本，聚合出第二条
+        // RichText —— text 块与第一条重复。命中（输入框文本仍等于 in-flight 快照）时
+        // <strong>不再消费这段文本</strong>：返回 false 交回逐条图片发送路径，让第二批
+        // 图片照常发出，但不重复发文本。用户若改了文本即视为新意图，放行正常聚合。
+        if (com.chat.uikit.chat.manager.WKRichTextSender
+                .isDuplicatePendingText(pendingRichTextSnapshot, rawText)) {
+            return false;
+        }
         // 文本超字节上限：不聚合（与发送键路径同源阈值）。交回逐条图片发送，
         // 超限文本留在输入框，由发送键走 showTextToFileAlert 转文件，避免发出超限 payload。
         if (chatPanelManager.isTextOverByteLimit(rawText)) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -1427,6 +1427,12 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         // channel 残留的 snapshot 命中新 channel 的 applyDataToAdapter）
         unreadStartSnapshotOrderSeq = 0;
         tipsSnapshotOrderSeq = 0;
+        // 图文混排 in-flight 快照（YUJ-2872 🔴 defect d，Jerry-Xin 复审）：必须随 channel
+        // 切换清掉，否则旧 channel 一条混排发送 in-flight 期间切到新 channel 时，快照残留 +
+        // channelId 已变 → (a) 新 channel 里发同串文本被发送键 isPendingRichTextDuplicate
+        // 静默吞掉（消息丢失）；(b) 旧 send 的 onEnqueued 用新 channelId 误清新 channel 的
+        // 落盘草稿 / 输入框。in-flight 上传随旧 Activity 状态作废，快照不再有意义，直接清零。
+        pendingRichTextSnapshot = null;
         unreadStartMsgOrderSeq = 0;
         tipsOrderSeq = 0;
         lastPreviewMsgOrderSeq = 0;

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -3114,12 +3114,47 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                             chatPanelManager.getEditText().setText(null);
                         }
                     }
+                    // 同时清掉<em>已持久化</em>的草稿（YUJ-2872 🔴 defect c，Jerry-Xin 复审）：
+                    // 上传期间文本有意留在输入框（崩溃恢复），若用户在上传完成前离开会话，
+                    // 离场 teardown（persistOldChannelEditState / persistCurrentChannelEditState /
+                    // saveEditContent）会把这段“即将发出”的可见文本落成 server 草稿。等本次
+                    // 入队后只清了内存 EditText 却不清落盘草稿 → 重开会话又恢复出已发文本，
+                    // 既是 stale UI 又是一键重复发送。故仅当落盘草稿仍恰好等于本次消费的快照
+                    // 时清掉它；用户离场后新打的草稿（不等于快照）保留，不误删。
+                    clearPersistedDraftIfMatches(rawText);
                     // in-flight 结束：清快照，发送键不再拦截。
                     if (rawText.equals(pendingRichTextSnapshot)) {
                         pendingRichTextSnapshot = null;
                     }
                 });
         return true;
+    }
+
+    /**
+     * 清掉<em>已持久化</em>的草稿——仅当它仍恰好等于本次混排发送消费的快照（YUJ-2872
+     * 🔴 defect c）。图文混排上传期间文本有意留在输入框（崩溃恢复），用户若在上传完成前
+     * 离开会话，离场 teardown 会把这段可见文本落成 server/本地草稿；本次发送入队后必须把
+     * 这条草稿一并清掉，否则重开会话又把已发文本恢复出来 = stale UI + 一键重复发送。
+     *
+     * <p>幂等且不误删：用 {@link com.chat.uikit.chat.manager.WKRichTextSender#shouldClearComposer}
+     * 同款“快照 vs 现值”判定——离场后用户又打的新草稿（不等于快照）保留不动。
+     */
+    private void clearPersistedDraftIfMatches(String consumedSnapshot) {
+        if (TextUtils.isEmpty(channelId)) {
+            return;
+        }
+        WKConversationMsgExtra extra = WKIM.getInstance().getConversationManager()
+                .getMsgExtraWithChannel(channelId, channelType);
+        if (extra == null || TextUtils.isEmpty(extra.draft)) {
+            return; // 没落盘草稿（用户没离场，或离场后已被别处清空）→ 无需处理。
+        }
+        if (!com.chat.uikit.chat.manager.WKRichTextSender
+                .shouldClearComposer(consumedSnapshot, extra.draft)) {
+            return; // 落盘草稿已是用户新打的内容（≠ 本次快照）→ 保留，不误删。
+        }
+        // 落盘草稿仍是这段已发文本 → 清空（保留浏览位置等其它 extra 字段）。
+        MsgModel.getInstance().updateCoverExtra(channelId, channelType,
+                extra.browseTo, extra.keepMessageSeq, extra.keepOffsetY, "");
     }
 
     /**

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -3051,6 +3051,51 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
     }
 
     /**
+     * 发送到<strong>指定捕获频道</strong>（YUJ-2872 🔴 跨频道路由）。图文混排延迟入队时
+     * Activity 可能已被复用切到别的频道（{@link #onNewIntent} 改写 channelId/channelType），
+     * 此路径按发起时捕获的 {@code destChannel} 落库，<em>不读</em> mutable 字段，避免把用 A
+     * 频道凭证上传的图片错投到当前 B 频道。
+     *
+     * <p>仅当捕获频道仍等于当前频道时才执行那些只对「当前会话 UI」有意义的副作用
+     * （清未读红点滚动、子区首发自动加入）；已切走时跳过，避免污染新会话。
+     */
+    @Override
+    public void sendMessageToChannel(WKMessageContent messageContent, WKChannel destChannel) {
+        if (destChannel == null || TextUtils.isEmpty(destChannel.channelID)) {
+            sendMessage(messageContent); // 没捕获到目标 → 回退原行为（当前会话）。
+            return;
+        }
+        boolean isCurrentChannel = destChannel.channelID.equals(channelId)
+                && destChannel.channelType == channelType;
+        if (isCurrentChannel && redDot > 0) {
+            wkVBinding.chatUnreadLayout.newMsgLayout.performClick();
+        }
+        // DM space_id 按目标频道类型判定（不依赖 mutable channelType）。
+        String spaceId = MsgModel.getInstance().getCurrentSpaceId();
+        if (!TextUtils.isEmpty(spaceId) && destChannel.channelType == WKChannelType.PERSONAL) {
+            messageContent.spaceId = spaceId;
+        }
+        WKMsg wkMsg = new WKMsg();
+        wkMsg.channelID = destChannel.channelID;
+        wkMsg.channelType = destChannel.channelType;
+        wkMsg.type = messageContent.type;
+        wkMsg.baseContentMsgModel = messageContent;
+        WKChannel channelInfo = WKIM.getInstance().getChannelManager()
+                .getChannel(destChannel.channelID, destChannel.channelType);
+        wkMsg.setChannelInfo(channelInfo != null ? channelInfo : destChannel);
+        WKSendMsgUtils.getInstance().sendMessage(wkMsg);
+
+        if (isCurrentChannel && destChannel.channelType == WKChannelType.COMMUNITY_TOPIC
+                && !hasJoinedThread) {
+            hasJoinedThread = true;
+            String[] parsed = ThreadModel.getInstance().parseChannelId(destChannel.channelID);
+            if (parsed != null) {
+                ThreadModel.getInstance().joinThread(parsed[0], parsed[1], (code, msg) -> {});
+            }
+        }
+    }
+
+    /**
      * 图文混排（RichText=14）发送侧聚合入口（Phase 1，对称 web#227）。
      *
      * <p>仅当输入框含待发文本时接管：把文本与本次选取的图片聚合成单条 type=14
@@ -3110,9 +3155,19 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         // 仍恰好等于本次消费的 rawText 快照时才清；否则保留用户新打的内容。
         // pendingRichTextSnapshot 同时供发送键拦截重复发送（defect b）使用。
         pendingRichTextSnapshot = rawText;
+        // 捕获本次发送的目标频道快照（YUJ-2872 🔴 跨频道路由）：上传可耗时数秒，回调触发时
+        // Activity 可能已切到别的频道。落库与清落盘草稿都按这个捕获值走，不读 mutable 字段。
+        final WKChannel sendChannel = getChatChannelInfo();
         com.chat.uikit.chat.manager.WKRichTextSender.send(this, content, rawText, imageLocalPaths,
                 () -> {
-                    if (chatPanelManager != null && chatPanelManager.getEditText() != null
+                    // 仅当回调到达时仍停留在<em>发起时</em>那个频道，才动 in-memory 输入框
+                    // （YUJ-2872 🔴 跨频道）：已切走时这个输入框属于新频道，绝不能清它。
+                    boolean stillOnSendChannel = sendChannel != null
+                            && sendChannel.channelID != null
+                            && sendChannel.channelID.equals(channelId)
+                            && sendChannel.channelType == channelType;
+                    if (stillOnSendChannel && chatPanelManager != null
+                            && chatPanelManager.getEditText() != null
                             && chatPanelManager.getEditText().getText() != null) {
                         String current = chatPanelManager.getEditText().getText().toString();
                         if (com.chat.uikit.chat.manager.WKRichTextSender
@@ -3125,9 +3180,9 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                     // 离场 teardown（persistOldChannelEditState / persistCurrentChannelEditState /
                     // saveEditContent）会把这段“即将发出”的可见文本落成 server 草稿。等本次
                     // 入队后只清了内存 EditText 却不清落盘草稿 → 重开会话又恢复出已发文本，
-                    // 既是 stale UI 又是一键重复发送。故仅当落盘草稿仍恰好等于本次消费的快照
-                    // 时清掉它；用户离场后新打的草稿（不等于快照）保留，不误删。
-                    clearPersistedDraftIfMatches(rawText);
+                    // 既是 stale UI 又是一键重复发送。按捕获频道清（跨频道安全），且仅当落盘
+                    // 草稿仍恰好等于本次消费的快照时清；用户新打的草稿（不等于快照）保留不误删。
+                    clearPersistedDraftIfMatches(sendChannel, rawText);
                     // in-flight 结束：清快照，发送键不再拦截。
                     if (rawText.equals(pendingRichTextSnapshot)) {
                         pendingRichTextSnapshot = null;
@@ -3142,15 +3197,18 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
      * 离开会话，离场 teardown 会把这段可见文本落成 server/本地草稿；本次发送入队后必须把
      * 这条草稿一并清掉，否则重开会话又把已发文本恢复出来 = stale UI + 一键重复发送。
      *
+     * <p>按<em>捕获</em>的 {@code destChannel} 清（YUJ-2872 🔴 跨频道路由）：上传期间 Activity
+     * 可能已切走，不能读 mutable 字段，否则会去清错频道的草稿 / 漏清目标频道。
+     *
      * <p>幂等且不误删：用 {@link com.chat.uikit.chat.manager.WKRichTextSender#shouldClearComposer}
      * 同款“快照 vs 现值”判定——离场后用户又打的新草稿（不等于快照）保留不动。
      */
-    private void clearPersistedDraftIfMatches(String consumedSnapshot) {
-        if (TextUtils.isEmpty(channelId)) {
+    private void clearPersistedDraftIfMatches(WKChannel destChannel, String consumedSnapshot) {
+        if (destChannel == null || TextUtils.isEmpty(destChannel.channelID)) {
             return;
         }
         WKConversationMsgExtra extra = WKIM.getInstance().getConversationManager()
-                .getMsgExtraWithChannel(channelId, channelType);
+                .getMsgExtraWithChannel(destChannel.channelID, destChannel.channelType);
         if (extra == null || TextUtils.isEmpty(extra.draft)) {
             return; // 没落盘草稿（用户没离场，或离场后已被别处清空）→ 无需处理。
         }
@@ -3159,7 +3217,7 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
             return; // 落盘草稿已是用户新打的内容（≠ 本次快照）→ 保留，不误删。
         }
         // 落盘草稿仍是这段已发文本 → 清空（保留浏览位置等其它 extra 字段）。
-        MsgModel.getInstance().updateCoverExtra(channelId, channelType,
+        MsgModel.getInstance().updateCoverExtra(destChannel.channelID, destChannel.channelType,
                 extra.browseTo, extra.keepMessageSeq, extra.keepOffsetY, "");
     }
 

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -105,6 +105,7 @@ import com.chat.base.utils.ActManagerUtils;
 import com.chat.base.utils.AndroidUtilities;
 import com.chat.base.utils.LayoutHelper;
 import com.chat.base.utils.SoftKeyboardUtils;
+import com.chat.base.utils.StringUtils;
 import com.chat.base.utils.UserUtils;
 import com.chat.base.utils.WKDialogUtils;
 import com.chat.base.utils.WKPermissions;
@@ -3035,6 +3036,51 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                 ThreadModel.getInstance().joinThread(parsed[0], parsed[1], (code, msg) -> {});
             }
         }
+    }
+
+    /**
+     * 图文混排（RichText=14）发送侧聚合入口（Phase 1，对称 web#227）。
+     *
+     * <p>仅当输入框含待发文本时接管：把文本与本次选取的图片聚合成单条 type=14
+     * （text 块在前、image 块按选取顺序在后），mention（三态 humans/ais + 群成员 uids）
+     * 与发送键文本路径同源复用，发送后清空输入框、关闭顶部提示。无文本则返回 false，
+     * 调用方继续走原有逐张图片发送（纯图片零回归）。
+     *
+     * <p>编辑态 / 回复态下不接管（保持既有逐条语义），由 sendMessage 的特化路径处理。
+     */
+    @Override
+    public boolean trySendRichTextMixed(List<String> imageLocalPaths) {
+        if (imageLocalPaths == null || imageLocalPaths.isEmpty()) {
+            return false;
+        }
+        if (chatPanelManager == null || chatPanelManager.getEditText() == null
+                || chatPanelManager.getEditText().getText() == null) {
+            return false;
+        }
+        // 编辑 / 回复态走既有特化路径，不聚合（避免破坏 edit/reply 语义）。
+        if (editMsg != null || replyWKMsg != null) {
+            return false;
+        }
+        String rawText = chatPanelManager.getEditText().getText().toString();
+        if (TextUtils.isEmpty(StringUtils.replaceBlank(rawText))) {
+            return false; // 无文本 → 纯图片，交回原逐条发送路径。
+        }
+        // 文本超字节上限：不聚合（与发送键路径同源阈值）。交回逐条图片发送，
+        // 超限文本留在输入框，由发送键走 showTextToFileAlert 转文件，避免发出超限 payload。
+        if (chatPanelManager.isTextOverByteLimit(rawText)) {
+            return false;
+        }
+
+        com.chat.uikit.chat.msgmodel.WKRichTextContent content =
+                new com.chat.uikit.chat.msgmodel.WKRichTextContent();
+        // mention 合并：与发送键文本路径同源（三态 humans/ais + 群成员 uids 不丢）。
+        chatPanelManager.applyInputMentionsTo(content, rawText);
+
+        com.chat.uikit.chat.manager.WKRichTextSender.send(this, content, rawText, imageLocalPaths);
+
+        // 与文本发送一致：清空输入框、关闭顶部提示条。
+        chatPanelManager.getEditText().setText(null);
+        return true;
     }
 
     private boolean isUpdate(WKMessageContent messageContent) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -270,6 +270,12 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
     private int hideChannelAllPinnedMessage = 0;
     private PanelSwitchHelper mHelper;
     private ChatPanelManager chatPanelManager;
+    // 图文混排（RichText=14）一条 in-flight 发送消费的输入框文本快照（YUJ-2872 🔴）。
+    // 上传期间被消费的文本仍留在输入框（YUJ-2832 崩溃恢复），此快照用于：
+    //   (a) onEnqueued 清空时 snapshot-aware——仅当输入框仍等于它才清，绝不擦用户新草稿；
+    //   (b) 拦截手动发送键把同一段可见文本重复单发（重复文本 + 之后的 RichText）。
+    // 仅主线程读写（send 启动 / onEnqueued 回调 / 发送键点击都在主线程）。null = 无 in-flight。
+    private String pendingRichTextSnapshot;
     private ActChatLayoutBinding wkVBinding;
     private int unfilledHeight = 0;
     private final String loginUID = WKConfig.getInstance().getUid();
@@ -3082,13 +3088,40 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         // 才落库入队。绝不能在上传开始时就清空输入框——否则进程被杀 / Activity 销毁 /
         // 上传始终未回调时，文本既不在输入框也没入队 → 丢消息回归。改为仅在消息真正
         // 入队后（onEnqueued）才清空；上传未完成期间文本留在输入框，由草稿持久化兜底可恢复。
+        //
+        // snapshot-aware 清空（YUJ-2872 🔴 defect a，对齐 web#227 第二轮）：上传可耗时数秒，
+        // 用户在等待期间可能又打了新草稿。本次 send 入队后绝不能无条件清空——只有当输入框
+        // 仍恰好等于本次消费的 rawText 快照时才清；否则保留用户新打的内容。
+        // pendingRichTextSnapshot 同时供发送键拦截重复发送（defect b）使用。
+        pendingRichTextSnapshot = rawText;
         com.chat.uikit.chat.manager.WKRichTextSender.send(this, content, rawText, imageLocalPaths,
                 () -> {
-                    if (chatPanelManager != null && chatPanelManager.getEditText() != null) {
-                        chatPanelManager.getEditText().setText(null);
+                    if (chatPanelManager != null && chatPanelManager.getEditText() != null
+                            && chatPanelManager.getEditText().getText() != null) {
+                        String current = chatPanelManager.getEditText().getText().toString();
+                        if (com.chat.uikit.chat.manager.WKRichTextSender
+                                .shouldClearComposer(rawText, current)) {
+                            chatPanelManager.getEditText().setText(null);
+                        }
+                    }
+                    // in-flight 结束：清快照，发送键不再拦截。
+                    if (rawText.equals(pendingRichTextSnapshot)) {
+                        pendingRichTextSnapshot = null;
                     }
                 });
         return true;
+    }
+
+    /**
+     * 重复发送拦截（YUJ-2872 🔴 defect b）：一条图文混排发送 in-flight 期间，被消费的文本
+     * 仍留在输入框（YUJ-2832 崩溃恢复）。此时用户手动点发送键会把<em>同一段</em>可见文本
+     * 作为独立纯文本单发出去 → 重复文本消息 + 之后那条 RichText。命中（候选文本与 in-flight
+     * 快照完全相同）时返回 true，发送键路径应吞掉这次点击。文本被改动即视为新意图，放行。
+     */
+    @Override
+    public boolean isPendingRichTextDuplicate(String candidateText) {
+        return com.chat.uikit.chat.manager.WKRichTextSender
+                .isDuplicatePendingText(pendingRichTextSnapshot, candidateText);
     }
 
     private boolean isUpdate(WKMessageContent messageContent) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -3043,8 +3043,10 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
      *
      * <p>仅当输入框含待发文本时接管：把文本与本次选取的图片聚合成单条 type=14
      * （text 块在前、image 块按选取顺序在后），mention（三态 humans/ais + 群成员 uids）
-     * 与发送键文本路径同源复用，发送后清空输入框、关闭顶部提示。无文本则返回 false，
-     * 调用方继续走原有逐张图片发送（纯图片零回归）。
+     * 与发送键文本路径同源复用。<strong>输入框仅在消息真正入队后才清空</strong>（见
+     * WKRichTextSender 的 onEnqueued）——上传未完成期间文本留在输入框可恢复，保证
+     * 「文本必达」（YUJ-2832 P1）。无文本则返回 false，调用方继续走原有逐张图片发送
+     * （纯图片零回归）。
      *
      * <p>编辑态 / 回复态下不接管（保持既有逐条语义），由 sendMessage 的特化路径处理。
      */
@@ -3076,10 +3078,16 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         // mention 合并：与发送键文本路径同源（三态 humans/ais + 群成员 uids 不丢）。
         chatPanelManager.applyInputMentionsTo(content, rawText);
 
-        com.chat.uikit.chat.manager.WKRichTextSender.send(this, content, rawText, imageLocalPaths);
-
-        // 与文本发送一致：清空输入框、关闭顶部提示条。
-        chatPanelManager.getEditText().setText(null);
+        // 文本必达（YUJ-2832 P1）：图片上传是异步的，sendMessage 要等所有上传回调完成
+        // 才落库入队。绝不能在上传开始时就清空输入框——否则进程被杀 / Activity 销毁 /
+        // 上传始终未回调时，文本既不在输入框也没入队 → 丢消息回归。改为仅在消息真正
+        // 入队后（onEnqueued）才清空；上传未完成期间文本留在输入框，由草稿持久化兜底可恢复。
+        com.chat.uikit.chat.manager.WKRichTextSender.send(this, content, rawText, imageLocalPaths,
+                () -> {
+                    if (chatPanelManager != null && chatPanelManager.getEditText() != null) {
+                        chatPanelManager.getEditText().setText(null);
+                    }
+                });
         return true;
     }
 

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -416,6 +416,64 @@ class ChatPanelManager(
         return this.editText
     }
 
+    /**
+     * 文本字节是否超过输入框上限（与发送键文本路径同一阈值）。图文混排聚合发送前用它做
+     * 同源校验，避免绕过 [showTextToFileAlert] 发出超限 payload。
+     */
+    fun isTextOverByteLimit(text: String): Boolean {
+        return messageTextMaxBytes > 0 && text.toByteArray(Charsets.UTF_8).size > messageTextMaxBytes
+    }
+
+    /** 弹出"转为文件发送"确认框（供超限文本复用，与发送键路径同源）。 */
+    fun promptTextToFile(text: String) {
+        showTextToFileAlert(text)
+    }
+
+    /**
+     * 把当前输入框的 @mention（三态 humans/ais + 群成员 uids）应用到给定消息体。
+     *
+     * 供图文混排（RichText=14）聚合发送复用——与发送键文本路径【同源】，
+     * 保证群 @ 通知（含 @所有AI）不丢。刻意不写 entities：图文混排的 plain 非权威，
+     * 且 entity offset 是相对纯文本块的字符偏移，跨 block 拼接后无意义。
+     *
+     * 复用既有 [scanPlainTextMentions] / [expandRobotMembersIntoUids]，与 sendIV 文本
+     * 发送逻辑保持单一来源。
+     */
+    fun applyInputMentionsTo(content: WKMessageContent, text: String) {
+        val list = editText.allUIDs.toMutableList()
+        val entities = editText.allEntity.toMutableList()
+
+        if (iConversationContext.chatChannelInfo.channelType == WKChannelType.GROUP ||
+            iConversationContext.chatChannelInfo.channelType == WKChannelType.COMMUNITY_TOPIC
+        ) {
+            scanPlainTextMentions(text, entities, list)
+        }
+
+        if (list.isEmpty()) return
+
+        val mInfo = WKMentionInfo()
+        val uidList: MutableList<String> = ArrayList()
+        for (uid in list) {
+            when {
+                uid.equals("-1", ignoreCase = true) -> {
+                    content.mentionHumans = 1
+                    mInfo.humans = true
+                }
+                uid == "-2" -> {
+                    content.mentionAis = 1
+                    mInfo.ais = true
+                }
+                else -> uidList.add(uid)
+            }
+        }
+        // @所有AI 命中时把会话内 robot 成员展开到 mention.uids，兼容旧 adapter。
+        if (content.mentionAis == 1) {
+            expandRobotMembersIntoUids(uidList)
+        }
+        mInfo.uids = uidList
+        content.mentionInfo = mInfo
+    }
+
     fun showReplyLayout(mMsg: WKMsg) {
         var showName: String? = ""
         if (mMsg.from != null) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -1554,6 +1554,14 @@ class ChatPanelManager(
             if (!TextUtils.isEmpty(content)) {
                 content = editText.text.toString()
 
+                // 重复发送拦截（YUJ-2872 🔴 defect b）：图文混排发送 in-flight 期间，被消费
+                // 的文本仍留在输入框（YUJ-2832 崩溃恢复）。此时点发送键会把同一段可见文本作为
+                // 独立纯文本单发 → 重复文本 + 之后那条 RichText。命中（与 in-flight 快照完全
+                // 相同）则吞掉这次点击；文本被改动即视为新意图，放行。
+                if (iConversationContext.isPendingRichTextDuplicate(content)) {
+                    return@setOnClickListener
+                }
+
                 // 检查文本字节大小是否超过限制
                 val textBytes = content.toByteArray(Charsets.UTF_8)
                 if (messageTextMaxBytes > 0 && textBytes.size > messageTextMaxBytes) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKRichTextSender.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKRichTextSender.java
@@ -103,6 +103,41 @@ public final class WKRichTextSender {
         }
     }
 
+    /**
+     * Snapshot-aware 清空判定（YUJ-2872 🔴 defect a，对齐 web#227 第二轮 isEditorUnchanged）。
+     *
+     * <p>图片上传是异步的，消息要等所有上传回调完成才入队（{@link OnEnqueued}）。在那之前
+     * 输入框保留待发文本（YUJ-2832 崩溃恢复）。若用户在等待期间又打了新草稿，则<em>较早</em>
+     * 那条 send 入队后<strong>绝不能</strong>无条件清空输入框——否则把用户新打的内容擦掉。
+     * 仅当输入框<em>仍然恰好</em>等于本次消费的快照文本时才清；否则保留更新后的草稿。
+     *
+     * @param consumedSnapshot   本次混排发送消费的输入框文本快照（send 入参 text）
+     * @param currentComposerText 入队回调触发时输入框的当前文本
+     * @return true 表示可以安全清空（输入框未变）；false 表示用户已打新草稿，须保留
+     */
+    public static boolean shouldClearComposer(String consumedSnapshot, String currentComposerText) {
+        if (consumedSnapshot == null) {
+            return false;
+        }
+        return consumedSnapshot.equals(currentComposerText);
+    }
+
+    /**
+     * 重复发送判定（YUJ-2872 🔴 defect b，对齐 web#227 sendingRef 防重入）。
+     *
+     * <p>一条混排发送 in-flight 期间，被消费的文本仍留在输入框（YUJ-2832 崩溃恢复）。此时
+     * 用户手动点发送键会把<em>同一段</em>可见文本作为一条独立纯文本消息单发出去 → 重复文本
+     * 消息 + 之后那条 RichText。命中（候选手动发送文本与 in-flight 快照完全相同）时调用方
+     * 应吞掉这次点击。文本被改动（哪怕一个字符）即视为用户的新意图，放行。
+     *
+     * @param pendingSnapshot in-flight 混排发送消费的文本快照（无 in-flight 时为 null）
+     * @param candidateText   手动发送键将要发出的文本
+     * @return true 表示这是 in-flight 混排发送的重复，手动发送须被拦截
+     */
+    public static boolean isDuplicatePendingText(String pendingSnapshot, String candidateText) {
+        return pendingSnapshot != null && pendingSnapshot.equals(candidateText);
+    }
+
     private static volatile ImageUploader uploader = defaultUploader();
 
     @VisibleForTesting

--- a/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKRichTextSender.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKRichTextSender.java
@@ -19,6 +19,8 @@ package com.chat.uikit.chat.manager;
 import android.graphics.BitmapFactory;
 import android.text.TextUtils;
 
+import androidx.annotation.VisibleForTesting;
+
 import com.chat.base.msg.IConversationContext;
 import com.chat.base.net.ud.WKUploader;
 import com.chat.base.utils.WKToastUtils;
@@ -50,17 +52,67 @@ import java.util.UUID;
  * downloadUrl 再塞 block，故本类先逐张上传（顺序串行，天然保序）。
  *
  * <p>安全：每张图上传后用 {@link WKRichTextContent#isSafeImageUrl(String)} 校验
- * http/https，阻断 {@code javascript:}/{@code data:}/{@code file:} 注入；不安全或上传
- * 失败的图片跳过并 Toast。
+ * http/https 或 server 相对路径，阻断 {@code javascript:}/{@code data:}/{@code file:}
+ * 等注入；不安全或上传失败的图片跳过并 Toast。
  *
  * <p>原子性（对齐 YUJ-2740 元教训②）：文本<strong>始终落成一条消息</strong>——只要有
  * ≥1 张有效图片就发图文混排单条；若所有图片都失败，则降级发纯文本（text 不丢失）。
  * mention（三态 humans/ais + 群成员 uids）由调用方在传入的 {@code content} 上预置，
  * 全部图片失败降级时同样迁移到纯文本消息，保证群 @ 通知不丢。
+ *
+ * <p><strong>文本必达（YUJ-2832 P1 修复）</strong>：图片上传是异步的，
+ * {@link IConversationContext#sendMessage} 要等所有上传回调完成才落库入队。在那之前，
+ * 调用方<em>绝不能</em>提前清空输入框——否则进程被杀 / Activity 销毁 / 上传始终未回调
+ * 时，用户文本既不在输入框、也没作为本地 outgoing message 落库，造成相对 text/media
+ * 路径（立即入队）的丢消息回归。为此 {@code send} 接收一个 {@link OnEnqueued} 回调，
+ * <strong>仅在消息真正入队后</strong>（混排单条或纯文本降级）才触发；上传未完成期间文本
+ * 留在输入框，由 ChatActivity 的草稿持久化兜底，可恢复。
  */
 public final class WKRichTextSender {
 
     private WKRichTextSender() {
+    }
+
+    /**
+     * 消息已持久入队的回调。<strong>仅</strong>在 {@link IConversationContext#sendMessage}
+     * 真正被调用（混排单条或纯文本降级落库）后触发；上传未完成 / 全程无消息入队时
+     * 永不触发，保证调用方据此清空输入框时「文本已必达」。在主线程触发（WKUploader
+     * 回调已 post 回主 looper）。
+     */
+    public interface OnEnqueued {
+        void onEnqueued();
+    }
+
+    /**
+     * 单张图片上传抽象（可注入测试替身）。生产实现走 {@link WKUploader} 两步（取凭证
+     * → PUT），回调在主线程。把它抽成 seam 是为了让「上传未完成 → 文本仍可恢复 / 不被
+     * 提前清空」这条 P1 回归可在纯 JVM 单测下被断言。
+     */
+    public interface ImageUploader {
+        /**
+         * @param channel   目标频道
+         * @param localPath 图片本地路径
+         * @param result    上传结果回调（成功给 downloadUrl；失败 / 未完成则不调用 onSuccess）
+         */
+        void upload(WKChannel channel, String localPath, Result result);
+
+        interface Result {
+            void onSuccess(String downloadUrl);
+
+            void onFailure();
+        }
+    }
+
+    private static volatile ImageUploader uploader = defaultUploader();
+
+    @VisibleForTesting
+    static void setUploaderForTest(ImageUploader testUploader) {
+        uploader = testUploader != null ? testUploader : defaultUploader();
+    }
+
+    @VisibleForTesting
+    static void resetUploader() {
+        uploader = defaultUploader();
     }
 
     /**
@@ -70,22 +122,25 @@ public final class WKRichTextSender {
      * @param content    调用方已预置 mention 基字段（mentionInfo/mentionHumans/mentionAis）的 RichText 载体
      * @param text       输入框原始文本（保证落地，不丢字）
      * @param imagePaths 本次选取的图片本地路径（按选取顺序）
+     * @param onEnqueued 消息真正入队后的回调；调用方应在此（且仅在此）清空输入框，
+     *                   保证「文本必达」。可为 null。
      */
     public static void send(IConversationContext context,
                             WKRichTextContent content,
                             String text,
-                            List<String> imagePaths) {
+                            List<String> imagePaths,
+                            OnEnqueued onEnqueued) {
         if (context == null || content == null) {
             return;
         }
         WKChannel channel = context.getChatChannelInfo();
         if (channel == null) {
-            sendTextFallback(context, content, text);
+            sendTextFallback(context, content, text, onEnqueued);
             return;
         }
         List<String> paths = imagePaths != null ? imagePaths : new ArrayList<>();
         uploadNext(context, channel, content, text, paths, 0,
-                new ArrayList<>(), new int[]{0});
+                new ArrayList<>(), new int[]{0}, onEnqueued);
     }
 
     /**
@@ -98,61 +153,54 @@ public final class WKRichTextSender {
                                    List<String> paths,
                                    int index,
                                    List<WKRichTextContent.RichTextBlock> imageBlocks,
-                                   int[] failedCount) {
+                                   int[] failedCount,
+                                   OnEnqueued onEnqueued) {
         if (index >= paths.size()) {
-            finish(context, content, text, imageBlocks, failedCount[0]);
+            finish(context, content, text, imageBlocks, failedCount[0], onEnqueued);
             return;
         }
         String localPath = paths.get(index);
         if (TextUtils.isEmpty(localPath)) {
             failedCount[0]++;
-            uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount);
+            uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount, onEnqueued);
             return;
         }
         int[] dims = decodeImageSize(localPath);
-        WKUploader.getInstance().getUploadCredentials(channel.channelID, channel.channelType, localPath,
-                (uploadUrl, downloadUrl, contentType, contentDisposition) -> {
-                    if (TextUtils.isEmpty(uploadUrl) || TextUtils.isEmpty(downloadUrl)) {
-                        failedCount[0]++;
-                        uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount);
-                        return;
-                    }
-                    WKUploader.getInstance().putUpload(uploadUrl, localPath, contentType, contentDisposition,
-                            UUID.randomUUID().toString().replaceAll("-", ""),
-                            new WKUploader.IUploadBack() {
-                                @Override
-                                public void onSuccess(String url) {
-                                    // 安全对称：上传成功也要校验 scheme，阻断 javascript:/data:/file:。
-                                    if (!WKRichTextContent.isSafeImageUrl(downloadUrl)) {
-                                        failedCount[0]++;
-                                    } else {
-                                        imageBlocks.add(WKRichTextContent.makeImageBlock(downloadUrl, dims[0], dims[1]));
-                                    }
-                                    uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount);
-                                }
+        uploader.upload(channel, localPath, new ImageUploader.Result() {
+            @Override
+            public void onSuccess(String downloadUrl) {
+                // 安全对称：上传成功也要校验 scheme，阻断 javascript:/data:/file:。
+                if (!WKRichTextContent.isSafeImageUrl(downloadUrl)) {
+                    failedCount[0]++;
+                } else {
+                    imageBlocks.add(WKRichTextContent.makeImageBlock(downloadUrl, dims[0], dims[1]));
+                }
+                uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount, onEnqueued);
+            }
 
-                                @Override
-                                public void onError() {
-                                    failedCount[0]++;
-                                    uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount);
-                                }
-                            });
-                });
+            @Override
+            public void onFailure() {
+                failedCount[0]++;
+                uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount, onEnqueued);
+            }
+        });
     }
 
     /**
      * 全部图片处理完毕：拼装有序 block（text 在前、image 按序在后）→ 发单条 RichText；
      * 若无任何有效图片，降级发纯文本（原子性：text 不丢）。失败有跳过时 Toast 提示。
+     * 入队成功后触发 {@code onEnqueued}（调用方据此清空输入框，保证文本必达）。
      */
     private static void finish(IConversationContext context,
                                WKRichTextContent content,
                                String text,
                                List<WKRichTextContent.RichTextBlock> imageBlocks,
-                               int failedCount) {
+                               int failedCount,
+                               OnEnqueued onEnqueued) {
         if (imageBlocks.isEmpty()) {
             // 所有图片都失败/不安全 → 文本仍要落地。
             toastFailIfAny(context, failedCount);
-            sendTextFallback(context, content, text);
+            sendTextFallback(context, content, text, onEnqueued);
             return;
         }
 
@@ -168,15 +216,17 @@ public final class WKRichTextSender {
 
         toastFailIfAny(context, failedCount);
         context.sendMessage(content);
+        notifyEnqueued(onEnqueued);
     }
 
     /**
      * 降级纯文本发送：把已预置在 RichText 载体上的 mention 基字段迁移到 WKTextContent，
-     * 保证群 @ 通知（含 @所有AI）不因降级而丢失。
+     * 保证群 @ 通知（含 @所有AI）不因降级而丢失。入队后触发 {@code onEnqueued}。
      */
     private static void sendTextFallback(IConversationContext context,
                                          WKRichTextContent richHolder,
-                                         String text) {
+                                         String text,
+                                         OnEnqueued onEnqueued) {
         if (TextUtils.isEmpty(text)) {
             return;
         }
@@ -186,6 +236,13 @@ public final class WKRichTextSender {
         textContent.mentionAis = richHolder.mentionAis;
         textContent.mentionInfo = richHolder.mentionInfo;
         context.sendMessage(textContent);
+        notifyEnqueued(onEnqueued);
+    }
+
+    private static void notifyEnqueued(OnEnqueued onEnqueued) {
+        if (onEnqueued != null) {
+            onEnqueued.onEnqueued();
+        }
     }
 
     private static void toastFailIfAny(IConversationContext context, int failedCount) {
@@ -207,5 +264,30 @@ public final class WKRichTextSender {
         } catch (Throwable t) {
             return new int[]{0, 0};
         }
+    }
+
+    /** 生产上传实现：WKUploader 两步（取凭证 → PUT），回调已 post 回主线程。 */
+    private static ImageUploader defaultUploader() {
+        return (channel, localPath, result) ->
+                WKUploader.getInstance().getUploadCredentials(channel.channelID, channel.channelType, localPath,
+                        (uploadUrl, downloadUrl, contentType, contentDisposition) -> {
+                            if (TextUtils.isEmpty(uploadUrl) || TextUtils.isEmpty(downloadUrl)) {
+                                result.onFailure();
+                                return;
+                            }
+                            WKUploader.getInstance().putUpload(uploadUrl, localPath, contentType, contentDisposition,
+                                    UUID.randomUUID().toString().replaceAll("-", ""),
+                                    new WKUploader.IUploadBack() {
+                                        @Override
+                                        public void onSuccess(String url) {
+                                            result.onSuccess(downloadUrl);
+                                        }
+
+                                        @Override
+                                        public void onError() {
+                                            result.onFailure();
+                                        }
+                                    });
+                        });
     }
 }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKRichTextSender.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKRichTextSender.java
@@ -270,6 +270,10 @@ public final class WKRichTextSender {
         textContent.mentionHumans = richHolder.mentionHumans;
         textContent.mentionAis = richHolder.mentionAis;
         textContent.mentionInfo = richHolder.mentionInfo;
+        // 注意：此处<em>有意</em>不迁移 mention 的 entities（@ 高亮区间）。仅全图失败的降级
+        // 路径会走到这里，发出纯文本单条，与既有发送键文本路径同语义——@ 通知靠上面的
+        // mentionAll/humans/ais + mentionInfo.uids 三态基字段保证不丢；entities 只影响接收侧
+        // 高亮渲染，且其跨 block 的 offset 在降级为纯文本后已失去意义，故不迁移。
         context.sendMessage(textContent);
         notifyEnqueued(onEnqueued);
     }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKRichTextSender.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKRichTextSender.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.manager;
+
+import android.graphics.BitmapFactory;
+import android.text.TextUtils;
+
+import com.chat.base.msg.IConversationContext;
+import com.chat.base.net.ud.WKUploader;
+import com.chat.base.utils.WKToastUtils;
+import com.chat.uikit.R;
+import com.chat.uikit.chat.msgmodel.WKRichTextContent;
+import com.xinbida.wukongim.entity.WKChannel;
+import com.xinbida.wukongim.msgmodel.WKMessageContent;
+import com.xinbida.wukongim.msgmodel.WKTextContent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 图文混排（RichText，ContentType=14）<em>发送侧</em>聚合器（Phase 1）。
+ *
+ * <p>与 web 发送侧 octo-web#227 对称：当输入框同时含文本 + 图片（且无非图片文件块）
+ * 时，把它们聚合成 <strong>一条</strong> {@code type=14} 消息（content 为有序 block
+ * 数组），而非逐张发独立消息。纯文本 / 纯图片 / 含文件块的路径保持原有逐条发送不变，
+ * 零回归。
+ *
+ * <p>关键链路差异（对齐 octo-android 实际架构）：Android 没有 web Tiptap 那种把文本与
+ * 图片交错暂存的内联编辑器——文本在输入框、图片从相册选取。因此「混排」的发生时机 =
+ * 输入框已有文本时用户又选了一批静态图片；此时本聚合器接管。穿插顺序固定为
+ * <em>文本块在前、图片块按选取顺序在后</em>（即用户先打字、再选图的自然顺序）。
+ *
+ * <p>RichTextContent extends {@link WKMessageContent}（非 Media），故最终走
+ * sendTextAndWaitAck 链路，不是 media upload 链路；但图片 URL 仍需先上传得到
+ * downloadUrl 再塞 block，故本类先逐张上传（顺序串行，天然保序）。
+ *
+ * <p>安全：每张图上传后用 {@link WKRichTextContent#isSafeImageUrl(String)} 校验
+ * http/https，阻断 {@code javascript:}/{@code data:}/{@code file:} 注入；不安全或上传
+ * 失败的图片跳过并 Toast。
+ *
+ * <p>原子性（对齐 YUJ-2740 元教训②）：文本<strong>始终落成一条消息</strong>——只要有
+ * ≥1 张有效图片就发图文混排单条；若所有图片都失败，则降级发纯文本（text 不丢失）。
+ * mention（三态 humans/ais + 群成员 uids）由调用方在传入的 {@code content} 上预置，
+ * 全部图片失败降级时同样迁移到纯文本消息，保证群 @ 通知不丢。
+ */
+public final class WKRichTextSender {
+
+    private WKRichTextSender() {
+    }
+
+    /**
+     * 发起图文混排聚合发送。
+     *
+     * @param context    会话上下文（用于最终 {@link IConversationContext#sendMessage} 落库 + 注入 spaceId）
+     * @param content    调用方已预置 mention 基字段（mentionInfo/mentionHumans/mentionAis）的 RichText 载体
+     * @param text       输入框原始文本（保证落地，不丢字）
+     * @param imagePaths 本次选取的图片本地路径（按选取顺序）
+     */
+    public static void send(IConversationContext context,
+                            WKRichTextContent content,
+                            String text,
+                            List<String> imagePaths) {
+        if (context == null || content == null) {
+            return;
+        }
+        WKChannel channel = context.getChatChannelInfo();
+        if (channel == null) {
+            sendTextFallback(context, content, text);
+            return;
+        }
+        List<String> paths = imagePaths != null ? imagePaths : new ArrayList<>();
+        uploadNext(context, channel, content, text, paths, 0,
+                new ArrayList<>(), new int[]{0});
+    }
+
+    /**
+     * 串行上传第 index 张图片（保序），完成后递归处理下一张；全部处理完构造并发送。
+     */
+    private static void uploadNext(IConversationContext context,
+                                   WKChannel channel,
+                                   WKRichTextContent content,
+                                   String text,
+                                   List<String> paths,
+                                   int index,
+                                   List<WKRichTextContent.RichTextBlock> imageBlocks,
+                                   int[] failedCount) {
+        if (index >= paths.size()) {
+            finish(context, content, text, imageBlocks, failedCount[0]);
+            return;
+        }
+        String localPath = paths.get(index);
+        if (TextUtils.isEmpty(localPath)) {
+            failedCount[0]++;
+            uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount);
+            return;
+        }
+        int[] dims = decodeImageSize(localPath);
+        WKUploader.getInstance().getUploadCredentials(channel.channelID, channel.channelType, localPath,
+                (uploadUrl, downloadUrl, contentType, contentDisposition) -> {
+                    if (TextUtils.isEmpty(uploadUrl) || TextUtils.isEmpty(downloadUrl)) {
+                        failedCount[0]++;
+                        uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount);
+                        return;
+                    }
+                    WKUploader.getInstance().putUpload(uploadUrl, localPath, contentType, contentDisposition,
+                            UUID.randomUUID().toString().replaceAll("-", ""),
+                            new WKUploader.IUploadBack() {
+                                @Override
+                                public void onSuccess(String url) {
+                                    // 安全对称：上传成功也要校验 scheme，阻断 javascript:/data:/file:。
+                                    if (!WKRichTextContent.isSafeImageUrl(downloadUrl)) {
+                                        failedCount[0]++;
+                                    } else {
+                                        imageBlocks.add(WKRichTextContent.makeImageBlock(downloadUrl, dims[0], dims[1]));
+                                    }
+                                    uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount);
+                                }
+
+                                @Override
+                                public void onError() {
+                                    failedCount[0]++;
+                                    uploadNext(context, channel, content, text, paths, index + 1, imageBlocks, failedCount);
+                                }
+                            });
+                });
+    }
+
+    /**
+     * 全部图片处理完毕：拼装有序 block（text 在前、image 按序在后）→ 发单条 RichText；
+     * 若无任何有效图片，降级发纯文本（原子性：text 不丢）。失败有跳过时 Toast 提示。
+     */
+    private static void finish(IConversationContext context,
+                               WKRichTextContent content,
+                               String text,
+                               List<WKRichTextContent.RichTextBlock> imageBlocks,
+                               int failedCount) {
+        if (imageBlocks.isEmpty()) {
+            // 所有图片都失败/不安全 → 文本仍要落地。
+            toastFailIfAny(context, failedCount);
+            sendTextFallback(context, content, text);
+            return;
+        }
+
+        List<WKRichTextContent.RichTextBlock> blocks = new ArrayList<>();
+        if (!TextUtils.isEmpty(text)) {
+            blocks.add(WKRichTextContent.makeTextBlock(text));
+        }
+        blocks.addAll(imageBlocks);
+
+        content.blocks = blocks;
+        // plain 非权威：仅填本地占位（image → 占位 wire token），server #232 Finalize 覆盖。
+        content.plain = WKRichTextContent.buildPlainFromBlocks(blocks);
+
+        toastFailIfAny(context, failedCount);
+        context.sendMessage(content);
+    }
+
+    /**
+     * 降级纯文本发送：把已预置在 RichText 载体上的 mention 基字段迁移到 WKTextContent，
+     * 保证群 @ 通知（含 @所有AI）不因降级而丢失。
+     */
+    private static void sendTextFallback(IConversationContext context,
+                                         WKRichTextContent richHolder,
+                                         String text) {
+        if (TextUtils.isEmpty(text)) {
+            return;
+        }
+        WKTextContent textContent = new WKTextContent(text);
+        textContent.mentionAll = richHolder.mentionAll;
+        textContent.mentionHumans = richHolder.mentionHumans;
+        textContent.mentionAis = richHolder.mentionAis;
+        textContent.mentionInfo = richHolder.mentionInfo;
+        context.sendMessage(textContent);
+    }
+
+    private static void toastFailIfAny(IConversationContext context, int failedCount) {
+        if (failedCount > 0 && context != null && context.getChatActivity() != null) {
+            WKToastUtils.getInstance().showToast(
+                    context.getChatActivity().getString(R.string.upload_fail));
+        }
+    }
+
+    /** inJustDecodeBounds 量本地图片尺寸（避免读 CDN 返回 0×0，对齐 web 本地量尺寸教训）。 */
+    private static int[] decodeImageSize(String localPath) {
+        try {
+            BitmapFactory.Options options = new BitmapFactory.Options();
+            options.inJustDecodeBounds = true;
+            BitmapFactory.decodeFile(localPath, options);
+            int w = Math.max(options.outWidth, 0);
+            int h = Math.max(options.outHeight, 0);
+            return new int[]{w, h};
+        } catch (Throwable t) {
+            return new int[]{0, 0};
+        }
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKRichTextSender.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKRichTextSender.java
@@ -170,7 +170,7 @@ public final class WKRichTextSender {
         }
         WKChannel channel = context.getChatChannelInfo();
         if (channel == null) {
-            sendTextFallback(context, content, text, onEnqueued);
+            sendTextFallback(context, null, content, text, onEnqueued);
             return;
         }
         List<String> paths = imagePaths != null ? imagePaths : new ArrayList<>();
@@ -191,7 +191,7 @@ public final class WKRichTextSender {
                                    int[] failedCount,
                                    OnEnqueued onEnqueued) {
         if (index >= paths.size()) {
-            finish(context, content, text, imageBlocks, failedCount[0], onEnqueued);
+            finish(context, channel, content, text, imageBlocks, failedCount[0], onEnqueued);
             return;
         }
         String localPath = paths.get(index);
@@ -227,6 +227,7 @@ public final class WKRichTextSender {
      * 入队成功后触发 {@code onEnqueued}（调用方据此清空输入框，保证文本必达）。
      */
     private static void finish(IConversationContext context,
+                               WKChannel channel,
                                WKRichTextContent content,
                                String text,
                                List<WKRichTextContent.RichTextBlock> imageBlocks,
@@ -235,7 +236,7 @@ public final class WKRichTextSender {
         if (imageBlocks.isEmpty()) {
             // 所有图片都失败/不安全 → 文本仍要落地。
             toastFailIfAny(context, failedCount);
-            sendTextFallback(context, content, text, onEnqueued);
+            sendTextFallback(context, channel, content, text, onEnqueued);
             return;
         }
 
@@ -250,7 +251,9 @@ public final class WKRichTextSender {
         content.plain = WKRichTextContent.buildPlainFromBlocks(blocks);
 
         toastFailIfAny(context, failedCount);
-        context.sendMessage(content);
+        // 按<em>捕获</em>的频道落库（YUJ-2872 🔴 跨频道路由）：上传期间 Activity 可能已切到
+        // 别的频道，绝不能读 mutable 字段，否则消息错投。channel 为本次发起时捕获的目标。
+        enqueueToChannel(context, content, channel);
         notifyEnqueued(onEnqueued);
     }
 
@@ -259,6 +262,7 @@ public final class WKRichTextSender {
      * 保证群 @ 通知（含 @所有AI）不因降级而丢失。入队后触发 {@code onEnqueued}。
      */
     private static void sendTextFallback(IConversationContext context,
+                                         WKChannel channel,
                                          WKRichTextContent richHolder,
                                          String text,
                                          OnEnqueued onEnqueued) {
@@ -274,8 +278,24 @@ public final class WKRichTextSender {
         // 路径会走到这里，发出纯文本单条，与既有发送键文本路径同语义——@ 通知靠上面的
         // mentionAll/humans/ais + mentionInfo.uids 三态基字段保证不丢；entities 只影响接收侧
         // 高亮渲染，且其跨 block 的 offset 在降级为纯文本后已失去意义，故不迁移。
-        context.sendMessage(textContent);
+        enqueueToChannel(context, textContent, channel);
         notifyEnqueued(onEnqueued);
+    }
+
+    /**
+     * 按<em>捕获</em>的目标频道落库（YUJ-2872 🔴 跨频道路由）。延迟入队期间 Activity 可能已
+     * 被复用切到别的频道；若 {@code channel} 已捕获就走 {@link IConversationContext#sendMessageToChannel}
+     * 锁定目标，避免错投。{@code channel} 为 null（无法获取频道）时回退 {@link IConversationContext#sendMessage}
+     * 保持原行为。
+     */
+    private static void enqueueToChannel(IConversationContext context,
+                                         WKMessageContent messageContent,
+                                         WKChannel channel) {
+        if (channel != null) {
+            context.sendMessageToChannel(messageContent, channel);
+        } else {
+            context.sendMessage(messageContent);
+        }
     }
 
     private static void notifyEnqueued(OnEnqueued onEnqueued) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
@@ -131,6 +131,11 @@ public class WKRichTextContent extends WKMessageContent {
      * {@code //}）的串都不以 {@code /} 开头，自然落入拒绝分支，{@code javascript:} /
      * {@code data:} / {@code file:} / {@code vbscript:} 等向量被一并堵死。上传成功但
      * URL 不安全的图片应被跳过。
+     *
+     * <p>YUJ-2872 🟡：进一步收紧——只放行<em>单斜杠</em> server 相对路径，拒绝以
+     * {@code //} 开头的 protocol-relative URL（如 {@code //evil.host/x.png}）。后者会被
+     * 浏览器 / WebView 解析成 {@code https://evil.host/x.png} 指向任意外站，与本方法注释
+     * 声称的「仅 server 相对路径」契约不符，构成开放重定向 / 外链注入面。
      */
     public static boolean isSafeImageUrl(String url) {
         if (isBlank(url)) {
@@ -140,9 +145,11 @@ public class WKRichTextContent extends WKMessageContent {
         if (lower.startsWith("http://") || lower.startsWith("https://")) {
             return true;
         }
-        // 白名单：仅 server 相对路径（以 / 开头且不含 scheme）。带任意 scheme 的串
-        // ——含 mailto:/content:/tel: 这类不带 // 的伪 scheme——都不以 / 开头，落此拒绝。
-        return lower.startsWith("/");
+        // 白名单：仅<strong>单斜杠</strong> server 相对路径（以 / 开头、但不以 // 开头，
+        // 且不含 scheme）。带任意 scheme 的串——含 mailto:/content:/tel: 这类不带 // 的
+        // 伪 scheme——都不以 / 开头，落此拒绝；以 // 开头的 protocol-relative URL 会被
+        // 解析成外站绝对地址，同样拒绝。
+        return lower.startsWith("/") && !lower.startsWith("//");
     }
 
     /**

--- a/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
@@ -98,7 +98,13 @@ public class WKRichTextContent extends WKMessageContent {
         return block;
     }
 
-    /** 构造 image block（url 已上传得到 + 本地量出的尺寸；尺寸必填 >0，对齐 octo-lib 契约）。 */
+    /**
+     * 构造 image block（url 已上传得到 + 本地量出的尺寸）。尺寸<em>正常应 &gt;0</em>（对齐
+     * octo-lib 契约，发送侧用 {@code inJustDecodeBounds} 本地量取）；但当本地文件无法解码
+     * 时会传入 {@code 0×0}——此时把它当作<strong>"尺寸未知"哨兵</strong>原样保留，由接收侧
+     * （宽高相等走方形占位渲染）与 server {@code #232 Finalize}（重算覆盖 plain/尺寸）兜底，
+     * 不在此处臆造一个错误纵横比。
+     */
     public static RichTextBlock makeImageBlock(String url, int width, int height) {
         RichTextBlock block = new RichTextBlock();
         block.type = BLOCK_TYPE_IMAGE;

--- a/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
@@ -122,24 +122,27 @@ public class WKRichTextContent extends WKMessageContent {
 
     /**
      * 图片 URL 安全校验（与接收侧 / web isSafeUrl / octo-lib URL allowlist 对称）：
-     * 放行 http/https 绝对地址与 server 相对路径（{@code WKApiConfig#getShowUrl} 会前缀
-     * baseUrl），阻断 {@code javascript:} / {@code data:} / {@code file:} / {@code vbscript:}
-     * 等注入向量。上传成功但 URL 不安全的图片应被跳过。
+     * <strong>白名单</strong>放行——只接受 http/https 绝对地址，或以 {@code /} 开头的
+     * server 相对路径（{@code WKApiConfig#getShowUrl} 会前缀 baseUrl）。其余一律拒绝。
+     *
+     * <p>之所以改成纯白名单（而非旧版「不含 {@code ://} 即放行」黑名单）：旧逻辑会把
+     * {@code mailto:x} / {@code content:x} / {@code tel:x} 这类<em>不带 {@code //} 的伪
+     * scheme</em> 当成相对路径放行，留下注入面。现在凡是带 scheme（无论是否带
+     * {@code //}）的串都不以 {@code /} 开头，自然落入拒绝分支，{@code javascript:} /
+     * {@code data:} / {@code file:} / {@code vbscript:} 等向量被一并堵死。上传成功但
+     * URL 不安全的图片应被跳过。
      */
     public static boolean isSafeImageUrl(String url) {
         if (isBlank(url)) {
             return false;
         }
         String lower = url.trim().toLowerCase();
-        if (lower.startsWith("javascript:") || lower.startsWith("data:")
-                || lower.startsWith("file:") || lower.startsWith("vbscript:")) {
-            return false;
-        }
         if (lower.startsWith("http://") || lower.startsWith("https://")) {
             return true;
         }
-        // 无 scheme 的相对路径视为 server 资源路径（安全）；带其它 scheme 一律拒绝。
-        return !lower.contains("://");
+        // 白名单：仅 server 相对路径（以 / 开头且不含 scheme）。带任意 scheme 的串
+        // ——含 mailto:/content:/tel: 这类不带 // 的伪 scheme——都不以 / 开头，落此拒绝。
+        return lower.startsWith("/");
     }
 
     /**

--- a/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
@@ -86,6 +86,62 @@ public class WKRichTextContent extends WKMessageContent {
         type = WKContentType.richText;
     }
 
+    // ---------------------------------------------------------------------
+    // 发送侧工厂（Phase 1 图文混排，与接收侧 decode 共址，复用同一份权威 schema）
+    // ---------------------------------------------------------------------
+
+    /** 构造 text block。 */
+    public static RichTextBlock makeTextBlock(String text) {
+        RichTextBlock block = new RichTextBlock();
+        block.type = BLOCK_TYPE_TEXT;
+        block.text = text;
+        return block;
+    }
+
+    /** 构造 image block（url 已上传得到 + 本地量出的尺寸；尺寸必填 >0，对齐 octo-lib 契约）。 */
+    public static RichTextBlock makeImageBlock(String url, int width, int height) {
+        RichTextBlock block = new RichTextBlock();
+        block.type = BLOCK_TYPE_IMAGE;
+        block.url = url;
+        block.width = width;
+        block.height = height;
+        return block;
+    }
+
+    /**
+     * 由有序 block 列表构造一条可发送的 RichText 消息。plain 仅填本地占位（image →
+     * {@link #IMAGE_PLACEHOLDER} 这一 wire token，非本地化文案），server #232 Finalize
+     * 会重算覆盖——client 不是 plain 的权威来源。
+     */
+    public static WKRichTextContent create(List<RichTextBlock> blocks) {
+        WKRichTextContent content = new WKRichTextContent();
+        content.blocks = blocks != null ? blocks : new ArrayList<>();
+        content.plain = buildPlainFromBlocks(content.blocks);
+        return content;
+    }
+
+    /**
+     * 图片 URL 安全校验（与接收侧 / web isSafeUrl / octo-lib URL allowlist 对称）：
+     * 放行 http/https 绝对地址与 server 相对路径（{@code WKApiConfig#getShowUrl} 会前缀
+     * baseUrl），阻断 {@code javascript:} / {@code data:} / {@code file:} / {@code vbscript:}
+     * 等注入向量。上传成功但 URL 不安全的图片应被跳过。
+     */
+    public static boolean isSafeImageUrl(String url) {
+        if (isBlank(url)) {
+            return false;
+        }
+        String lower = url.trim().toLowerCase();
+        if (lower.startsWith("javascript:") || lower.startsWith("data:")
+                || lower.startsWith("file:") || lower.startsWith("vbscript:")) {
+            return false;
+        }
+        if (lower.startsWith("http://") || lower.startsWith("https://")) {
+            return true;
+        }
+        // 无 scheme 的相对路径视为 server 资源路径（安全）；带其它 scheme 一律拒绝。
+        return !lower.contains("://");
+    }
+
     /**
      * 序列化回 RichText payload（content block 数组 + 顶层 plain），与 decodeMsg
      * 对称。Phase 1 不主动发送 RichText，但 SDK 在转存 / 引用 / 合并转发等路径会

--- a/wkuikit/src/test/java/com/chat/uikit/chat/manager/WKRichTextSenderTest.java
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/manager/WKRichTextSenderTest.java
@@ -311,6 +311,22 @@ public class WKRichTextSenderTest {
         assertFalse(WKRichTextSender.shouldClearComposer("abc", null));
     }
 
+    /**
+     * 🔴 defect c（Jerry-Xin 复审）：上传期间用户离开会话 → 留存的“即将发出”文本被离场
+     * teardown 落成草稿。本次发送入队后，{@code ChatActivity.clearPersistedDraftIfMatches}
+     * 用同一个 {@link WKRichTextSender#shouldClearComposer} 谓词判定<em>落盘草稿</em>是否
+     * 仍等于本次消费的快照：相同 → 清掉草稿（避免重开会话恢复出已发文本 = stale UI + 一键
+     * 重复发送）；离场后用户又改了草稿（≠ 快照）→ 保留不误删。与内存 EditText 清空同语义。
+     */
+    @Test
+    public void persistedDraftClearDecision_matchesConsumedSnapshot_butKeepsNewerDraft() {
+        final String consumed = "上传中的配文";
+        // 落盘草稿仍是这段已发文本 → 应清掉。
+        assertTrue(WKRichTextSender.shouldClearComposer(consumed, "上传中的配文"));
+        // 离场后用户又打了新草稿 → 不是本次快照 → 保留。
+        assertFalse(WKRichTextSender.shouldClearComposer(consumed, "离场后新打的草稿"));
+    }
+
     // ---------------------------------------------------------------------
 
     /** 受控 uploader：把单张图片的成功回调延迟到 {@link #release()} 调用时再触发。 */

--- a/wkuikit/src/test/java/com/chat/uikit/chat/manager/WKRichTextSenderTest.java
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/manager/WKRichTextSenderTest.java
@@ -269,6 +269,56 @@ public class WKRichTextSenderTest {
     }
 
     /**
+     * 🔴 跨频道路由回归（Jerry-Xin 复审 defect）：在 A 频道发起图文混排，上传完成<em>前</em>
+     * Activity 被复用切到 B 频道（getChatChannelInfo 改变）。入队必须落到<strong>发起时
+     * 捕获的 A 频道</strong>，而非当前 B 频道——否则用 A 凭证上传的图片错投到 B（隐私/路由
+     * bug）。本测试断言 sender 走 sendMessageToChannel 且目标恒为捕获的 A。
+     */
+    @Test
+    public void delayedEnqueue_routesToCapturedChannel_notSwitchedChannel() {
+        final ImageUploaderGate gate = new ImageUploaderGate("https://cdn/a.png");
+        WKRichTextSender.setUploaderForTest(gate);
+
+        // 发起时当前频道 = A，sender 在 send() 内部捕获它。
+        context.currentChannel = new WKChannel("channelA", (byte) 2);
+        WKRichTextContent content = new WKRichTextContent();
+        WKRichTextSender.send(context, content, "配文", Arrays.asList("/sd/a.png"), null);
+
+        // 上传 pending 期间用户切到 B 频道（Activity 复用，mutable 频道被改写）。
+        context.currentChannel = new WKChannel("channelB", (byte) 1);
+
+        // 现在上传回调到达 → 入队。
+        gate.release();
+
+        assertEquals(1, context.sent.size());
+        assertTrue(context.sent.get(0) instanceof WKRichTextContent);
+        // 关键：落库目标是发起时捕获的 A，不是切换后的 B。
+        WKChannel routed = context.sentChannels.get(0);
+        assertTrue("must route via sendMessageToChannel with captured channel", routed != null);
+        assertEquals("channelA", routed.channelID);
+        assertEquals((byte) 2, routed.channelType);
+    }
+
+    /**
+     * 🔴 跨频道路由回归（降级路径）：全图上传失败降级纯文本时，同样必须落到捕获频道。
+     */
+    @Test
+    public void delayedEnqueue_textFallback_routesToCapturedChannel() {
+        WKRichTextSender.setUploaderForTest((channel, localPath, result) -> result.onFailure());
+
+        context.currentChannel = new WKChannel("channelA", (byte) 2);
+        WKRichTextContent content = new WKRichTextContent();
+        WKRichTextSender.send(context, content, "只有文字会留下", Arrays.asList("/sd/a.png"), null);
+
+        // 全图失败是同步发生的（uploader 立即 onFailure），但路由仍须按捕获频道。
+        assertEquals(1, context.sent.size());
+        assertTrue(context.sent.get(0) instanceof WKTextContent);
+        WKChannel routed = context.sentChannels.get(0);
+        assertTrue(routed != null);
+        assertEquals("channelA", routed.channelID);
+    }
+
+    /**
      * 🔴 defect b：in-flight 混排发送期间，发送键拦截把同一段可见文本重复单发；
      * 文本被改动则放行。直接断言去重判定，不产生重复文本消息。
      */
@@ -355,15 +405,26 @@ public class WKRichTextSenderTest {
     /** 最小 IConversationContext 测试替身：记录入队消息，其余方法 no-op。 */
     private static final class CapturingContext implements IConversationContext {
         final List<WKMessageContent> sent = new ArrayList<>();
+        // 跨频道路由回归用：模拟 ChatActivity 可被复用切到别的频道。
+        WKChannel currentChannel = new WKChannel("c1", (byte) 2);
+        // 记录每条消息<em>实际</em>落库的目标频道（null 表示走了无频道的 sendMessage）。
+        final List<WKChannel> sentChannels = new ArrayList<>();
 
         @Override
         public void sendMessage(WKMessageContent wkMessageContent) {
             sent.add(wkMessageContent);
+            sentChannels.add(null);
+        }
+
+        @Override
+        public void sendMessageToChannel(WKMessageContent wkMessageContent, WKChannel channel) {
+            sent.add(wkMessageContent);
+            sentChannels.add(channel);
         }
 
         @Override
         public WKChannel getChatChannelInfo() {
-            return new WKChannel("c1", (byte) 2);
+            return currentChannel;
         }
 
         @Override

--- a/wkuikit/src/test/java/com/chat/uikit/chat/manager/WKRichTextSenderTest.java
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/manager/WKRichTextSenderTest.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.manager;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.chat.base.msg.ChatAdapter;
+import com.chat.base.msg.IConversationContext;
+import com.chat.uikit.chat.msgmodel.WKRichTextContent;
+import com.xinbida.wukongim.entity.WKChannel;
+import com.xinbida.wukongim.entity.WKMsg;
+import com.xinbida.wukongim.msgmodel.WKMessageContent;
+import com.xinbida.wukongim.msgmodel.WKTextContent;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Locks the RichText (ContentType=14) <em>send-side</em> "text-must-arrive"
+ * contract (YUJ-2832 P1, web #227 同类丢消息缺陷的 Android 对称面).
+ *
+ * <p>The defect: ChatActivity used to clear the input box <em>immediately</em>
+ * after kicking off async image uploads, while {@link WKRichTextSender} only
+ * calls {@code sendMessage} once every upload callback has returned. If the
+ * process is killed / the Activity is destroyed / an upload never reports back,
+ * the user's text was neither in the input box nor enqueued as a local outgoing
+ * message — a regression versus the text/media paths (which enqueue at once).
+ *
+ * <p>Fix under test: the input box is cleared <em>only</em> via the
+ * {@code onEnqueued} callback, which fires strictly after a message is actually
+ * handed to {@code sendMessage}. These tests assert that callback never fires
+ * while an upload is still pending, and that it does fire (exactly once) on both
+ * the mixed-message and the all-images-failed text-fallback paths.
+ *
+ * <p>Runs under plain JVM (no Robolectric). Image upload is replaced with an
+ * injectable {@link WKRichTextSender.ImageUploader} test double so the
+ * "upload not finished" state is directly controllable.
+ */
+public class WKRichTextSenderTest {
+
+    private CapturingContext context;
+
+    @Before
+    public void setUp() {
+        context = new CapturingContext();
+    }
+
+    @After
+    public void tearDown() {
+        WKRichTextSender.resetUploader();
+    }
+
+    /**
+     * 核心 P1 回归：上传未完成（uploader 永不回调）时，绝不能 sendMessage、
+     * 绝不能触发 onEnqueued —— 调用方据此不清输入框，文本留存可恢复。
+     */
+    @Test
+    public void uploadNeverCompletes_doesNotEnqueueAndDoesNotClearInput() {
+        // 永不回调的 uploader：模拟上传 in-flight / 进程被杀前回调未到。
+        WKRichTextSender.setUploaderForTest((channel, localPath, result) -> {
+            // 故意不调用 result.onSuccess / onFailure。
+        });
+
+        boolean[] cleared = {false};
+        WKRichTextContent content = new WKRichTextContent();
+        WKRichTextSender.send(context, content, "上线方案", Arrays.asList("/sd/a.png"),
+                () -> cleared[0] = true);
+
+        // 没有任何消息入队。
+        assertTrue(context.sent.isEmpty());
+        // onEnqueued 未触发 → 输入框不会被清空 → 文本必达（留在输入框可恢复）。
+        assertFalse(cleared[0]);
+    }
+
+    /**
+     * 上传成功：聚合成单条 RichText 入队，onEnqueued 恰好触发一次（此时清输入框安全）。
+     */
+    @Test
+    public void uploadSucceeds_enqueuesRichTextThenClearsInput() {
+        WKRichTextSender.setUploaderForTest((channel, localPath, result) ->
+                result.onSuccess("https://cdn/" + localPath.hashCode() + ".png"));
+
+        int[] clearedCount = {0};
+        WKRichTextContent content = new WKRichTextContent();
+        WKRichTextSender.send(context, content, "看图", Arrays.asList("/sd/a.png", "/sd/b.png"),
+                () -> clearedCount[0]++);
+
+        assertEquals(1, context.sent.size());
+        WKMessageContent sent = context.sent.get(0);
+        assertTrue(sent instanceof WKRichTextContent);
+        WKRichTextContent rich = (WKRichTextContent) sent;
+        // text 块在前、两张 image 块按序在后。
+        assertEquals(3, rich.blocks.size());
+        assertTrue(rich.blocks.get(0).isText());
+        assertEquals("看图", rich.blocks.get(0).text);
+        assertTrue(rich.blocks.get(1).isImage());
+        assertTrue(rich.blocks.get(2).isImage());
+        // onEnqueued 恰一次。
+        assertEquals(1, clearedCount[0]);
+    }
+
+    /**
+     * 所有图片失败：降级纯文本入队（text 不丢），onEnqueued 仍触发一次（清输入框安全）。
+     * mention 三态迁移到 WKTextContent，群 @ 通知不丢。
+     */
+    @Test
+    public void allUploadsFail_fallsBackToTextThenClearsInput() {
+        WKRichTextSender.setUploaderForTest((channel, localPath, result) -> result.onFailure());
+
+        int[] clearedCount = {0};
+        WKRichTextContent content = new WKRichTextContent();
+        content.mentionAll = 1;
+        content.mentionAis = 1;
+        WKRichTextSender.send(context, content, "全员看通知", Arrays.asList("/sd/a.png"),
+                () -> clearedCount[0]++);
+
+        assertEquals(1, context.sent.size());
+        WKMessageContent sent = context.sent.get(0);
+        assertTrue(sent instanceof WKTextContent);
+        assertEquals("全员看通知", ((WKTextContent) sent).content);
+        // mention 三态迁移不丢。
+        assertEquals(1, sent.mentionAll);
+        assertEquals(1, sent.mentionAis);
+        assertEquals(1, clearedCount[0]);
+    }
+
+    /**
+     * 部分图片不安全（伪 scheme）被跳过：仍发混排单条（含安全图片），文本不丢。
+     */
+    @Test
+    public void unsafeUrlSkipped_stillEnqueuesWithSafeImagesOnly() {
+        List<String> paths = Arrays.asList("/sd/ok.png", "/sd/bad.png");
+        WKRichTextSender.setUploaderForTest((channel, localPath, result) -> {
+            if (localPath.contains("bad")) {
+                // server 返回伪 scheme（攻击面）→ isSafeImageUrl 拒绝 → 跳过。
+                result.onSuccess("mailto:evil@x");
+            } else {
+                result.onSuccess("https://cdn/ok.png");
+            }
+        });
+
+        int[] clearedCount = {0};
+        WKRichTextContent content = new WKRichTextContent();
+        WKRichTextSender.send(context, content, "两张图", paths, () -> clearedCount[0]++);
+
+        assertEquals(1, context.sent.size());
+        WKRichTextContent rich = (WKRichTextContent) context.sent.get(0);
+        // text + 1 张安全 image（bad 被跳过）。
+        assertEquals(2, rich.blocks.size());
+        assertTrue(rich.blocks.get(0).isText());
+        assertTrue(rich.blocks.get(1).isImage());
+        assertEquals("https://cdn/ok.png", rich.blocks.get(1).url);
+        assertEquals(1, clearedCount[0]);
+    }
+
+    /**
+     * 第一张上传完成但第二张悬挂（未回调）：链路未走到 finish，不入队、不清输入框。
+     * 证明只要还有一张图片回调未到，文本就绝不提前丢失。
+     */
+    @Test
+    public void oneUploadPending_blocksEnqueueUntilAllComplete() {
+        WKRichTextSender.setUploaderForTest((channel, localPath, result) -> {
+            if (localPath.contains("a.png")) {
+                result.onSuccess("https://cdn/a.png");
+            }
+            // b.png 永不回调。
+        });
+
+        boolean[] cleared = {false};
+        WKRichTextContent content = new WKRichTextContent();
+        WKRichTextSender.send(context, content, "等第二张", Arrays.asList("/sd/a.png", "/sd/b.png"),
+                () -> cleared[0] = true);
+
+        assertTrue(context.sent.isEmpty());
+        assertFalse(cleared[0]);
+    }
+
+    // ---------------------------------------------------------------------
+
+    /** 最小 IConversationContext 测试替身：记录入队消息，其余方法 no-op。 */
+    private static final class CapturingContext implements IConversationContext {
+        final List<WKMessageContent> sent = new ArrayList<>();
+
+        @Override
+        public void sendMessage(WKMessageContent wkMessageContent) {
+            sent.add(wkMessageContent);
+        }
+
+        @Override
+        public WKChannel getChatChannelInfo() {
+            return new WKChannel("c1", (byte) 2);
+        }
+
+        @Override
+        public void showMultipleChoice() {
+        }
+
+        @Override
+        public void setTitleRightText(String text) {
+        }
+
+        @Override
+        public void showReply(WKMsg wkMsg) {
+        }
+
+        @Override
+        public void showEdit(WKMsg wkMsg) {
+        }
+
+        @Override
+        public void tipsMsg(String clientMsgNo) {
+        }
+
+        @Override
+        public void setEditContent(String content) {
+        }
+
+        @Override
+        public AppCompatActivity getChatActivity() {
+            // null → toastFailIfAny 短路，避免触碰 android Toast。
+            return null;
+        }
+
+        @Override
+        public WKMsg getReplyMsg() {
+            return null;
+        }
+
+        @Override
+        public void hideSoftKeyboard() {
+        }
+
+        @Override
+        public ChatAdapter getChatAdapter() {
+            return null;
+        }
+
+        @Override
+        public void sendCardMsg() {
+        }
+
+        @Override
+        public void chatRecyclerViewScrollToEnd() {
+        }
+
+        @Override
+        public void deleteOperationMsg() {
+        }
+
+        @Override
+        public void onChatAvatarClick(String uid, boolean isLongClick) {
+        }
+
+        @Override
+        public void onViewPicture(boolean isViewing) {
+        }
+
+        @Override
+        public void onMsgViewed(WKMsg wkMsg, int position) {
+        }
+
+        @Override
+        public android.view.View getRecyclerViewLayout() {
+            return null;
+        }
+
+        @Override
+        public boolean isShowChatActivity() {
+            return true;
+        }
+
+        @Override
+        public void closeActivity() {
+        }
+
+        @Override
+        public void chooseFile() {
+        }
+    }
+}

--- a/wkuikit/src/test/java/com/chat/uikit/chat/manager/WKRichTextSenderTest.java
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/manager/WKRichTextSenderTest.java
@@ -201,6 +201,125 @@ public class WKRichTextSenderTest {
     }
 
     // ---------------------------------------------------------------------
+    // YUJ-2872 🔴 composer-state race + 重复发送（对齐 web#227 第二轮 snapshot-aware）。
+    // ---------------------------------------------------------------------
+
+    /**
+     * 🔴 defect a 核心回归：上传 pending 期间用户打了新草稿，较早那条 send 入队后
+     * <strong>绝不能</strong>清掉新草稿。模拟 ChatActivity 的 onEnqueued snapshot-aware
+     * 清空逻辑：仅当输入框仍等于被消费的快照时才清。
+     */
+    @Test
+    public void draftTypedDuringUpload_survivesAfterEnqueue() {
+        // 受控 uploader：先攒回调，待"用户打新草稿"后再放行，复刻异步上传期间的竞态。
+        final ImageUploaderGate gate = new ImageUploaderGate("https://cdn/a.png");
+        WKRichTextSender.setUploaderForTest(gate);
+
+        // 模拟输入框：发送时消费的快照文本。
+        final String consumedSnapshot = "上线方案";
+        final StringBuilder composer = new StringBuilder(consumedSnapshot);
+
+        WKRichTextContent content = new WKRichTextContent();
+        WKRichTextSender.send(context, content, consumedSnapshot, Arrays.asList("/sd/a.png"),
+                () -> {
+                    // ChatActivity.onEnqueued 的 snapshot-aware 清空逻辑。
+                    if (WKRichTextSender.shouldClearComposer(consumedSnapshot, composer.toString())) {
+                        composer.setLength(0);
+                    }
+                });
+
+        // 上传 pending 期间用户打了一条全新的草稿（覆盖了仍留存的旧文本）。
+        composer.setLength(0);
+        composer.append("下一条新消息");
+
+        // 现在上传回调到达 → RichText 入队 → onEnqueued 触发。
+        gate.release();
+
+        // RichText 确实入队（旧文本必达）。
+        assertEquals(1, context.sent.size());
+        assertTrue(context.sent.get(0) instanceof WKRichTextContent);
+        // 关键：用户在等待期间新打的草稿没有被擦掉。
+        assertEquals("下一条新消息", composer.toString());
+    }
+
+    /**
+     * 🔴 对照组：上传 pending 期间用户<em>没动</em>输入框，入队后正常清空（输入框未变）。
+     */
+    @Test
+    public void composerUnchangedDuringUpload_clearedAfterEnqueue() {
+        final ImageUploaderGate gate = new ImageUploaderGate("https://cdn/a.png");
+        WKRichTextSender.setUploaderForTest(gate);
+
+        final String consumedSnapshot = "看这张图";
+        final StringBuilder composer = new StringBuilder(consumedSnapshot);
+
+        WKRichTextContent content = new WKRichTextContent();
+        WKRichTextSender.send(context, content, consumedSnapshot, Arrays.asList("/sd/a.png"),
+                () -> {
+                    if (WKRichTextSender.shouldClearComposer(consumedSnapshot, composer.toString())) {
+                        composer.setLength(0);
+                    }
+                });
+
+        gate.release();
+
+        assertEquals(1, context.sent.size());
+        // 输入框未变 → 清空。
+        assertEquals("", composer.toString());
+    }
+
+    /**
+     * 🔴 defect b：in-flight 混排发送期间，发送键拦截把同一段可见文本重复单发；
+     * 文本被改动则放行。直接断言去重判定，不产生重复文本消息。
+     */
+    @Test
+    public void duplicatePendingText_blocksManualResend_butAllowsEditedText() {
+        final String pending = "同一段文本";
+        // 与 in-flight 快照完全相同 → 拦截（避免重复文本消息）。
+        assertTrue(WKRichTextSender.isDuplicatePendingText(pending, "同一段文本"));
+        // 用户改动了文本（哪怕一字）→ 新意图，放行。
+        assertFalse(WKRichTextSender.isDuplicatePendingText(pending, "同一段文本!"));
+        assertFalse(WKRichTextSender.isDuplicatePendingText(pending, "别的内容"));
+        // 无 in-flight（快照 null）→ 永不拦截。
+        assertFalse(WKRichTextSender.isDuplicatePendingText(null, "同一段文本"));
+    }
+
+    /**
+     * 🔴 shouldClearComposer 边界：null 快照 / 文本已变 → 不清；完全相同 → 清。
+     */
+    @Test
+    public void shouldClearComposer_onlyWhenComposerStillEqualsSnapshot() {
+        assertTrue(WKRichTextSender.shouldClearComposer("abc", "abc"));
+        assertFalse(WKRichTextSender.shouldClearComposer("abc", "abcd"));
+        assertFalse(WKRichTextSender.shouldClearComposer("abc", ""));
+        assertFalse(WKRichTextSender.shouldClearComposer(null, "abc"));
+        assertFalse(WKRichTextSender.shouldClearComposer("abc", null));
+    }
+
+    // ---------------------------------------------------------------------
+
+    /** 受控 uploader：把单张图片的成功回调延迟到 {@link #release()} 调用时再触发。 */
+    private static final class ImageUploaderGate implements WKRichTextSender.ImageUploader {
+        private final String downloadUrl;
+        private Result pending;
+
+        ImageUploaderGate(String downloadUrl) {
+            this.downloadUrl = downloadUrl;
+        }
+
+        @Override
+        public void upload(WKChannel channel, String localPath, Result result) {
+            this.pending = result;
+        }
+
+        void release() {
+            if (pending != null) {
+                pending.onSuccess(downloadUrl);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
 
     /** 最小 IConversationContext 测试替身：记录入队消息，其余方法 no-op。 */
     private static final class CapturingContext implements IConversationContext {

--- a/wkuikit/src/test/java/com/chat/uikit/chat/manager/WKRichTextSenderTest.java
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/manager/WKRichTextSenderTest.java
@@ -285,6 +285,21 @@ public class WKRichTextSenderTest {
     }
 
     /**
+     * 🔴 defect b 第二道门（相册再选图路径）：in-flight 混排发送期间用户再开相册选第二批图，
+     * trySendRichTextMixed 会再次读到留存文本——若仍等于 in-flight 快照则<strong>不重复
+     * 消费</strong>（交回逐条图片发送，第二批图照常发出但不重发文本）。用 send 同款去重判定，
+     * 保证两道门语义一致：相同 → 不聚合（true 表示拦截/不消费）；文本已改 → 正常聚合。
+     */
+    @Test
+    public void duplicatePendingText_blocksAlbumRepick_butAllowsNewText() {
+        final String inFlight = "第一批配文";
+        // 第二批选图时输入框仍是 in-flight 那段文本 → 不再聚合消费（交回逐条图片路径）。
+        assertTrue(WKRichTextSender.isDuplicatePendingText(inFlight, "第一批配文"));
+        // 用户在等待期间改了配文 → 新意图，第二批应正常聚合。
+        assertFalse(WKRichTextSender.isDuplicatePendingText(inFlight, "第二批新配文"));
+    }
+
+    /**
      * 🔴 shouldClearComposer 边界：null 快照 / 文本已变 → 不清；完全相同 → 清。
      */
     @Test

--- a/wkuikit/src/test/java/com/chat/uikit/chat/msgmodel/WKRichTextContentTest.java
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/msgmodel/WKRichTextContentTest.java
@@ -267,5 +267,13 @@ public class WKRichTextContentTest {
         // 不以 / 开头的裸相对名（无 scheme）也拒绝——server 资源路径恒以 / 开头。
         assertTrue(!WKRichTextContent.isSafeImageUrl("abc.png"));
         assertTrue(!WKRichTextContent.isSafeImageUrl("../../etc/passwd"));
+
+        // YUJ-2872 🟡：收紧为单斜杠相对路径——以 // 开头的 protocol-relative URL 会被
+        // 解析成外站绝对地址（//evil.host/x → https://evil.host/x），与「仅 server 相对
+        // 路径」契约不符，必须拒绝。单斜杠相对路径仍放行。
+        assertTrue(!WKRichTextContent.isSafeImageUrl("//evil.host/x.png"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl("//cdn.attacker.com/a/b.png"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl("  //evil.host/x.png"));
+        assertTrue(WKRichTextContent.isSafeImageUrl("/single/slash/ok.png"));
     }
 }

--- a/wkuikit/src/test/java/com/chat/uikit/chat/msgmodel/WKRichTextContentTest.java
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/msgmodel/WKRichTextContentTest.java
@@ -174,4 +174,89 @@ public class WKRichTextContentTest {
         c.decodeMsg(null);
         assertNotNull(c.blocks);
     }
+
+    // ---------------------------------------------------------------------
+    // 发送侧（Phase 1 图文混排）：工厂 / URL 安全 / plain 占位 / encode↔decode 往返
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void send_create_interleavesTextThenImagesAndFillsPlaceholderPlain() {
+        java.util.List<WKRichTextContent.RichTextBlock> blocks = new java.util.ArrayList<>();
+        blocks.add(WKRichTextContent.makeTextBlock("看图"));
+        blocks.add(WKRichTextContent.makeImageBlock("https://x/a.png", 100, 200));
+        blocks.add(WKRichTextContent.makeImageBlock("https://x/b.png", 50, 60));
+
+        WKRichTextContent c = WKRichTextContent.create(blocks);
+
+        assertEquals(3, c.blocks.size());
+        assertTrue(c.blocks.get(0).isText());
+        assertTrue(c.blocks.get(1).isImage());
+        assertTrue(c.blocks.get(2).isImage());
+        // plain 仅本地占位（image → 占位 wire token），非权威，server #232 覆盖。
+        assertEquals("看图" + WKRichTextContent.IMAGE_PLACEHOLDER
+                + WKRichTextContent.IMAGE_PLACEHOLDER, c.plain);
+    }
+
+    @Test
+    public void send_encodeDecode_roundTripsMixedPayload() throws JSONException {
+        java.util.List<WKRichTextContent.RichTextBlock> blocks = new java.util.ArrayList<>();
+        blocks.add(WKRichTextContent.makeTextBlock("hi"));
+        blocks.add(WKRichTextContent.makeImageBlock("https://x/z.png", 30, 40));
+        WKRichTextContent sent = WKRichTextContent.create(blocks);
+
+        // 发送侧 encode → wire JSON。
+        JSONObject wire = sent.encodeMsg();
+        assertNotNull(wire);
+        assertTrue(wire.has("content"));
+
+        // 接收侧 decode 同一 wire，断言字段逐项对称。
+        WKRichTextContent received = new WKRichTextContent();
+        received.decodeMsg(wire);
+
+        assertEquals(2, received.blocks.size());
+        assertTrue(received.blocks.get(0).isText());
+        assertEquals("hi", received.blocks.get(0).text);
+        assertTrue(received.blocks.get(1).isImage());
+        assertEquals("https://x/z.png", received.blocks.get(1).url);
+        assertEquals(30, received.blocks.get(1).width);
+        assertEquals(40, received.blocks.get(1).height);
+        assertEquals("hi" + WKRichTextContent.IMAGE_PLACEHOLDER, received.plain);
+    }
+
+    @Test
+    public void send_encode_imageBlockOmitsTextField_byteHygiene() throws JSONException {
+        // image block 不应在 wire 写出 text 字段（字节卫生，与接收侧/server 契约对齐）。
+        java.util.List<WKRichTextContent.RichTextBlock> blocks = new java.util.ArrayList<>();
+        blocks.add(WKRichTextContent.makeImageBlock("https://x/i.png", 10, 10));
+        WKRichTextContent c = WKRichTextContent.create(blocks);
+
+        JSONObject wire = c.encodeMsg();
+        JSONArray content = wire.optJSONArray("content");
+        assertNotNull(content);
+        JSONObject imgJson = content.optJSONObject(0);
+        assertEquals(WKRichTextContent.BLOCK_TYPE_IMAGE, imgJson.optString("type"));
+        assertTrue(imgJson.has("url"));
+        assertTrue(imgJson.has("width"));
+        assertTrue(imgJson.has("height"));
+        // image block 不写 text 键。
+        assertTrue(!imgJson.has("text"));
+    }
+
+    @Test
+    public void send_isSafeImageUrl_allowsHttpAndRelative_blocksInjection() {
+        // 放行 http/https 与无 scheme 相对路径（server 资源）。
+        assertTrue(WKRichTextContent.isSafeImageUrl("https://cdn/x.png"));
+        assertTrue(WKRichTextContent.isSafeImageUrl("http://cdn/x.png"));
+        assertTrue(WKRichTextContent.isSafeImageUrl("HTTPS://cdn/x.png"));
+        assertTrue(WKRichTextContent.isSafeImageUrl("/0/123/abc.png"));
+
+        // 阻断注入向量。
+        assertTrue(!WKRichTextContent.isSafeImageUrl("javascript:alert(1)"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl("data:image/png;base64,AAAA"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl("file:///etc/passwd"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl("vbscript:msgbox"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl("ftp://host/x.png"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl(""));
+        assertTrue(!WKRichTextContent.isSafeImageUrl(null));
+    }
 }

--- a/wkuikit/src/test/java/com/chat/uikit/chat/msgmodel/WKRichTextContentTest.java
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/msgmodel/WKRichTextContentTest.java
@@ -244,13 +244,13 @@ public class WKRichTextContentTest {
 
     @Test
     public void send_isSafeImageUrl_allowsHttpAndRelative_blocksInjection() {
-        // 放行 http/https 与无 scheme 相对路径（server 资源）。
+        // 放行 http/https 与以 / 开头的 server 相对路径。
         assertTrue(WKRichTextContent.isSafeImageUrl("https://cdn/x.png"));
         assertTrue(WKRichTextContent.isSafeImageUrl("http://cdn/x.png"));
         assertTrue(WKRichTextContent.isSafeImageUrl("HTTPS://cdn/x.png"));
         assertTrue(WKRichTextContent.isSafeImageUrl("/0/123/abc.png"));
 
-        // 阻断注入向量。
+        // 阻断带 // 的注入向量。
         assertTrue(!WKRichTextContent.isSafeImageUrl("javascript:alert(1)"));
         assertTrue(!WKRichTextContent.isSafeImageUrl("data:image/png;base64,AAAA"));
         assertTrue(!WKRichTextContent.isSafeImageUrl("file:///etc/passwd"));
@@ -258,5 +258,14 @@ public class WKRichTextContentTest {
         assertTrue(!WKRichTextContent.isSafeImageUrl("ftp://host/x.png"));
         assertTrue(!WKRichTextContent.isSafeImageUrl(""));
         assertTrue(!WKRichTextContent.isSafeImageUrl(null));
+
+        // YUJ-2832 🟡：白名单——不带 :// 的伪 scheme 旧黑名单逻辑会误放行，现必须拒绝。
+        assertTrue(!WKRichTextContent.isSafeImageUrl("mailto:a@b.com"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl("content://media/external/images/1"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl("tel:10086"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl("sms:10086"));
+        // 不以 / 开头的裸相对名（无 scheme）也拒绝——server 资源路径恒以 / 开头。
+        assertTrue(!WKRichTextContent.isSafeImageUrl("abc.png"));
+        assertTrue(!WKRichTextContent.isSafeImageUrl("../../etc/passwd"));
     }
 }


### PR DESCRIPTION
## What

Android **send-side** for 图文混排 RichText (ContentType=14), Phase 1 (text + image). Symmetric with web send-side **octo-web#227**. Builds on the receive-side schema from **#26** (`WKRichTextContent`), now merged to `main`.

> Recreated from PR #30 (auto-closed when its base `feat/richtext-receive-render` was deleted on #26 merge). Branch was rebased onto latest `main` (b48ea6b) — the 3 receive-side commits were identical to what #26 squash-merged, so only the send-side commit remains. No conflicts; gradle build + RichText unit tests green.

## Changes (6 files, all in wkuikit/wkbase)

1. **Aggregate into a single RichText=14 message** — when the input box holds text **and** the album selection is all static images (no video/gif/file), `ChatActivity.trySendRichTextMixed` builds **one** `type=14` payload (ordered `content` blocks: text first, images in pick order) instead of separate text + per-image messages. Pure text/image/video/gif/file paths are **untouched** — zero regression.
2. **Reuse the receive-side schema, no fork** (`WKRichTextContent`) — added send-side factories `makeTextBlock` / `makeImageBlock` / `create` next to the #26 decode logic; reuses the same encode↔decode round-trip.
3. **plain stays non-authoritative** — client fills a local placeholder; server #232 `Finalize` recomputes and overwrites.
4. **Security** — each image uploaded, then `isSafeImageUrl` validates http/https (blocks `javascript:`/`data:`/`file:`/`vbscript:`) before the URL enters a block.
5. **mention merge** — `ChatPanelManager.applyInputMentionsTo` reuses send-button mention logic (tri-state humans/ais + group uids, `@所有AI` expansion).
6. **Atomicity** — text always lands: mixed message when ≥1 image succeeds; plain-text fallback when all images fail.

## Verification

- `./gradlew :wkuikit:testDebugUnitTest :wkuikit:assembleDebug` — green (JDK 17).
- RichText unit tests: 10/10 (6 receive from #26 + 4 send: factory interleave, encode↔decode round-trip, image-block byte hygiene, URL safety allow/deny).

Fixes #29
