### PR TITLE
feat(richtext): mention highlighting + crash fixes (v1.3.2)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
         applicationId appId
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 32
-        versionName "1.3.1"
+        versionCode 33
+        versionName "1.3.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -168,6 +168,7 @@
 -keep class com.chat.uikit.chat.msgmodel.** { *; }
 -keep class com.chat.uikit.enity.** { *; }
 -keep class com.chat.uikit.thread.service.entity.** { *; }
+-keep class com.chat.uikit.thread.msgmodel.** { *; }
 -keep class com.chat.uikit.sidebar.SidebarItemEntity { *; }
 -keep class com.chat.uikit.sidebar.SidebarSyncResponse { *; }
 -keep class com.chat.uikit.sidebar.FollowModel$FollowSortItem { *; }

--- a/wkbase/src/main/java/com/chat/base/ui/components/ContactEditText.java
+++ b/wkbase/src/main/java/com/chat/base/ui/components/ContactEditText.java
@@ -328,9 +328,9 @@ public class ContactEditText extends AppCompatAutoCompleteTextView {
     public boolean onTextContextMenuItem(int id) {
         if (id == android.R.id.paste) {
             ClipboardManager cm = (ClipboardManager) getContext().getSystemService(CLIPBOARD_SERVICE);
-            assert cm != null;
+            if (cm == null) return super.onTextContextMenuItem(id);
             ClipData data = cm.getPrimaryClip();
-            assert data != null;
+            if (data == null || data.getItemCount() == 0) return super.onTextContextMenuItem(id);
             ClipData.Item item = data.getItemAt(0);
             String editContent = "";
             if (item.getText() != null)

--- a/wkim/src/main/java/com/xinbida/wukongim/db/ConversationDbManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/ConversationDbManager.java
@@ -454,7 +454,8 @@ public class ConversationDbManager {
                 }
                 cursor.close();
             }
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            WKLoggerUtils.getInstance().e(TAG, "queryMsgExtraWithChannel error");
         }
         return msgExtra;
     }
@@ -466,15 +467,20 @@ public class ConversationDbManager {
 
     private List<WKConversationMsgExtra> queryWithExtraChannelIds(List<String> channelIds) {
         List<WKConversationMsgExtra> list = new ArrayList<>();
-        try (Cursor cursor = WKIMApplication.getInstance().getDbHelper().select(conversationExtra, "channel_id in (" + WKCursor.getPlaceholders(channelIds.size()) + ")", channelIds.toArray(new String[0]), null)) {
-            if (cursor == null) {
-                return list;
+        // SQLite 变量上限 999，分片查询避免超限
+        int chunkSize = 500;
+        for (int start = 0; start < channelIds.size(); start += chunkSize) {
+            int end = Math.min(start + chunkSize, channelIds.size());
+            List<String> chunk = channelIds.subList(start, end);
+            try (Cursor cursor = WKIMApplication.getInstance().getDbHelper().select(conversationExtra, "channel_id in (" + WKCursor.getPlaceholders(chunk.size()) + ")", chunk.toArray(new String[0]), null)) {
+                if (cursor == null) continue;
+                for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext()) {
+                    WKConversationMsgExtra extra = serializeMsgExtra(cursor);
+                    list.add(extra);
+                }
+            } catch (Exception e) {
+                WKLoggerUtils.getInstance().e(TAG, "queryWithExtraChannelIds chunk error");
             }
-            for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext()) {
-                WKConversationMsgExtra extra = serializeMsgExtra(cursor);
-                list.add(extra);
-            }
-        } catch (Exception ignored) {
         }
         return list;
     }

--- a/wkim/src/main/java/com/xinbida/wukongim/db/ConversationDbManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/ConversationDbManager.java
@@ -443,17 +443,25 @@ public class ConversationDbManager {
 
     public WKConversationMsgExtra queryMsgExtraWithChannel(String channelID, byte channelType) {
         WKConversationMsgExtra msgExtra = null;
-        String selection = "channel_id=? and channel_type=?";
-        Cursor cursor = WKIMApplication
-                .getInstance()
-                .getDbHelper().select(conversationExtra, selection, new String[]{channelID, String.valueOf(channelType)}, null);
-        if (cursor != null) {
-            if (cursor.moveToFirst()) {
-                msgExtra = serializeMsgExtra(cursor);
+        try {
+            String selection = "channel_id=? and channel_type=?";
+            Cursor cursor = WKIMApplication
+                    .getInstance()
+                    .getDbHelper().select(conversationExtra, selection, new String[]{channelID, String.valueOf(channelType)}, null);
+            if (cursor != null) {
+                if (cursor.moveToFirst()) {
+                    msgExtra = serializeMsgExtra(cursor);
+                }
+                cursor.close();
             }
-            cursor.close();
+        } catch (Exception ignored) {
         }
         return msgExtra;
+    }
+
+    public List<WKConversationMsgExtra> queryMsgExtrasForChannelIds(List<String> channelIds) {
+        if (channelIds == null || channelIds.isEmpty()) return new ArrayList<>();
+        return queryWithExtraChannelIds(channelIds);
     }
 
     private List<WKConversationMsgExtra> queryWithExtraChannelIds(List<String> channelIds) {
@@ -466,6 +474,7 @@ public class ConversationDbManager {
                 WKConversationMsgExtra extra = serializeMsgExtra(cursor);
                 list.add(extra);
             }
+        } catch (Exception ignored) {
         }
         return list;
     }

--- a/wkim/src/main/java/com/xinbida/wukongim/db/ReminderDBManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/ReminderDBManager.java
@@ -74,6 +74,8 @@ public class ReminderDBManager {
         if (dbHelper == null) return false;
         try (Cursor cursor = dbHelper.rawQuery(sql, new Object[]{prefix, reminderType})) {
             return cursor != null && cursor.moveToFirst();
+        } catch (Exception ignored) {
+            return false;
         }
     }
 

--- a/wkim/src/main/java/com/xinbida/wukongim/db/ReminderDBManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/ReminderDBManager.java
@@ -74,7 +74,8 @@ public class ReminderDBManager {
         if (dbHelper == null) return false;
         try (Cursor cursor = dbHelper.rawQuery(sql, new Object[]{prefix, reminderType})) {
             return cursor != null && cursor.moveToFirst();
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            WKLoggerUtils.getInstance().e(TAG, "hasUndoneReminderWithChannelPrefix error");
             return false;
         }
     }

--- a/wkim/src/main/java/com/xinbida/wukongim/entity/WKMsg.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/entity/WKMsg.java
@@ -234,6 +234,15 @@ public class WKMsg implements Parcelable {
         return memberOfFrom;
     }
 
+    /**
+     * 返回已缓存的发送者成员信息，不触发数据库查询。
+     * 用于主线程批量刷新场景（onRefreshChannel / onRefreshChannelMember），
+     * 避免对未加载的消息发起同步 DB 查询导致 ANR。
+     */
+    public WKChannelMember getMemberOfFromIfCached() {
+        return memberOfFrom;
+    }
+
     public void setMemberOfFrom(WKChannelMember memberOfFrom) {
         this.memberOfFrom = memberOfFrom;
     }

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/ChannelManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/ChannelManager.java
@@ -77,6 +77,16 @@ public class ChannelManager extends BaseManager {
     }
 
     /**
+     * 仅从内存缓存返回频道信息，不触发 DB 查询。
+     * 用于主线程渲染路径（RecyclerView bind），避免 cache miss 时
+     * 同步 DB 查询导致 ANR。
+     */
+    public WKChannel getChannelIfCached(String channelID, byte channelType) {
+        if (TextUtils.isEmpty(channelID)) return null;
+        return channelInfoCache.get(cacheKey(channelID, channelType));
+    }
+
+    /**
      *  · 慢路径：cache miss 时走 synchronized + list 线性扫描 + DB fallback。
      *
      * <p>保留 {@link #wkChannelList} 的原有语义是因为别的路径（比如

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
@@ -348,6 +348,19 @@ public class ConversationManager extends BaseManager {
         return ConversationDbManager.getInstance().queryMsgExtraWithChannel(channelID, channelType);
     }
 
+    /**
+     * 批量查询会话 extras（草稿等），一次 DB 查询替代 N 次单条查询。
+     * 返回 Map 以 channelID:channelType 为复合 key。
+     */
+    public java.util.Map<String, WKConversationMsgExtra> getMsgExtrasForChannels(java.util.List<String> channelIds) {
+        java.util.Map<String, WKConversationMsgExtra> map = new java.util.HashMap<>();
+        java.util.List<WKConversationMsgExtra> list = ConversationDbManager.getInstance().queryMsgExtrasForChannelIds(channelIds);
+        for (WKConversationMsgExtra extra : list) {
+            map.put(extra.channelID + ":" + extra.channelType, extra);
+        }
+        return map;
+    }
+
     public void updateMsgExtra(WKConversationMsgExtra extra) {
         boolean result = ConversationDbManager.getInstance().insertOrUpdateMsgExtra(extra);
         if (result) {

--- a/wkpush/src/main/java/com/chat/push/WKPushApplication.java
+++ b/wkpush/src/main/java/com/chat/push/WKPushApplication.java
@@ -143,7 +143,12 @@ public class WKPushApplication {
     }
 
     private void initOPPO() {
-        HeytapPushManager.init(mContext.get(), true);
+        try {
+            HeytapPushManager.init(mContext.get(), true);
+        } catch (Throwable e) {
+            Log.w("Push", "OPPO push init failed", e);
+            return;
+        }
         //  P-11: AppExecutors.io() 取代 new Thread()
         AppExecutors.io().execute(() -> HeytapPushManager.register(mContext.get(), BuildConfig.OPPO_APP_KEY, BuildConfig.OPPO_APP_SECRET, new ICallBackResultService() {
             @Override

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -1562,11 +1562,11 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                         chatAdapter.getData().get(i).wkMsg.setFrom(channel);
                         isRefresh = true;
                     }
-                    if (chatAdapter.getData().get(i).wkMsg.getMemberOfFrom() != null && chatAdapter.getData().get(i).wkMsg.getMemberOfFrom().memberUID.equals(channel.channelID) && channel.channelType == WKChannelType.PERSONAL) {
-                        chatAdapter.getData().get(i).wkMsg.getMemberOfFrom().memberRemark = channel.channelRemark;
-                        chatAdapter.getData().get(i).wkMsg.getMemberOfFrom().memberName = channel.channelName;
-                        chatAdapter.getData().get(i).wkMsg.getMemberOfFrom().memberAvatar = channel.avatar;
-                        chatAdapter.getData().get(i).wkMsg.getMemberOfFrom().memberAvatarCacheKey = channel.avatarCacheKey;
+                    if (chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached() != null && chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberUID.equals(channel.channelID) && channel.channelType == WKChannelType.PERSONAL) {
+                        chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberRemark = channel.channelRemark;
+                        chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberName = channel.channelName;
+                        chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberAvatar = channel.avatar;
+                        chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberAvatarCacheKey = channel.avatarCacheKey;
                         isRefresh = true;
                     }
                     if (chatAdapter.getData().get(i).wkMsg.baseContentMsgModel != null && WKReader.isNotEmpty(chatAdapter.getData().get(i).wkMsg.baseContentMsgModel.entities)) {
@@ -1597,10 +1597,10 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                     } else {
                         //成员名字改变
                         for (int i = 0, size = chatAdapter.getData().size(); i < size; i++) {
-                            if (chatAdapter.getData().get(i).wkMsg != null && chatAdapter.getData().get(i).wkMsg.getMemberOfFrom() != null && !TextUtils.isEmpty(chatAdapter.getData().get(i).wkMsg.getMemberOfFrom().memberUID) && chatAdapter.getData().get(i).wkMsg.getMemberOfFrom().memberUID.equals(channelMember.memberUID)) {
-                                chatAdapter.getData().get(i).wkMsg.getMemberOfFrom().memberName = channelMember.memberName;
-                                chatAdapter.getData().get(i).wkMsg.getMemberOfFrom().memberRemark = channelMember.memberRemark;
-                                chatAdapter.getData().get(i).wkMsg.getMemberOfFrom().memberAvatar = channelMember.memberAvatar;
+                            if (chatAdapter.getData().get(i).wkMsg != null && chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached() != null && !TextUtils.isEmpty(chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberUID) && chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberUID.equals(channelMember.memberUID)) {
+                                chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberName = channelMember.memberName;
+                                chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberRemark = channelMember.memberRemark;
+                                chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberAvatar = channelMember.memberAvatar;
                                 chatAdapter.getData().get(i).isRefreshAvatarAndName = true;
                                 chatAdapter.notifyItemChanged(i, chatAdapter.getData().get(i));
                             }
@@ -3313,6 +3313,9 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                 mInfo.uids = filteredUids;
             }
             content.mentionInfo = mInfo;
+            if (pendingCaptionMentionEntities != null && !pendingCaptionMentionEntities.isEmpty()) {
+                content.entities = pendingCaptionMentionEntities;
+            }
         } else if (chatPanelManager != null) {
             chatPanelManager.applyInputMentionsTo(content, rawText);
         }
@@ -3877,6 +3880,7 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
     private List<String> pendingCaptionMentionUids;
     private boolean pendingCaptionMentionAll;
     private boolean pendingCaptionMentionAis;
+    private List<com.xinbida.wukongim.msgmodel.WKMsgEntity> pendingCaptionMentionEntities;
 
     ActivityResultLauncher<Intent> richTextCaptionLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
         if (result.getResultCode() == Activity.RESULT_OK && result.getData() != null) {
@@ -3885,6 +3889,8 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
             pendingCaptionMentionUids = result.getData().getStringArrayListExtra("mentionUids");
             pendingCaptionMentionAll = result.getData().getBooleanExtra("mentionAll", false);
             pendingCaptionMentionAis = result.getData().getBooleanExtra("mentionAis", false);
+            pendingCaptionMentionEntities = parseMentionEntitiesFromJson(
+                    result.getData().getStringExtra("mentionEntities"));
             if (paths != null && !paths.isEmpty()) {
                 String text = caption != null ? caption : "";
                 if (!TextUtils.isEmpty(text) && chatPanelManager != null && chatPanelManager.isTextOverByteLimit(text)) {
@@ -3897,6 +3903,7 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
             pendingCaptionMentionUids = null;
             pendingCaptionMentionAll = false;
             pendingCaptionMentionAis = false;
+            pendingCaptionMentionEntities = null;
         } else if (result.getResultCode() == Activity.RESULT_CANCELED && result.getData() != null) {
             String restored = result.getData().getStringExtra("caption");
             if (restored != null && !restored.isEmpty() && chatPanelManager != null) {
@@ -3940,6 +3947,28 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
             }
         }
     });
+
+    private static List<com.xinbida.wukongim.msgmodel.WKMsgEntity> parseMentionEntitiesFromJson(String json) {
+        if (TextUtils.isEmpty(json)) return null;
+        try {
+            org.json.JSONArray arr = new org.json.JSONArray(json);
+            List<com.xinbida.wukongim.msgmodel.WKMsgEntity> result = new ArrayList<>();
+            for (int i = 0; i < arr.length(); i++) {
+                org.json.JSONObject obj = arr.getJSONObject(i);
+                com.xinbida.wukongim.msgmodel.WKMsgEntity entity = new com.xinbida.wukongim.msgmodel.WKMsgEntity();
+                entity.type = com.chat.base.msg.ChatContentSpanType.getMention();
+                entity.value = obj.optString("uid", "");
+                entity.offset = obj.optInt("offset", -1);
+                entity.length = obj.optInt("length", 0);
+                if (!entity.value.isEmpty() && entity.offset >= 0 && entity.length > 0) {
+                    result.add(entity);
+                }
+            }
+            return result.isEmpty() ? null : result;
+        } catch (org.json.JSONException e) {
+            return null;
+        }
+    }
 
     private void handleFileResult(android.net.Uri uri) {
         try {
@@ -4411,6 +4440,7 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         if (BuildConfig.DEBUG) Log.d("MsgDebug", "[ChatActivity.refreshMsg] findPositionByMsg=" + i + " listSize=" + list.size());
         if (i >= 0 && i < list.size()) {
             {
+                WKUIChatMsgItemEntity entity = list.get(i);
                 boolean isNotify = false;
                 if (wkMsg.messageSeq > maxMsgSeq) {
                     maxMsgSeq = wkMsg.messageSeq;
@@ -4418,72 +4448,72 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                 if (wkMsg.messageSeq > lastVisibleMsgSeq) {
                     lastVisibleMsgSeq = wkMsg.messageSeq;
                 }
-                if (list.get(i).wkMsg.remoteExtra.revoke != wkMsg.remoteExtra.revoke) {
+                if (entity.wkMsg.remoteExtra.revoke != wkMsg.remoteExtra.revoke) {
                     isNotify = true;
-                    if (BuildConfig.DEBUG) Log.d("MsgDebug", "[ChatActivity.refreshMsg] REVOKE CHANGED: msgID=" + wkMsg.messageID + " old=" + list.get(i).wkMsg.remoteExtra.revoke + " new=" + wkMsg.remoteExtra.revoke);
+                    if (BuildConfig.DEBUG) Log.d("MsgDebug", "[ChatActivity.refreshMsg] REVOKE CHANGED: msgID=" + wkMsg.messageID + " old=" + entity.wkMsg.remoteExtra.revoke + " new=" + wkMsg.remoteExtra.revoke);
                 }
                 // 消息撤回
-                list.get(i).wkMsg.remoteExtra.revoke = wkMsg.remoteExtra.revoke;
-                list.get(i).wkMsg.remoteExtra.revoker = wkMsg.remoteExtra.revoker;
-                if (list.get(i).wkMsg.status != WKSendMsgResult.send_success && wkMsg.status == WKSendMsgResult.send_success) {
+                entity.wkMsg.remoteExtra.revoke = wkMsg.remoteExtra.revoke;
+                entity.wkMsg.remoteExtra.revoker = wkMsg.remoteExtra.revoker;
+                if (entity.wkMsg.status != WKSendMsgResult.send_success && wkMsg.status == WKSendMsgResult.send_success) {
                     WKPlaySound.getInstance().playOutMsg(R.raw.sound_out);
                 }
                 boolean isResetStatus = false;
                 boolean isResetListener = false;
                 boolean isResetData = false;
                 boolean isResetReaction = false;
-                if (list.get(i).wkMsg.status != wkMsg.status
-                        || (list.get(i).wkMsg.remoteExtra.readedCount != wkMsg.remoteExtra.readedCount && list.get(i).wkMsg.remoteExtra.readedCount == 0)
-                        || list.get(i).wkMsg.remoteExtra.editedAt != wkMsg.remoteExtra.editedAt
+                if (entity.wkMsg.status != wkMsg.status
+                        || (entity.wkMsg.remoteExtra.readedCount != wkMsg.remoteExtra.readedCount && entity.wkMsg.remoteExtra.readedCount == 0)
+                        || entity.wkMsg.remoteExtra.editedAt != wkMsg.remoteExtra.editedAt
                 ) {
-                    list.get(i).isUpdateStatus = true;
+                    entity.isUpdateStatus = true;
                     isResetStatus = true;
                 }
-                if (list.get(i).wkMsg.remoteExtra.isPinned != wkMsg.remoteExtra.isPinned) {
+                if (entity.wkMsg.remoteExtra.isPinned != wkMsg.remoteExtra.isPinned) {
                     isResetStatus = true;
                 }
-                list.get(i).wkMsg.voiceStatus = wkMsg.voiceStatus;
+                entity.wkMsg.voiceStatus = wkMsg.voiceStatus;
 
                 if (hideChannelAllPinnedMessage == 0) {
-                    list.get(i).isPinned = wkMsg.remoteExtra.isPinned;
+                    entity.isPinned = wkMsg.remoteExtra.isPinned;
                 } else {
-                    list.get(i).isPinned = 0;
+                    entity.isPinned = 0;
                 }
-                if (list.get(i).wkMsg.remoteExtra.readedCount != wkMsg.remoteExtra.readedCount && !isResetStatus) {
+                if (entity.wkMsg.remoteExtra.readedCount != wkMsg.remoteExtra.readedCount && !isResetStatus) {
                     isResetListener = true;
                 }
-                list.get(i).wkMsg.remoteExtra.isPinned = wkMsg.remoteExtra.isPinned;
-                list.get(i).wkMsg.remoteExtra.readed = wkMsg.remoteExtra.readed;
-                list.get(i).wkMsg.remoteExtra.readedCount = wkMsg.remoteExtra.readedCount;
-                list.get(i).wkMsg.remoteExtra.needUpload = wkMsg.remoteExtra.needUpload;
-                if (list.get(i).wkMsg.remoteExtra.readedCount == 0) {
-                    list.get(i).wkMsg.remoteExtra.unreadCount = count - 1;
+                entity.wkMsg.remoteExtra.isPinned = wkMsg.remoteExtra.isPinned;
+                entity.wkMsg.remoteExtra.readed = wkMsg.remoteExtra.readed;
+                entity.wkMsg.remoteExtra.readedCount = wkMsg.remoteExtra.readedCount;
+                entity.wkMsg.remoteExtra.needUpload = wkMsg.remoteExtra.needUpload;
+                if (entity.wkMsg.remoteExtra.readedCount == 0) {
+                    entity.wkMsg.remoteExtra.unreadCount = count - 1;
                 } else
-                    list.get(i).wkMsg.remoteExtra.unreadCount = wkMsg.remoteExtra.unreadCount;
-                if ((TextUtils.isEmpty(list.get(i).wkMsg.remoteExtra.contentEdit) && !TextUtils.isEmpty(wkMsg.remoteExtra.contentEdit)) || (!TextUtils.isEmpty(list.get(i).wkMsg.remoteExtra.contentEdit) && !TextUtils.isEmpty(wkMsg.remoteExtra.contentEdit) && !list.get(i).wkMsg.remoteExtra.contentEdit.equals(wkMsg.remoteExtra.contentEdit))) {
-                    list.get(i).wkMsg.remoteExtra.editedAt = wkMsg.remoteExtra.editedAt;
-                    list.get(i).wkMsg.remoteExtra.contentEdit = wkMsg.remoteExtra.contentEdit;
-                    list.get(i).wkMsg.remoteExtra.contentEditMsgModel = wkMsg.remoteExtra.contentEditMsgModel;
-                    list.get(i).isUpdateStatus = true;
-                    list.get(i).formatSpans(ChatActivity.this, chatAdapter.getData().get(i).wkMsg);
+                    entity.wkMsg.remoteExtra.unreadCount = wkMsg.remoteExtra.unreadCount;
+                if ((TextUtils.isEmpty(entity.wkMsg.remoteExtra.contentEdit) && !TextUtils.isEmpty(wkMsg.remoteExtra.contentEdit)) || (!TextUtils.isEmpty(entity.wkMsg.remoteExtra.contentEdit) && !TextUtils.isEmpty(wkMsg.remoteExtra.contentEdit) && !entity.wkMsg.remoteExtra.contentEdit.equals(wkMsg.remoteExtra.contentEdit))) {
+                    entity.wkMsg.remoteExtra.editedAt = wkMsg.remoteExtra.editedAt;
+                    entity.wkMsg.remoteExtra.contentEdit = wkMsg.remoteExtra.contentEdit;
+                    entity.wkMsg.remoteExtra.contentEditMsgModel = wkMsg.remoteExtra.contentEditMsgModel;
+                    entity.isUpdateStatus = true;
+                    entity.formatSpans(ChatActivity.this, entity.wkMsg);
                     isResetData = true;
                 }
 
-                list.get(i).wkMsg.isDeleted = wkMsg.isDeleted;
-                list.get(i).wkMsg.messageID = wkMsg.messageID;
-                list.get(i).wkMsg.messageSeq = wkMsg.messageSeq;
-                list.get(i).wkMsg.orderSeq = wkMsg.orderSeq;
+                entity.wkMsg.isDeleted = wkMsg.isDeleted;
+                entity.wkMsg.messageID = wkMsg.messageID;
+                entity.wkMsg.messageSeq = wkMsg.messageSeq;
+                entity.wkMsg.orderSeq = wkMsg.orderSeq;
                 if ((wkMsg.localExtraMap != null && !wkMsg.localExtraMap.isEmpty())) {
                     isNotify = true;
                 }
-                if (isRefreshReaction(list.get(i).wkMsg.reactionList, wkMsg.reactionList)) {
+                if (isRefreshReaction(entity.wkMsg.reactionList, wkMsg.reactionList)) {
                     isResetReaction = true;
                 }
-                list.get(i).wkMsg.localExtraMap = wkMsg.localExtraMap;
-                list.get(i).wkMsg.content = wkMsg.content;
-                list.get(i).wkMsg.reactionList = wkMsg.reactionList;
-                list.get(i).wkMsg.baseContentMsgModel = wkMsg.baseContentMsgModel;
-                list.get(i).wkMsg.status = wkMsg.status;
+                entity.wkMsg.localExtraMap = wkMsg.localExtraMap;
+                entity.wkMsg.content = wkMsg.content;
+                entity.wkMsg.reactionList = wkMsg.reactionList;
+                entity.wkMsg.baseContentMsgModel = wkMsg.baseContentMsgModel;
+                entity.wkMsg.status = wkMsg.status;
                 if (isNotify) {
                     EndpointManager.getInstance().invoke("stop_reaction_animation", null);
                     chatAdapter.notifyItemChanged(i);
@@ -4498,21 +4528,21 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                         chatAdapter.notifyData(i);
                     }
                     if (isResetReaction) {
-                        list.get(i).isRefreshReaction = true;
-                        chatAdapter.notifyItemChanged(i, list.get(i));
-                        //chatAdapter.notifyReaction(i, wkMsg.reactionList);
+                        entity.isRefreshReaction = true;
+                        chatAdapter.notifyItemChanged(i, entity);
                     }
                 }
 
-                if (list.get(i).wkMsg.remoteExtra.revoke == 1) {
+                if (entity.wkMsg.remoteExtra.revoke == 1) {
                     int finalI = i;
                     new Handler(Looper.getMainLooper()).postDelayed(() -> {
                         int previousIndex = finalI - 1;
                         int nextIndex = finalI + 1;
-                        if (previousIndex >= 0 && list.get(previousIndex).wkMsg.remoteExtra.revoke == 0) {
+                        List<WKUIChatMsgItemEntity> currentList = chatAdapter.getData();
+                        if (previousIndex >= 0 && previousIndex < currentList.size() && currentList.get(previousIndex).wkMsg.remoteExtra.revoke == 0) {
                             chatAdapter.notifyItemChanged(previousIndex);
                         }
-                        if (nextIndex <= chatAdapter.getData().size() - 1 && list.get(nextIndex).wkMsg.remoteExtra.revoke == 0) {
+                        if (nextIndex >= 0 && nextIndex < currentList.size() && currentList.get(nextIndex).wkMsg.remoteExtra.revoke == 0) {
                             chatAdapter.notifyItemChanged(nextIndex);
                         }
                     }, 200);

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -3894,6 +3894,10 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
             if (paths != null && !paths.isEmpty()) {
                 String text = caption != null ? caption : "";
                 if (!TextUtils.isEmpty(text) && chatPanelManager != null && chatPanelManager.isTextOverByteLimit(text)) {
+                    pendingCaptionMentionUids = null;
+                    pendingCaptionMentionAll = false;
+                    pendingCaptionMentionAis = false;
+                    pendingCaptionMentionEntities = null;
                     sendRichTextTray("", paths, null, null);
                     chatPanelManager.promptTextToFile(text);
                 } else {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -454,8 +454,8 @@ class ChatPanelManager(
      * 把当前输入框的 @mention（三态 humans/ais + 群成员 uids）应用到给定消息体。
      *
      * 供图文混排（RichText=14）聚合发送复用——与发送键文本路径【同源】，
-     * 保证群 @ 通知（含 @所有AI）不丢。刻意不写 entities：图文混排的 plain 非权威，
-     * 且 entity offset 是相对纯文本块的字符偏移，跨 block 拼接后无意义。
+     * 保证群 @ 通知（含 @所有AI）不丢。同时写入 mention.entities（offset/length/uid），
+     * 使接收侧可高亮并点击 @mention 跳转个人名片。
      *
      * 复用既有 [scanPlainTextMentions] / [expandRobotMembersIntoUids]，与 sendIV 文本
      * 发送逻辑保持单一来源。
@@ -493,6 +493,11 @@ class ChatPanelManager(
         }
         mInfo.uids = uidList
         content.mentionInfo = mInfo
+
+        val mentionEntities = entities.filter { it.type == ChatContentSpanType.mention }
+        if (mentionEntities.isNotEmpty()) {
+            content.entities = mentionEntities
+        }
     }
 
     fun showReplyLayout(mMsg: WKMsg) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/WKRichTextCaptionActivity.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/WKRichTextCaptionActivity.kt
@@ -136,12 +136,33 @@ class WKRichTextCaptionActivity : AppCompatActivity() {
             allUids.addAll(modalUids)
             val hasAll = allUids.contains("-1")
             val hasAis = allUids.contains("-2")
+
+            val mentionEntities = binding.captionEt.allEntity
+            var entitiesJson: String? = null
+            if (mentionEntities != null && mentionEntities.isNotEmpty()) {
+                val arr = org.json.JSONArray()
+                for (e in mentionEntities) {
+                    if (e.type != com.chat.base.msg.ChatContentSpanType.mention) continue
+                    val obj = org.json.JSONObject()
+                    obj.put("uid", e.value)
+                    obj.put("offset", e.offset)
+                    obj.put("length", e.length)
+                    arr.put(obj)
+                }
+                if (arr.length() > 0) {
+                    entitiesJson = arr.toString()
+                }
+            }
+
             val result = Intent()
             result.putStringArrayListExtra("paths", ArrayList(imagePaths))
             result.putExtra("caption", caption)
             result.putStringArrayListExtra("mentionUids", ArrayList(allUids))
             result.putExtra("mentionAll", hasAll)
             result.putExtra("mentionAis", hasAis)
+            if (entitiesJson != null) {
+                result.putExtra("mentionEntities", entitiesJson)
+            }
             setResult(RESULT_OK, result)
             finish()
         }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKRichTextSender.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKRichTextSender.java
@@ -28,6 +28,7 @@ import com.chat.uikit.R;
 import com.chat.uikit.chat.msgmodel.WKRichTextContent;
 import com.xinbida.wukongim.entity.WKChannel;
 import com.xinbida.wukongim.msgmodel.WKMessageContent;
+import com.xinbida.wukongim.msgmodel.WKMsgEntity;
 import com.xinbida.wukongim.msgmodel.WKTextContent;
 
 import java.util.ArrayList;
@@ -285,6 +286,12 @@ public final class WKRichTextSender {
         // plain 非权威：仅填本地占位（image → 占位 wire token），server #232 Finalize 覆盖。
         content.plain = WKRichTextContent.buildPlainFromBlocks(blocks);
 
+        // entity offset 调整：composer 产生的 offset 是 text-block-local 的（相对于纯文本），
+        // 但 wire 上 offset 必须相对于 plain（含 [图片] 占位符）。在此处一次性调整，
+        // 使 encodeMsg() 和 SDK getSendPayload() 两条序列化路径都拿到正确的 plain-relative 偏移。
+        // 同时过滤哨兵 UID（-1/-2），广播仅由 mention.all/humans/ais 标志位承担。
+        adjustEntitiesForPlain(content, imageBlocks.size());
+
         toastFailIfAny(context, failedCount);
         // 按<em>捕获</em>的频道落库（YUJ-2872 🔴 跨频道路由）：上传期间 Activity 可能已切到
         // 别的频道，绝不能读 mutable 字段，否则消息错投。channel 为本次发起时捕获的目标。
@@ -390,5 +397,23 @@ public final class WKRichTextSender {
                                         }
                                     });
                         });
+    }
+
+    /**
+     * 将 content.entities 从 text-block-local 偏移调整为 plain-relative 偏移，
+     * 并过滤掉哨兵 UID（-1/-2）。调整量 = 前置图片数 × IMAGE_PLACEHOLDER 长度。
+     * 在 blocks 组装完成后、入队前调用，确保 encodeMsg() 和 SDK getSendPayload()
+     * 两条序列化路径都拿到一致的 plain-relative 偏移。
+     */
+    private static void adjustEntitiesForPlain(WKRichTextContent content, int imageCount) {
+        if (content.entities == null || content.entities.isEmpty()) return;
+        int imageOffset = imageCount * WKRichTextContent.IMAGE_PLACEHOLDER.length();
+        List<WKMsgEntity> adjusted = new ArrayList<>();
+        for (WKMsgEntity entity : content.entities) {
+            if ("-1".equals(entity.value) || "-2".equals(entity.value)) continue;
+            entity.offset += imageOffset;
+            adjusted.add(entity);
+        }
+        content.entities = adjusted;
     }
 }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
@@ -28,6 +28,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import com.chat.base.msg.MentionEntityHelper;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -188,6 +190,37 @@ public class WKRichTextContent extends WKMessageContent {
             jsonObject.put("content", contentArr);
             if (!isBlank(plain)) {
                 jsonObject.put("plain", plain);
+            }
+
+            // mention 数据：与 WKMentionTextContent 同模式，将 mention.entities 写入
+            // payload。SDK 的 getSendPayload 检查 json.has("mention")，已包含则不覆盖。
+            boolean hasUids = mentionInfo != null && mentionInfo.uids != null && !mentionInfo.uids.isEmpty();
+            boolean hasMentionAll = mentionAll == 1;
+            boolean hasHumans = mentionHumans == 1 || (mentionInfo != null && mentionInfo.humans);
+            boolean hasAis = mentionAis == 1;
+            if (hasUids || hasMentionAll || hasHumans || hasAis) {
+                JSONObject mentionJson = new JSONObject();
+                if (hasMentionAll) {
+                    mentionJson.put("all", 1);
+                }
+                if (hasHumans) {
+                    mentionJson.put("humans", 1);
+                }
+                if (hasAis) {
+                    mentionJson.put("ais", 1);
+                }
+                if (hasUids) {
+                    JSONArray uidsArr = new JSONArray();
+                    for (String uid : mentionInfo.uids) {
+                        uidsArr.put(uid);
+                    }
+                    mentionJson.put("uids", uidsArr);
+                }
+                JSONArray mentionEntitiesArr = MentionEntityHelper.buildMentionEntitiesJson(entities);
+                if (mentionEntitiesArr != null) {
+                    mentionJson.put("entities", mentionEntitiesArr);
+                }
+                jsonObject.put("mention", mentionJson);
             }
         } catch (JSONException e) {
             e.printStackTrace();

--- a/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
@@ -28,7 +28,9 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import com.chat.base.msg.ChatContentSpanType;
 import com.chat.base.msg.MentionEntityHelper;
+import com.xinbida.wukongim.msgmodel.WKMsgEntity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -216,7 +218,7 @@ public class WKRichTextContent extends WKMessageContent {
                     }
                     mentionJson.put("uids", uidsArr);
                 }
-                JSONArray mentionEntitiesArr = MentionEntityHelper.buildMentionEntitiesJson(entities);
+                JSONArray mentionEntitiesArr = buildPlainRelativeEntitiesJson(entities, blocks);
                 if (mentionEntitiesArr != null) {
                     mentionJson.put("entities", mentionEntitiesArr);
                 }
@@ -258,6 +260,45 @@ public class WKRichTextContent extends WKMessageContent {
             plain = buildPlainFromBlocks(blocks);
         }
         return this;
+    }
+
+    /**
+     * 将 block-local 的 entity offset 转换为 plain-relative 后构建 JSON 数组。
+     * 遍历 blocks 计算每个 text block 在 plain 中的起始偏移（前面的 image block
+     * 各占 IMAGE_PLACEHOLDER 长度），把落在该 text block 内的 entity offset 加上
+     * 该偏移量，使 wire 上的 offset 相对于 plain 文本。
+     */
+    private static JSONArray buildPlainRelativeEntitiesJson(
+            List<WKMsgEntity> entities, List<RichTextBlock> blocks) {
+        if (entities == null || entities.isEmpty() || blocks == null) return null;
+        int plainOffset = 0;
+        int textBlockPlainStart = -1;
+        for (RichTextBlock block : blocks) {
+            if (block == null) continue;
+            if (BLOCK_TYPE_IMAGE.equals(block.type)) {
+                plainOffset += IMAGE_PLACEHOLDER.length();
+            } else {
+                if (textBlockPlainStart < 0) {
+                    textBlockPlainStart = plainOffset;
+                }
+                String text = block.text;
+                plainOffset += (text != null ? text.length() : 0);
+            }
+        }
+        if (textBlockPlainStart < 0) textBlockPlainStart = 0;
+        JSONArray arr = new JSONArray();
+        for (WKMsgEntity entity : entities) {
+            if (!ChatContentSpanType.getMention().equals(entity.type)) continue;
+            try {
+                JSONObject obj = new JSONObject();
+                obj.put("uid", entity.value);
+                obj.put("offset", entity.offset + textBlockPlainStart);
+                obj.put("length", entity.length);
+                arr.put(obj);
+            } catch (JSONException ignored) {
+            }
+        }
+        return arr.length() > 0 ? arr : null;
     }
 
     /**

--- a/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/WKRichTextContent.java
@@ -28,9 +28,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import com.chat.base.msg.ChatContentSpanType;
 import com.chat.base.msg.MentionEntityHelper;
-import com.xinbida.wukongim.msgmodel.WKMsgEntity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -218,7 +216,7 @@ public class WKRichTextContent extends WKMessageContent {
                     }
                     mentionJson.put("uids", uidsArr);
                 }
-                JSONArray mentionEntitiesArr = buildPlainRelativeEntitiesJson(entities, blocks);
+                JSONArray mentionEntitiesArr = MentionEntityHelper.buildMentionEntitiesJson(entities);
                 if (mentionEntitiesArr != null) {
                     mentionJson.put("entities", mentionEntitiesArr);
                 }
@@ -260,45 +258,6 @@ public class WKRichTextContent extends WKMessageContent {
             plain = buildPlainFromBlocks(blocks);
         }
         return this;
-    }
-
-    /**
-     * 将 block-local 的 entity offset 转换为 plain-relative 后构建 JSON 数组。
-     * 遍历 blocks 计算每个 text block 在 plain 中的起始偏移（前面的 image block
-     * 各占 IMAGE_PLACEHOLDER 长度），把落在该 text block 内的 entity offset 加上
-     * 该偏移量，使 wire 上的 offset 相对于 plain 文本。
-     */
-    private static JSONArray buildPlainRelativeEntitiesJson(
-            List<WKMsgEntity> entities, List<RichTextBlock> blocks) {
-        if (entities == null || entities.isEmpty() || blocks == null) return null;
-        int plainOffset = 0;
-        int textBlockPlainStart = -1;
-        for (RichTextBlock block : blocks) {
-            if (block == null) continue;
-            if (BLOCK_TYPE_IMAGE.equals(block.type)) {
-                plainOffset += IMAGE_PLACEHOLDER.length();
-            } else {
-                if (textBlockPlainStart < 0) {
-                    textBlockPlainStart = plainOffset;
-                }
-                String text = block.text;
-                plainOffset += (text != null ? text.length() : 0);
-            }
-        }
-        if (textBlockPlainStart < 0) textBlockPlainStart = 0;
-        JSONArray arr = new JSONArray();
-        for (WKMsgEntity entity : entities) {
-            if (!ChatContentSpanType.getMention().equals(entity.type)) continue;
-            try {
-                JSONObject obj = new JSONObject();
-                obj.put("uid", entity.value);
-                obj.put("offset", entity.offset + textBlockPlainStart);
-                obj.put("length", entity.length);
-                arr.put(obj);
-            } catch (JSONException ignored) {
-            }
-        }
-        return arr.length() > 0 ? arr : null;
     }
 
     /**

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKRichTextProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKRichTextProvider.kt
@@ -123,11 +123,12 @@ class WKRichTextProvider : WKChatBaseProvider() {
         val allImageUrls = mutableListOf<String>()
         var imageCount = 0
         var renderedImageIndex = 0
-        var textOffset = 0
+        var plainOffset = 0
         for (block in blocks) {
             if (block == null) continue
             when {
                 block.isImage() -> {
+                    plainOffset += WKRichTextContent.IMAGE_PLACEHOLDER.length
                     if (imageCount < MAX_RENDER_IMAGES) {
                         val showUrl = WKApiConfig.getShowUrl(block.url)
                         if (!TextUtils.isEmpty(showUrl)) {
@@ -142,8 +143,8 @@ class WKRichTextProvider : WKChatBaseProvider() {
                     if (!TextUtils.isEmpty(block.text)) {
                         val blockLen = block.text.length
                         val blockEntities = if (mentionEntities.isNotEmpty()) {
-                            val startOff = textOffset
-                            val endOff = textOffset + blockLen
+                            val startOff = plainOffset
+                            val endOff = plainOffset + blockLen
                             mentionEntities.filter { e ->
                                 e.offset >= startOff && (e.offset + e.length) <= endOff
                             }
@@ -152,11 +153,11 @@ class WKRichTextProvider : WKChatBaseProvider() {
                         }
                         addTextBlock(
                             blocksLayout, textColor, block.text, textMaxWidth,
-                            blockEntities, textOffset, mentionColor,
+                            blockEntities, plainOffset, mentionColor,
                             uiChatMsgItemEntity,
                             broadcastsAll, broadcastsAis
                         )
-                        textOffset += blockLen
+                        plainOffset += blockLen
                     }
                 }
             }
@@ -269,7 +270,7 @@ class WKRichTextProvider : WKChatBaseProvider() {
 
                 var showName = ssb.subSequence(localStart, localEnd).toString()
                 if (!isSentinel) {
-                    val channel = WKIM.getInstance().channelManager.getChannel(uid, WKChannelType.PERSONAL)
+                    val channel = WKIM.getInstance().channelManager.getChannelIfCached(uid, WKChannelType.PERSONAL)
                     if (channel != null) {
                         val name = if (TextUtils.isEmpty(channel.channelRemark)) channel.channelName else channel.channelRemark
                         if (!TextUtils.isEmpty(name)) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKRichTextProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKRichTextProvider.kt
@@ -16,8 +16,14 @@
 
 package com.chat.uikit.chat.provider
 
+import android.graphics.Color
+import android.graphics.Typeface
+import android.text.SpannableStringBuilder
+import android.text.Spanned
 import android.text.TextUtils
 import android.text.method.LinkMovementMethod
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
 import android.util.TypedValue
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -33,35 +39,24 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.CenterInside
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.chat.base.config.WKApiConfig
+import com.chat.base.msg.ChatContentSpanType
 import com.chat.base.msgitem.WKChatBaseProvider
 import com.chat.base.msgitem.WKChatIteMsgFromType
 import com.chat.base.msgitem.WKContentType
 import com.chat.base.msgitem.WKMsgBgType
 import com.chat.base.msgitem.WKUIChatMsgItemEntity
+import com.chat.base.ui.components.NormalClickableContent
+import com.chat.base.ui.components.NormalClickableSpan
 import com.chat.base.utils.AndroidUtilities
 import com.chat.base.utils.WKDialogUtils
+import com.chat.base.ui.Theme
 import com.chat.base.views.BubbleLayout
 import com.chat.uikit.R
 import com.chat.uikit.chat.msgmodel.WKRichTextContent
+import com.xinbida.wukongim.WKIM
+import com.xinbida.wukongim.entity.WKChannelType
+import com.xinbida.wukongim.msgmodel.WKMsgEntity
 
-/**
- * 图文混排消息（RichText=14）接收渲染 provider（Phase 1，仅接收）。
- *
- * <p>消费 {@link WKRichTextContent#blocks}，按数组顺序在气泡内垂直穿插 text /
- * image 子 View：
- * <ul>
- *   <li>text block → [EmojiTextView]，MVP 锁纯文本（不渲 markdown），emoji 仍由
- *       EmojiTextView 渲染；</li>
- *   <li>image block → [AppCompatImageView] + Glide 内联加载，尺寸走与图片消息
- *       一致的 [ImageUtils.getImageWidthAndHeightToTalk]。</li>
- * </ul>
- *
- * <p>复制 / 回复 / 转发 / 删除 / 撤回 / reaction 等长按操作复用基类标准
- * [addLongClick] 弹出菜单；复制项由 WKUIKitApplication 注册的 wkChatPopupItem
- * 菜单提供，取顶层 plain（{@link WKRichTextContent#getDisplayContent}），勿丢字。
- *
- * <p>所有渲染逻辑封装在本 provider，未触碰宿主 ChatActivity / ChatFragment。
- */
 class WKRichTextProvider : WKChatBaseProvider() {
 
     companion object {
@@ -81,16 +76,12 @@ class WKRichTextProvider : WKChatBaseProvider() {
         val contentLayout = parentView.findViewById<LinearLayout>(R.id.contentLayout)
         val contentTvLayout = parentView.findViewById<BubbleLayout>(R.id.contentTvLayout)
         val blocksLayout = parentView.findViewById<LinearLayout>(R.id.richBlocksLayout)
-        // RecyclerView 复用：每次重建子 View，避免残留上一条消息内容。
         blocksLayout.removeAllViews()
 
         resetCellBackground(parentView, uiChatMsgItemEntity, from)
         contentLayout.gravity =
             if (from == WKChatIteMsgFromType.RECEIVED) Gravity.START else Gravity.END
 
-        // 群/社区里 RichText 接收消息显示发送者昵称：基类对 richText 跳过通用
-        // sender-name 路径（WKChatBaseProvider:464/190），故在 provider 内手动复用
-        // 基类 setFromName 渲染外部名字行（含实名徽章 / @Space 后缀逻辑）。
         applyFromName(parentView, uiChatMsgItemEntity, from)
 
         val textColor = if (from == WKChatIteMsgFromType.SEND) {
@@ -99,13 +90,10 @@ class WKRichTextProvider : WKChatBaseProvider() {
             ContextCompat.getColor(context, R.color.receive_text_color)
         }
 
-        // 文本块最大宽度：与文本消息一致取 getViewWidth(...)（pane 宽减头像/勾选/边距），
-        // 约束长文本块换行而非撑成超宽气泡 clip/溢出（对齐 WKTextProvider:1240）。
         val textMaxWidth = getViewWidth(from, uiChatMsgItemEntity)
 
         val model = uiChatMsgItemEntity.wkMsg.baseContentMsgModel as? WKRichTextContent
         if (model == null) {
-            // 解析失败兜底：展示已知 plain（若有），否则未知消息提示。
             addTextBlock(blocksLayout, textColor, context.getString(R.string.base_unknow_msg), textMaxWidth)
             addLongClick(contentTvLayout, uiChatMsgItemEntity)
             return
@@ -113,15 +101,29 @@ class WKRichTextProvider : WKChatBaseProvider() {
 
         val blocks = model.blocks
         if (blocks.isNullOrEmpty()) {
-            // 无 block：回退顶层 plain，仍为空则未知消息提示。
             addTextBlock(blocksLayout, textColor, fallbackText(model), textMaxWidth)
             addLongClick(contentTvLayout, uiChatMsgItemEntity)
             return
         }
 
+        val mentionEntities = uiChatMsgItemEntity.wkMsg.baseContentMsgModel?.entities
+            ?.filter { it.type == ChatContentSpanType.mention }
+            ?: emptyList()
+
+        val isSelfDarkBubble = Theme.isDark()
+                && from == WKChatIteMsgFromType.SEND
+        val mentionColor = if (isSelfDarkBubble) Color.WHITE else Theme.colorAccount
+
+        val wkMsg = uiChatMsgItemEntity.wkMsg
+        val broadcastsAll = wkMsg.baseContentMsgModel.mentionAll == 1
+                || wkMsg.baseContentMsgModel.mentionHumans == 1
+                || (wkMsg.baseContentMsgModel.mentionInfo?.humans == true)
+        val broadcastsAis = wkMsg.baseContentMsgModel.mentionAis == 1
+
         val allImageUrls = mutableListOf<String>()
         var imageCount = 0
         var renderedImageIndex = 0
+        var textOffset = 0
         for (block in blocks) {
             if (block == null) continue
             when {
@@ -137,32 +139,36 @@ class WKRichTextProvider : WKChatBaseProvider() {
                     }
                 }
                 else -> {
-                    // text block 与未知 type（带 text）都走文本渲染，前向兼容二期扩展。
                     if (!TextUtils.isEmpty(block.text)) {
-                        addTextBlock(blocksLayout, textColor, block.text, textMaxWidth)
+                        val blockLen = block.text.length
+                        val blockEntities = if (mentionEntities.isNotEmpty()) {
+                            val startOff = textOffset
+                            val endOff = textOffset + blockLen
+                            mentionEntities.filter { e ->
+                                e.offset >= startOff && (e.offset + e.length) <= endOff
+                            }
+                        } else {
+                            emptyList()
+                        }
+                        addTextBlock(
+                            blocksLayout, textColor, block.text, textMaxWidth,
+                            blockEntities, textOffset, mentionColor,
+                            uiChatMsgItemEntity,
+                            broadcastsAll, broadcastsAis
+                        )
+                        textOffset += blockLen
                     }
                 }
             }
         }
 
-        // 全部 block 渲染后内容仍为空（如纯未知 block 无 text）→ 回退 plain，勿留空气泡。
         if (blocksLayout.childCount == 0) {
             addTextBlock(blocksLayout, textColor, fallbackText(model), textMaxWidth)
         }
 
-        // 复制 / 回复 / 转发 / 删除 / reaction 走基类标准长按菜单。
         addLongClick(contentTvLayout, uiChatMsgItemEntity)
     }
 
-    /**
-     * 渲染发送者昵称行。RichText item 复用基类 chat_item_base_layout 的外部名字行
-     * （receivedNameTv，是 wkBaseContentLayout 的兄弟节点，非其后代），故从 parentView
-     * 的父容器 fullContentLayout 内查 receivedNameTv 再交给基类 setFromName 处理
-     * （群/社区可见、私聊隐藏、实名徽章、@Space 后缀均由 setFromName 内部统一裁决）。
-     *
-     * <p>full-bind（WKChatBaseProvider.showData → setData）与局部刷新
-     * （convert(payloads) → resetFromName）两条路径都需调用，避免首屏昵称不显示。
-     */
     private fun applyFromName(
         parentView: View,
         uiChatMsgItemEntity: WKUIChatMsgItemEntity,
@@ -182,7 +188,6 @@ class WKRichTextProvider : WKChatBaseProvider() {
         applyFromName(parentView, uiChatMsgItemEntity, from)
     }
 
-    /** block 渲染为空时的兜底文本：优先顶层 plain，否则未知消息提示。 */
     private fun fallbackText(model: WKRichTextContent): String {
         return if (!TextUtils.isEmpty(model.plain)) {
             model.plain
@@ -191,9 +196,30 @@ class WKRichTextProvider : WKChatBaseProvider() {
         }
     }
 
-    private fun addTextBlock(parent: LinearLayout, textColor: Int, text: String?, maxWidth: Int) {
+    private fun addTextBlock(
+        parent: LinearLayout,
+        textColor: Int,
+        text: String?,
+        maxWidth: Int,
+        mentionEntities: List<WKMsgEntity> = emptyList(),
+        blockTextOffset: Int = 0,
+        mentionColor: Int = 0,
+        uiEntity: WKUIChatMsgItemEntity? = null,
+        broadcastsAll: Boolean = false,
+        broadcastsAis: Boolean = false
+    ) {
+        val rawText = text ?: ""
+        val spannable = buildMentionSpans(
+            rawText, mentionEntities, blockTextOffset, mentionColor, uiEntity,
+            broadcastsAll, broadcastsAis
+        )
+
         val tv = EmojiTextView(context).apply {
-            this.text = text ?: ""
+            if (spannable != null) {
+                setText(spannable, TextView.BufferType.SPANNABLE)
+            } else {
+                this.text = rawText
+            }
             setTextColor(textColor)
             setTextSize(
                 TypedValue.COMPLEX_UNIT_PX,
@@ -201,7 +227,6 @@ class WKRichTextProvider : WKChatBaseProvider() {
             )
             setLineSpacing(2f * context.resources.displayMetrics.density, 1f)
             movementMethod = LinkMovementMethod.getInstance()
-            // 与文本消息一致：约束最大宽度，长文本块换行而非撑成超宽气泡 clip/溢出。
             if (maxWidth > 0) {
                 this.maxWidth = maxWidth
             }
@@ -213,6 +238,134 @@ class WKRichTextProvider : WKChatBaseProvider() {
                 LinearLayout.LayoutParams.WRAP_CONTENT
             )
         )
+    }
+
+    private fun buildMentionSpans(
+        text: String,
+        mentionEntities: List<WKMsgEntity>,
+        blockTextOffset: Int,
+        mentionColor: Int,
+        uiEntity: WKUIChatMsgItemEntity?,
+        broadcastsAll: Boolean,
+        broadcastsAis: Boolean
+    ): SpannableStringBuilder? {
+        val hasEntities = mentionEntities.isNotEmpty()
+        val hasBroadcasts = broadcastsAll || broadcastsAis
+        if (!hasEntities && !hasBroadcasts) return null
+
+        val ssb = SpannableStringBuilder(text)
+
+        if (hasEntities && uiEntity != null) {
+            val sortedEntities = mentionEntities.sortedByDescending { it.offset }
+            var lastProcessedStart = Int.MAX_VALUE
+            for (entity in sortedEntities) {
+                val localStart = entity.offset - blockTextOffset
+                val localEnd = localStart + entity.length
+                if (localStart < 0 || localEnd > ssb.length || localEnd > lastProcessedStart) continue
+                lastProcessedStart = localStart
+
+                val uid = entity.value ?: continue
+                val isSentinel = uid == "-1" || uid == "-2"
+
+                var showName = ssb.subSequence(localStart, localEnd).toString()
+                if (!isSentinel) {
+                    val channel = WKIM.getInstance().channelManager.getChannel(uid, WKChannelType.PERSONAL)
+                    if (channel != null) {
+                        val name = if (TextUtils.isEmpty(channel.channelRemark)) channel.channelName else channel.channelRemark
+                        if (!TextUtils.isEmpty(name)) {
+                            showName = if (name.startsWith("@")) name else "@$name"
+                            showName = "$showName "
+                        }
+                    }
+                }
+
+                val nameSpan = SpannableStringBuilder(showName)
+                nameSpan.setSpan(StyleSpan(Typeface.BOLD), 0, showName.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+                if (!isSentinel && uiEntity.iLinkClick != null) {
+                    val wkMsg = uiEntity.wkMsg
+                    val groupNo = if (wkMsg.channelType == WKChannelType.GROUP
+                        || wkMsg.channelType == WKChannelType.COMMUNITY_TOPIC) {
+                        wkMsg.channelID
+                    } else ""
+                    val clickContent = "$uid|$groupNo"
+                    nameSpan.setSpan(
+                        NormalClickableSpan(
+                            false, mentionColor,
+                            NormalClickableContent(NormalClickableContent.NormalClickableTypes.Remind, clickContent),
+                            object : NormalClickableSpan.IClick {
+                                override fun onClick(view: View) {
+                                    uiEntity.iLinkClick.onShowUserDetail(uid, groupNo)
+                                }
+                            }
+                        ),
+                        0, showName.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                } else {
+                    nameSpan.setSpan(
+                        ForegroundColorSpan(mentionColor),
+                        0, showName.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                }
+
+                ssb.replace(localStart, localEnd, nameSpan)
+            }
+        }
+
+        if (hasBroadcasts) {
+            applyBroadcastHighlight(ssb, mentionColor, broadcastsAll, broadcastsAis)
+        }
+
+        return ssb
+    }
+
+    private fun applyBroadcastHighlight(
+        ssb: SpannableStringBuilder,
+        mentionColor: Int,
+        broadcastsAll: Boolean,
+        broadcastsAis: Boolean
+    ) {
+        val tokens = mutableListOf<String>()
+        val seen = mutableSetOf<String>()
+        if (broadcastsAll) {
+            addToken(tokens, seen, "@所有人")
+            addToken(tokens, seen, "@All People")
+            addToken(tokens, seen, "@All")
+            addToken(tokens, seen, "@" + context.getString(R.string.base_mention_all))
+        }
+        if (broadcastsAis) {
+            addToken(tokens, seen, "@所有AI")
+            addToken(tokens, seen, "@All AIs")
+            addToken(tokens, seen, "@" + context.getString(R.string.base_mention_all_ais))
+        }
+        tokens.sortByDescending { it.length }
+
+        val currentText = ssb.toString()
+        for (token in tokens) {
+            var fromIndex = 0
+            while (fromIndex < currentText.length) {
+                val idx = currentText.indexOf(token, fromIndex)
+                if (idx < 0) break
+                val end = idx + token.length
+                if (end < currentText.length) {
+                    val nextCh = currentText[end]
+                    if (nextCh.isLetterOrDigit() || nextCh == '_') {
+                        fromIndex = idx + 1
+                        continue
+                    }
+                }
+                ssb.setSpan(ForegroundColorSpan(mentionColor), idx, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                ssb.setSpan(StyleSpan(Typeface.BOLD), idx, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                fromIndex = end
+            }
+        }
+    }
+
+    private fun addToken(tokens: MutableList<String>, seen: MutableSet<String>, token: String) {
+        val key = token.lowercase()
+        if (key.length <= 1 || seen.contains(key)) return
+        seen.add(key)
+        tokens.add(token)
     }
 
     private fun addImageBlock(parent: LinearLayout, block: WKRichTextContent.RichTextBlock, allImageUrls: List<String>, imageIndex: Int) {

--- a/wkuikit/src/main/java/com/chat/uikit/db/ProhibitWordDB.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/db/ProhibitWordDB.kt
@@ -94,7 +94,8 @@ class ProhibitWordDB private constructor() {
                     return serialize(cursor).version
                 }
             }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            android.util.Log.w("ProhibitWordDB", "getMaxVersion error", e)
         }
         return 0
     }
@@ -113,7 +114,8 @@ class ProhibitWordDB private constructor() {
                     cursor.moveToNext()
                 }
             }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            android.util.Log.w("ProhibitWordDB", "getAll error", e)
         }
         return result
     }
@@ -142,7 +144,8 @@ class ProhibitWordDB private constructor() {
                     cursor.moveToNext()
                 }
             }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            android.util.Log.w("ProhibitWordDB", "queryWithsIds error", e)
         }
         return result
     }

--- a/wkuikit/src/main/java/com/chat/uikit/db/ProhibitWordDB.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/db/ProhibitWordDB.kt
@@ -83,64 +83,66 @@ class ProhibitWordDB private constructor() {
     }
 
     fun getMaxVersion(): Long {
-        if (WKBaseApplication.getInstance().dbHelper == null) {
-            return 0
+        val helper = WKBaseApplication.getInstance().dbHelper ?: return 0
+        if (helper.isClosed) return 0
+        try {
+            val sql = "select * from $table order by `version` desc limit 1"
+            val cursor: Cursor = helper.rawQuery(sql, null) ?: return 0
+            cursor.use {
+                cursor.moveToFirst()
+                if (!cursor.isAfterLast) {
+                    return serialize(cursor).version
+                }
+            }
+        } catch (_: Exception) {
         }
-        val sql = "select * from $table order by `version` desc limit 1"
-        val cursor: Cursor = WKBaseApplication.getInstance().dbHelper.rawQuery(sql, null)
-        cursor.moveToFirst()
-        var num = 0L
-        if (!cursor.isAfterLast) {
-            val word = serialize(cursor)
-            num = word.version
-            cursor.moveToNext()
-        }
-        cursor.close()
-        return num
+        return 0
     }
 
     fun getAll(): ArrayList<ProhibitWord> {
-        val sql = "select * from $table where is_deleted=0"
         val result = ArrayList<ProhibitWord>()
-        if (WKBaseApplication.getInstance().dbHelper != null) {
-            val cursor: Cursor = WKBaseApplication.getInstance().dbHelper.rawQuery(sql, null)
-                ?: return result
-            run {
+        val helper = WKBaseApplication.getInstance().dbHelper ?: return result
+        if (helper.isClosed) return result
+        try {
+            val sql = "select * from $table where is_deleted=0"
+            val cursor: Cursor = helper.rawQuery(sql, null) ?: return result
+            cursor.use {
                 cursor.moveToFirst()
                 while (!cursor.isAfterLast) {
                     result.add(serialize(cursor))
                     cursor.moveToNext()
                 }
             }
-            cursor.close()
+        } catch (_: Exception) {
         }
         return result
     }
 
     private fun queryWithsIds(list: List<Int>): List<ProhibitWord> {
         if (list.isEmpty()) return ArrayList()
-        val placeholders = StringBuilder()
-        val args = arrayOfNulls<String>(list.size)
-        for ((index, id) in list.withIndex()) {
-            if (index != 0) {
-                placeholders.append(",")
-            }
-            placeholders.append("?")
-            args[index] = id.toString()
-        }
-        val sql = "select * from $table where sid in (${placeholders})"
         val result = ArrayList<ProhibitWord>()
-        if (WKBaseApplication.getInstance().dbHelper != null) {
-            val cursor: Cursor = WKBaseApplication.getInstance().dbHelper.rawQuery(sql, args)
-                ?: return result
-            run {
+        val helper = WKBaseApplication.getInstance().dbHelper ?: return result
+        if (helper.isClosed) return result
+        try {
+            val placeholders = StringBuilder()
+            val args = arrayOfNulls<String>(list.size)
+            for ((index, id) in list.withIndex()) {
+                if (index != 0) {
+                    placeholders.append(",")
+                }
+                placeholders.append("?")
+                args[index] = id.toString()
+            }
+            val sql = "select * from $table where sid in (${placeholders})"
+            val cursor: Cursor = helper.rawQuery(sql, args) ?: return result
+            cursor.use {
                 cursor.moveToFirst()
                 while (!cursor.isAfterLast) {
                     result.add(serialize(cursor))
                     cursor.moveToNext()
                 }
             }
-            cursor.close()
+        } catch (_: Exception) {
         }
         return result
     }

--- a/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
+++ b/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
@@ -950,6 +950,13 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
                 }
                 spaceConversationKeys.clear();
                 List<ChatConversationMsg> uiList = new ArrayList<>();
+                // 批量预加载 extras（草稿等），1 次 DB 查询替代 N 次
+                List<String> extraChannelIds = new ArrayList<>();
+                for (WKUIConversationMsg uiConversationMsg : list) {
+                    extraChannelIds.add(uiConversationMsg.channelID);
+                }
+                java.util.Map<String, WKConversationMsgExtra> extrasMap =
+                        WKIM.getInstance().getConversationManager().getMsgExtrasForChannels(extraChannelIds);
                 for (WKUIConversationMsg uiConversationMsg : list) {
                     // 私聊 Space 未读数适配：跨 Space 消息不计入未读（参考 iOS）
                     adjustPersonalForSpace(uiConversationMsg);
@@ -978,9 +985,8 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
                     if (reject) {
                         continue;
                     }
-                    // sync 结果不含 conversation_extra（草稿等），从本地 DB 补充
-                    WKConversationMsgExtra extra = WKIM.getInstance().getConversationManager()
-                            .getMsgExtraWithChannel(uiConversationMsg.channelID, uiConversationMsg.channelType);
+                    // sync 结果不含 conversation_extra（草稿等），从预加载的批量结果补充
+                    WKConversationMsgExtra extra = extrasMap.get(uiConversationMsg.channelID + ":" + uiConversationMsg.channelType);
                     if (extra != null) {
                         uiConversationMsg.setRemoteMsgExtra(extra);
                     }
@@ -1246,11 +1252,17 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
 
         // syncCoverExtra 完成后刷新草稿等 extra 信息
         EndpointManager.getInstance().setMethod("refresh_conversation_extras", object -> {
+            List<String> channelIds = new ArrayList<>();
+            for (int i = 0, size = chatConversationAdapter.getData().size(); i < size; i++) {
+                if (chatConversationAdapter.getData().get(i).isSectionHeader) continue;
+                channelIds.add(chatConversationAdapter.getData().get(i).uiConversationMsg.channelID);
+            }
+            java.util.Map<String, WKConversationMsgExtra> extrasMap =
+                    WKIM.getInstance().getConversationManager().getMsgExtrasForChannels(channelIds);
             for (int i = 0, size = chatConversationAdapter.getData().size(); i < size; i++) {
                 if (chatConversationAdapter.getData().get(i).isSectionHeader) continue;
                 WKUIConversationMsg convMsg = chatConversationAdapter.getData().get(i).uiConversationMsg;
-                WKConversationMsgExtra extra = WKIM.getInstance().getConversationManager()
-                        .getMsgExtraWithChannel(convMsg.channelID, convMsg.channelType);
+                WKConversationMsgExtra extra = extrasMap.get(convMsg.channelID + ":" + convMsg.channelType);
                 if (extra != null) {
                     convMsg.setRemoteMsgExtra(extra);
                     chatConversationAdapter.getData().get(i).isResetContent = true;
@@ -1993,12 +2005,21 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
      * 在 onResume 中调用，确保无论 syncCoverExtra 何时完成都能显示草稿。
      */
     private void refreshExtrasIfNeeded() {
+        // 批量预加载需要补充草稿的 extras
+        List<String> channelIds = new ArrayList<>();
+        for (ChatConversationMsg allMsg : allConversations) {
+            WKUIConversationMsg convMsg = allMsg.uiConversationMsg;
+            if (convMsg.getRemoteMsgExtra() == null || TextUtils.isEmpty(convMsg.getRemoteMsgExtra().draft)) {
+                channelIds.add(convMsg.channelID);
+            }
+        }
+        java.util.Map<String, WKConversationMsgExtra> extrasMap =
+                WKIM.getInstance().getConversationManager().getMsgExtrasForChannels(channelIds);
         // 刷新 allConversations（覆盖所有 tab 的会话）
         for (ChatConversationMsg allMsg : allConversations) {
             WKUIConversationMsg convMsg = allMsg.uiConversationMsg;
             if (convMsg.getRemoteMsgExtra() == null || TextUtils.isEmpty(convMsg.getRemoteMsgExtra().draft)) {
-                WKConversationMsgExtra extra = WKIM.getInstance().getConversationManager()
-                        .getMsgExtraWithChannel(convMsg.channelID, convMsg.channelType);
+                WKConversationMsgExtra extra = extrasMap.get(convMsg.channelID + ":" + convMsg.channelType);
                 if (extra != null && !TextUtils.isEmpty(extra.draft)) {
                     convMsg.setRemoteMsgExtra(extra);
                     allMsg.isResetContent = true;

--- a/wkuikit/src/main/java/com/chat/uikit/group/RemindMemberAdapter.java
+++ b/wkuikit/src/main/java/com/chat/uikit/group/RemindMemberAdapter.java
@@ -32,6 +32,8 @@ import com.chat.base.external.ExternalViewerResolver;
 import com.chat.base.ui.Theme;
 import com.chat.base.ui.components.AvatarView;
 import com.chat.base.utils.StringUtils;
+import androidx.recyclerview.widget.RecyclerView;
+
 import com.chat.base.views.NoEventRecycleView;
 import com.chat.uikit.R;
 import com.xinbida.wukongim.WKIM;
@@ -201,7 +203,10 @@ public class RemindMemberAdapter extends BaseQuickAdapter<GroupMemberEntity, Bas
         } else {
             addData(memberList);
         }
-        ((NoEventRecycleView) getRecyclerView()).setItemCount(getItemCount());
+        RecyclerView rv = getRecyclerView();
+        if (rv instanceof NoEventRecycleView) {
+            ((NoEventRecycleView) rv).setItemCount(getItemCount());
+        }
     }
 
     public String getSearchKey() {

--- a/wkuikit/src/main/java/com/chat/uikit/user/MyHeadPortraitActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/user/MyHeadPortraitActivity.java
@@ -165,6 +165,7 @@ public class MyHeadPortraitActivity extends WKBaseActivity<ActMyHeadPortraitLayo
             @Override
             public void onBack(List<ChooseResult> paths) {
                 if (WKReader.isNotEmpty(paths)) {
+                    if (isFinishing() || isDestroyed()) return;
                     String path = paths.get(0).path;
                     if (!TextUtils.isEmpty(path)) {
                         Intent intent;

--- a/wkuikit/src/main/java/com/chat/uikit/user/UserDetailActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/user/UserDetailActivity.java
@@ -756,6 +756,7 @@ public class UserDetailActivity extends WKBaseActivity<ActUserDetailLayoutBindin
                     @Override
                     public void onBack(List<ChooseResult> paths) {
                         if (!WKReader.isNotEmpty(paths)) return;
+                        if (isFinishing() || isDestroyed()) return;
                         String path = paths.get(0).path;
                         if (TextUtils.isEmpty(path)) return;
                         Intent intent;


### PR DESCRIPTION
## Summary

- **图文混排 @mention 高亮 + 点击跳转**：发送侧编码 `mention.entities`，接收侧 `WKRichTextProvider` 渲染高亮可点击的 @mention（含 @所有人/@所有AI 广播标签），点击跳转个人名片页面，对齐 iOS 端行为
- **Bugly 崩溃修复（7 项）**：ContactEditText 粘贴 NPE、ChatActivity refreshMsg 越界、OPPO Push ClassNotFound、RemindMemberAdapter ClassCast、ProhibitWordDB 连接池关闭、UserDetailActivity/MyHeadPortraitActivity 未注册 Launcher
- **DB 性能优化**：批量查询替代循环单查（`getMsgExtrasForChannels`）、`getMemberOfFromIfCached` 避免刷新回调触发主线程 DB 查询、DB 方法统一 try-catch 防连接池关闭崩溃
- **ProGuard 规则**：补充 `thread.msgmodel` keep 规则防止 release 包混淆崩溃
- **版本号**：1.3.1 (32) → 1.3.2 (33)

## Test plan

- [ ] 群聊中发送带 @mention 的图文混排消息，确认 @mention 高亮显示（紫色+粗体）
- [ ] 点击高亮 @mention 跳转到个人名片页面
- [ ] @所有人/@所有AI 只高亮不可点击
- [ ] 纯文本消息 @mention 仍正常工作（无回归）
- [ ] 无 mention 的图文混排消息正常渲染
- [ ] 剪贴板为空时粘贴不崩溃
- [ ] OPPO 设备推送初始化失败不崩溃
- [ ] 会话列表加载、频道刷新无 ANR
- [ ] release 包混淆后正常运行

🤖 Generated with [Claude Code](https://claude.com/claude-code)