### PR TITLE
ci: pin all GitHub Actions to exact SHA digests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
 
       - name: Build with Gradle
         run: ./gradlew testDebugUnitTest assembleDevDebug


### PR DESCRIPTION
## What

Replace all tag-based action references (`@v4`) with SHA-pinned versions plus version comments.

## Why

Tag refs can be force-pushed, creating a supply chain attack vector. SHA pinning ensures the exact code version is used. This aligns with the org standard already followed by other Mininglamp-OSS repos.

## Changes

- `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4`
- `actions/setup-java@v4` → `actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4`
- `gradle/actions/setup-gradle@v4` → `gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4`

## Verification

```
grep -r '@v[0-9]' .github/workflows/
```
Returns empty — all actions are now SHA-pinned.