### PR TITLE
ci: replace paths-ignore with dorny/paths-filter preflight job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
+      # code=true when at least one changed file matches the code filter.
+      # predicate-quantifier:every + negation patterns (no bare '**'):
+      # a file matches 'code' iff ALL negation patterns are satisfied
+      # (file is not a doc/template). code=false only when all changed files
+      # are docs/templates. Push events default to 'true'.
       code: ${{ github.event_name == 'pull_request' && steps.filter.outputs.code || 'true' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -41,6 +46,22 @@ jobs:
         id: filter
         if: github.event_name == 'pull_request'
         with:
+          # predicate-quantifier: every — a file matches 'code' only when ALL
+          # negation patterns are satisfied (file is NOT a doc/template file).
+          #
+          # Validated by picomatch v4 unit test (same library used internally):
+          #   README.md:    !**/*.md=false → every=false → not match → code=false ✅
+          #   main file:    all negations=true → every=true → match → code=true ✅
+          #   mixed PR:     code file matches → code=true (some over changed files) ✅
+          #   dotfiles:     all negations=true → every=true → CI runs ✅
+          #   Dockerfile:   all negations=true → CI runs ✅
+          #
+          # Do NOT add '**': picomatch('**') doesn't match dotfiles (e.g. .golangci.yml)
+          # causing them to incorrectly skip CI with the 'every' quantifier.
+          # Do NOT use 'some' + negation: every changed file matches at least one
+          # negation pattern (e.g. main.go matches !**/*.md), so some=true always
+          # and the skip logic becomes a no-op.
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '!**/*.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
         id: filter
         if: github.event_name == 'pull_request'
         with:
-          predicate-quantifier: 'every'
           filters: |
             code:
               - '!**/*.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,12 @@ on:
       - 'docs/**'
       - '.github/ISSUE_TEMPLATE/**'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - '.github/ISSUE_TEMPLATE/**'
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    # paths-ignore is intentionally NOT set here — workflow-level path filtering
+    # prevents GitHub from creating any check run, which deadlocks required-status
+    # checks on docs-only PRs. Path-based skipping is handled by the `changes`
+    # preflight job below instead (dorny/paths-filter produces "skipped" statuses
+    # that GitHub counts as passing for required checks).
   workflow_dispatch:
 
 permissions: {}
@@ -22,8 +23,36 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ github.event_name == 'pull_request' && steps.filter.outputs.code || 'true' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        if: github.event_name == 'pull_request'
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+              - '!.github/ISSUE_TEMPLATE/**'
+
   build:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What

Replace workflow-level `paths-ignore` on `pull_request` trigger with a `changes` preflight job using `dorny/paths-filter`.

## Why

When `paths-ignore` is set at the workflow level, GitHub will not create any check run for docs-only PRs. If CI is a required status check, those PRs can never merge. The preflight job produces a "skipped" status instead, which GitHub counts as passing.

## Changes

- Removed `paths-ignore` from `pull_request` trigger (kept on `push`)
- Added `changes` preflight job with `dorny/paths-filter`
- Added `needs: [changes]` condition to build/test jobs
- Added draft PR skip (`converted_to_draft` type + draft condition)

## Reference

Follows the same pattern as octo-server's CI workflow.

Refs: Mininglamp-OSS workflow optimization T13