### PR TITLE
fix: crash fixes and bot revoke permission

### DIFF
--- a/wkbase/src/main/java/com/chat/base/common/WKCommonModel.java
+++ b/wkbase/src/main/java/com/chat/base/common/WKCommonModel.java
@@ -217,6 +217,14 @@ public class WKCommonModel extends WKBaseModel {
                 wkChannel.remoteExtraMap = new HashMap<>();
             }
             wkChannel.remoteExtraMap.put("bot_creator_uid", entity.bot_creator_uid);
+        } else if (localChannel != null && localChannel.remoteExtraMap != null) {
+            Object creatorUid = localChannel.remoteExtraMap.get("bot_creator_uid");
+            if (creatorUid instanceof String && ((String) creatorUid).length() > 0) {
+                if (wkChannel.remoteExtraMap == null) {
+                    wkChannel.remoteExtraMap = new HashMap<>();
+                }
+                wkChannel.remoteExtraMap.put("bot_creator_uid", creatorUid);
+            }
         }
         hashMap.put(WKChannelExtras.beDeleted, entity.be_deleted);
         hashMap.put(WKChannelExtras.beBlacklist, entity.be_blacklist);

--- a/wkbase/src/main/java/com/chat/base/common/WKCommonModel.java
+++ b/wkbase/src/main/java/com/chat/base/common/WKCommonModel.java
@@ -211,6 +211,16 @@ public class WKCommonModel extends WKBaseModel {
             }
             wkChannel.remoteExtraMap.put("space_id", entity.space_id);
         }
+        // bot_creator_uid 由 /users/{uid} 写入本地，channels API 可能不返回；保留已有值
+        if (localChannel != null && localChannel.remoteExtraMap != null) {
+            Object creatorUid = localChannel.remoteExtraMap.get("bot_creator_uid");
+            if (creatorUid instanceof String && ((String) creatorUid).length() > 0) {
+                if (wkChannel.remoteExtraMap == null) {
+                    wkChannel.remoteExtraMap = new HashMap<>();
+                }
+                wkChannel.remoteExtraMap.putIfAbsent("bot_creator_uid", creatorUid);
+            }
+        }
         hashMap.put(WKChannelExtras.beDeleted, entity.be_deleted);
         hashMap.put(WKChannelExtras.beBlacklist, entity.be_blacklist);
         hashMap.put(WKChannelExtras.notice, entity.notice);

--- a/wkbase/src/main/java/com/chat/base/common/WKCommonModel.java
+++ b/wkbase/src/main/java/com/chat/base/common/WKCommonModel.java
@@ -216,14 +216,14 @@ public class WKCommonModel extends WKBaseModel {
             if (wkChannel.remoteExtraMap == null) {
                 wkChannel.remoteExtraMap = new HashMap<>();
             }
-            wkChannel.remoteExtraMap.put("bot_creator_uid", entity.bot_creator_uid);
+            wkChannel.remoteExtraMap.put(WKChannelExtras.botCreatorUid, entity.bot_creator_uid);
         } else if (localChannel != null && localChannel.remoteExtraMap != null) {
-            Object creatorUid = localChannel.remoteExtraMap.get("bot_creator_uid");
+            Object creatorUid = localChannel.remoteExtraMap.get(WKChannelExtras.botCreatorUid);
             if (creatorUid instanceof String && ((String) creatorUid).length() > 0) {
                 if (wkChannel.remoteExtraMap == null) {
                     wkChannel.remoteExtraMap = new HashMap<>();
                 }
-                wkChannel.remoteExtraMap.put("bot_creator_uid", creatorUid);
+                wkChannel.remoteExtraMap.put(WKChannelExtras.botCreatorUid, creatorUid);
             }
         }
         hashMap.put(WKChannelExtras.beDeleted, entity.be_deleted);

--- a/wkbase/src/main/java/com/chat/base/common/WKCommonModel.java
+++ b/wkbase/src/main/java/com/chat/base/common/WKCommonModel.java
@@ -211,15 +211,12 @@ public class WKCommonModel extends WKBaseModel {
             }
             wkChannel.remoteExtraMap.put("space_id", entity.space_id);
         }
-        // bot_creator_uid 由 /users/{uid} 写入本地，channels API 可能不返回；保留已有值
-        if (localChannel != null && localChannel.remoteExtraMap != null) {
-            Object creatorUid = localChannel.remoteExtraMap.get("bot_creator_uid");
-            if (creatorUid instanceof String && ((String) creatorUid).length() > 0) {
-                if (wkChannel.remoteExtraMap == null) {
-                    wkChannel.remoteExtraMap = new HashMap<>();
-                }
-                wkChannel.remoteExtraMap.putIfAbsent("bot_creator_uid", creatorUid);
+        // bot_creator_uid 同样是顶层字段（仅 robot channel 下发），存入 remoteExtraMap
+        if (!TextUtils.isEmpty(entity.bot_creator_uid)) {
+            if (wkChannel.remoteExtraMap == null) {
+                wkChannel.remoteExtraMap = new HashMap<>();
             }
+            wkChannel.remoteExtraMap.put("bot_creator_uid", entity.bot_creator_uid);
         }
         hashMap.put(WKChannelExtras.beDeleted, entity.be_deleted);
         hashMap.put(WKChannelExtras.beBlacklist, entity.be_blacklist);

--- a/wkbase/src/main/java/com/chat/base/entity/ChannelInfoEntity.java
+++ b/wkbase/src/main/java/com/chat/base/entity/ChannelInfoEntity.java
@@ -45,6 +45,7 @@ public class ChannelInfoEntity {
     public int flame_second;
     public int device_flag;
     public String space_id;
+    public String bot_creator_uid;
     public Map extra;
 
 

--- a/wkbase/src/main/java/com/chat/base/msgitem/WKChatBaseProvider.kt
+++ b/wkbase/src/main/java/com/chat/base/msgitem/WKChatBaseProvider.kt
@@ -1231,13 +1231,25 @@ abstract class WKChatBaseProvider : BaseItemProvider<WKUIChatMsgItemEntity>() {
                 isManager = true
             }
         }
+
+        val isBotOwner = isBotOwner(mMsg)
+
         var revokeSecond = WKConfig.getInstance().appConfig.revoke_second
-        if (revokeSecond == -1 && (mMsg.fromUID == WKConfig.getInstance().uid || isManager)) {
+        if (revokeSecond == -1 && (mMsg.fromUID == WKConfig.getInstance().uid || isManager || isBotOwner)) {
             return true
         }
         if (revokeSecond == 0) revokeSecond = 120
         return (WKTimeUtils.getInstance().currentSeconds - mMsg.timestamp < revokeSecond
-                && mMsg.fromUID == WKConfig.getInstance().uid && mMsg.status == WKSendMsgResult.send_success) || (isManager && mMsg.status == WKSendMsgResult.send_success)
+                && (mMsg.fromUID == WKConfig.getInstance().uid || isBotOwner) && mMsg.status == WKSendMsgResult.send_success) || (isManager && mMsg.status == WKSendMsgResult.send_success)
+    }
+
+    private fun isBotOwner(mMsg: WKMsg): Boolean {
+        val loginUid = WKConfig.getInstance().uid
+        if (mMsg.fromUID == loginUid) return false
+        val fromChannel = mMsg.from ?: return false
+        if (fromChannel.robot != 1) return false
+        val creatorUid = fromChannel.remoteExtraMap?.get("bot_creator_uid") as? String
+        return !TextUtils.isEmpty(creatorUid) && creatorUid == loginUid
     }
 
     open fun getMsgConfig(msgType: Int): MsgConfig {

--- a/wkbase/src/main/java/com/chat/base/msgitem/WKChatBaseProvider.kt
+++ b/wkbase/src/main/java/com/chat/base/msgitem/WKChatBaseProvider.kt
@@ -101,6 +101,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.xinbida.wukongim.WKIM
 import com.xinbida.wukongim.entity.WKChannel
 import com.xinbida.wukongim.entity.WKChannelType
+import com.xinbida.wukongim.entity.WKChannelExtras
 import com.xinbida.wukongim.entity.WKMsg
 import com.xinbida.wukongim.entity.WKSendOptions
 import com.xinbida.wukongim.message.type.WKSendMsgResult
@@ -1248,7 +1249,7 @@ abstract class WKChatBaseProvider : BaseItemProvider<WKUIChatMsgItemEntity>() {
         if (mMsg.fromUID == loginUid) return false
         val fromChannel = mMsg.from ?: return false
         if (fromChannel.robot != 1) return false
-        val creatorUid = fromChannel.remoteExtraMap?.get("bot_creator_uid") as? String
+        val creatorUid = fromChannel.remoteExtraMap?.get(WKChannelExtras.botCreatorUid) as? String
         return !TextUtils.isEmpty(creatorUid) && creatorUid == loginUid
     }
 

--- a/wkim/src/main/java/com/xinbida/wukongim/entity/WKChannelExtras.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/entity/WKChannelExtras.java
@@ -30,4 +30,6 @@ public class WKChannelExtras {
     public final static String allowViewHistoryMsg = "allow_view_history_msg";
     // 群类型
     public final static String groupType = "group_type";
+    // Bot 创建者 uid
+    public final static String botCreatorUid = "bot_creator_uid";
 }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -1523,6 +1523,13 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
             if (channel == null) return;
             if (channel.channelID.equals(channelId) && channel.channelType == channelType) { //同一个会话
                 showChannelName(channel);
+                if (channelType == WKChannelType.PERSONAL) {
+                    for (int i = 0, size = chatAdapter.getData().size(); i < size; i++) {
+                        if (channel.channelID.equals(chatAdapter.getData().get(i).wkMsg.fromUID)) {
+                            chatAdapter.getData().get(i).wkMsg.setFrom(channel);
+                        }
+                    }
+                }
                 if (channelType == WKChannelType.COMMUNITY_TOPIC) {
                     wkVBinding.topLayout.avatarView.defaultAvatarTv.setVisibility(View.GONE);
                     wkVBinding.topLayout.avatarView.imageView.setVisibility(View.VISIBLE);

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -1784,6 +1784,7 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         MsgModel.getInstance().syncExtraMsg(channelId, channelType);
         WKRobotModel.getInstance().syncRobotData(getChatChannelInfo());
         getChannelState();
+        prefetchBotCreatorUids();
 
         // : do NOT clear the adapter here. The previous setList(empty)
         // caused a visible white-screen flash while getData() is waiting on
@@ -1848,6 +1849,7 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                         hideOrShowRightView(member == null || member.isDeleted != 1);
                         WKRobotModel.getInstance().syncRobotData(getChatChannelInfo());
                         chatPanelManager.showOrHideForbiddenView();
+                        prefetchBotCreatorUids();
                     }
                 });
             } else {
@@ -2774,6 +2776,26 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         if (channelType == WKChannelType.GROUP) {
             WKChannelMember member = WKIM.getInstance().getChannelMembersManager().getMember(channelId, channelType, loginUID);
             hideOrShowRightView(member == null || member.isDeleted == 0);
+        }
+    }
+
+    private void prefetchBotCreatorUids() {
+        if (channelType == WKChannelType.PERSONAL) {
+            WKChannel channel = WKIM.getInstance().getChannelManager().getChannel(channelId, channelType);
+            if (channel != null && channel.robot == 1
+                    && (channel.remoteExtraMap == null || !channel.remoteExtraMap.containsKey("bot_creator_uid"))) {
+                UserModel.getInstance().getUserInfo(channelId, "", null);
+            }
+        } else if (channelType == WKChannelType.GROUP || channelType == WKChannelType.COMMUNITY_TOPIC) {
+            List<WKChannelMember> robotMembers = WKIM.getInstance().getChannelMembersManager().getRobotMembers(channelId, channelType);
+            if (WKReader.isNotEmpty(robotMembers)) {
+                for (WKChannelMember bot : robotMembers) {
+                    WKChannel botChannel = WKIM.getInstance().getChannelManager().getChannel(bot.memberUID, WKChannelType.PERSONAL);
+                    if (botChannel == null || botChannel.remoteExtraMap == null || !botChannel.remoteExtraMap.containsKey("bot_creator_uid")) {
+                        UserModel.getInstance().getUserInfo(bot.memberUID, "", null);
+                    }
+                }
+            }
         }
     }
 

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -1525,8 +1525,9 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                 showChannelName(channel);
                 if (channelType == WKChannelType.PERSONAL) {
                     for (int i = 0, size = chatAdapter.getData().size(); i < size; i++) {
-                        if (channel.channelID.equals(chatAdapter.getData().get(i).wkMsg.fromUID)) {
-                            chatAdapter.getData().get(i).wkMsg.setFrom(channel);
+                        WKMsg msg = chatAdapter.getData().get(i).wkMsg;
+                        if (msg != null && channel.channelID.equals(msg.fromUID)) {
+                            msg.setFrom(channel);
                         }
                     }
                 }
@@ -2786,11 +2787,14 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         }
     }
 
+    private final java.util.Set<String> botCreatorFetchedUids = new java.util.HashSet<>();
+
     private void prefetchBotCreatorUids() {
         if (channelType == WKChannelType.PERSONAL) {
             WKChannel channel = WKIM.getInstance().getChannelManager().getChannel(channelId, channelType);
             if (channel != null && channel.robot == 1
-                    && (channel.remoteExtraMap == null || !channel.remoteExtraMap.containsKey("bot_creator_uid"))) {
+                    && (channel.remoteExtraMap == null || !channel.remoteExtraMap.containsKey(WKChannelExtras.botCreatorUid))
+                    && botCreatorFetchedUids.add(channelId)) {
                 UserModel.getInstance().getUserInfo(channelId, "", null);
             }
         } else if (channelType == WKChannelType.GROUP || channelType == WKChannelType.COMMUNITY_TOPIC) {
@@ -2798,7 +2802,8 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
             if (WKReader.isNotEmpty(robotMembers)) {
                 for (WKChannelMember bot : robotMembers) {
                     WKChannel botChannel = WKIM.getInstance().getChannelManager().getChannel(bot.memberUID, WKChannelType.PERSONAL);
-                    if (botChannel == null || botChannel.remoteExtraMap == null || !botChannel.remoteExtraMap.containsKey("bot_creator_uid")) {
+                    if ((botChannel == null || botChannel.remoteExtraMap == null || !botChannel.remoteExtraMap.containsKey(WKChannelExtras.botCreatorUid))
+                            && botCreatorFetchedUids.add(bot.memberUID)) {
                         UserModel.getInstance().getUserInfo(bot.memberUID, "", null);
                     }
                 }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKVideoProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKVideoProvider.kt
@@ -231,6 +231,7 @@ class WKVideoProvider : WKChatBaseProvider() {
     ) {
         super.resetCellListener(position, parentView, uiChatMsgItemEntity, from)
         val coverImageView = parentView.findViewById<FilterImageView>(R.id.coverImageView)
+            ?: return
         addLongClick(coverImageView, uiChatMsgItemEntity)
     }
 

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKVideoProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKVideoProvider.kt
@@ -70,7 +70,9 @@ class WKVideoProvider : WKChatBaseProvider() {
             return
         }
         val coverImageView = parentView.findViewById<FilterImageView>(R.id.coverImageView)
+            ?: return
         val blurView = parentView.findViewById<ShapeBlurView>(R.id.blurView)
+            ?: return
         setCorners(from, uiChatMsgItemEntity, coverImageView, blurView)
 
         val progressTv = parentView.findViewById<TextView>(R.id.progressTv)

--- a/wkuikit/src/main/java/com/chat/uikit/contacts/service/FriendModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/contacts/service/FriendModel.java
@@ -168,6 +168,13 @@ public class FriendModel extends WKBaseModel {
                         hashMap.put(WKChannelExtras.sourceDesc, list.get(i).source_desc);
                         hashMap.put(WKChannelExtras.chatPwdOn, list.get(i).chat_pwd_on);
                         hashMap.put(WKChannelExtras.vercode, list.get(i).vercode);
+                        WKChannel existing = WKIM.getInstance().getChannelManager().getChannel(channel.channelID, channel.channelType);
+                        if (existing != null && existing.remoteExtraMap != null) {
+                            Object creatorUid = existing.remoteExtraMap.get(WKChannelExtras.botCreatorUid);
+                            if (creatorUid instanceof String && ((String) creatorUid).length() > 0) {
+                                hashMap.put(WKChannelExtras.botCreatorUid, creatorUid);
+                            }
+                        }
                         channel.remoteExtraMap = hashMap;
                         channels.add(channel);
                         if (list.get(i).version > tempVersion) {

--- a/wkuikit/src/main/java/com/chat/uikit/fragment/MyFragment.java
+++ b/wkuikit/src/main/java/com/chat/uikit/fragment/MyFragment.java
@@ -48,6 +48,8 @@ import java.util.List;
 public class MyFragment extends WKBaseFragment<FragMyLayoutBinding> {
     private PersonalItemAdapter adapter;
     private boolean isAppConfigLoaded = false;
+    private final android.os.Handler longPressHandler = new android.os.Handler(android.os.Looper.getMainLooper());
+    private Runnable longPressRunnable;
 
     @Override
     protected FragMyLayoutBinding getViewBinding() {
@@ -102,8 +104,7 @@ public class MyFragment extends WKBaseFragment<FragMyLayoutBinding> {
         }));
         SingleClickUtil.onSingleClick(wkVBinding.cardLayout, view -> gotoMyInfo());
         // 隐藏入口：长按头像 3 秒修改 API 地址
-        final android.os.Handler longPressHandler = new android.os.Handler(android.os.Looper.getMainLooper());
-        final Runnable longPressRunnable = () -> {
+        longPressRunnable = () -> {
             if (getActivity() == null) return;
             ApiUrlDialog dialog = new ApiUrlDialog(getActivity());
             dialog.setOnConfirmListener(url -> {
@@ -133,6 +134,12 @@ public class MyFragment extends WKBaseFragment<FragMyLayoutBinding> {
 
     void gotoMyInfo() {
         startActivity(new Intent(getActivity(), MyInfoActivity.class));
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        longPressHandler.removeCallbacks(longPressRunnable);
     }
 
     @Override

--- a/wkuikit/src/main/java/com/chat/uikit/fragment/MyFragment.java
+++ b/wkuikit/src/main/java/com/chat/uikit/fragment/MyFragment.java
@@ -143,6 +143,12 @@ public class MyFragment extends WKBaseFragment<FragMyLayoutBinding> {
     }
 
     @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        longPressHandler.removeCallbacks(longPressRunnable);
+    }
+
+    @Override
     public void onResume() {
         super.onResume();
         //  (#227)：displayName 合并 —— 实名态下用 realname，否则用 nickname

--- a/wkuikit/src/main/java/com/chat/uikit/user/service/UserModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/user/service/UserModel.java
@@ -409,11 +409,13 @@ public class UserModel extends WKBaseModel {
                 }
                 if (result.robot == 1 && !TextUtils.isEmpty(result.bot_creator_uid)) {
                     WKChannel ch = WKIM.getInstance().getChannelManager().getChannel(uid, WKChannelType.PERSONAL);
-                    if (ch != null) {
-                        if (ch.remoteExtraMap == null) ch.remoteExtraMap = new java.util.HashMap<>();
-                        ch.remoteExtraMap.put("bot_creator_uid", result.bot_creator_uid);
-                        WKIM.getInstance().getChannelManager().saveOrUpdateChannel(ch);
+                    if (ch == null) {
+                        ch = new WKChannel(uid, WKChannelType.PERSONAL);
+                        ch.channelName = result.name;
                     }
+                    if (ch.remoteExtraMap == null) ch.remoteExtraMap = new java.util.HashMap<>();
+                    ch.remoteExtraMap.put("bot_creator_uid", result.bot_creator_uid);
+                    WKIM.getInstance().getChannelManager().saveOrUpdateChannel(ch);
                 }
                 if (iUserInfo != null) {
                     iUserInfo.onResult(HttpResponseCode.success, "", result);

--- a/wkuikit/src/main/java/com/chat/uikit/user/service/UserModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/user/service/UserModel.java
@@ -407,6 +407,14 @@ public class UserModel extends WKBaseModel {
                     WKChannelMember member = buildMemberFromUserInfo(result.group_member);
                     WKIM.getInstance().getChannelMembersManager().save(member);
                 }
+                if (result.robot == 1 && !TextUtils.isEmpty(result.bot_creator_uid)) {
+                    WKChannel ch = WKIM.getInstance().getChannelManager().getChannel(uid, WKChannelType.PERSONAL);
+                    if (ch != null) {
+                        if (ch.remoteExtraMap == null) ch.remoteExtraMap = new java.util.HashMap<>();
+                        ch.remoteExtraMap.put("bot_creator_uid", result.bot_creator_uid);
+                        WKIM.getInstance().getChannelManager().saveOrUpdateChannel(ch);
+                    }
+                }
                 if (iUserInfo != null) {
                     iUserInfo.onResult(HttpResponseCode.success, "", result);
                 }

--- a/wkuikit/src/main/java/com/chat/uikit/user/service/UserModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/user/service/UserModel.java
@@ -50,6 +50,7 @@ import com.chat.uikit.enity.VerifyTokenResponse;
 import com.chat.uikit.group.service.entity.GroupMember;
 import com.xinbida.wukongim.WKIM;
 import com.xinbida.wukongim.entity.WKChannel;
+import com.xinbida.wukongim.entity.WKChannelExtras;
 import com.xinbida.wukongim.entity.WKChannelMember;
 import com.xinbida.wukongim.entity.WKChannelMemberExtras;
 import com.xinbida.wukongim.entity.WKChannelType;
@@ -412,9 +413,10 @@ public class UserModel extends WKBaseModel {
                     if (ch == null) {
                         ch = new WKChannel(uid, WKChannelType.PERSONAL);
                         ch.channelName = result.name;
+                        ch.robot = 1;
                     }
                     if (ch.remoteExtraMap == null) ch.remoteExtraMap = new java.util.HashMap<>();
-                    ch.remoteExtraMap.put("bot_creator_uid", result.bot_creator_uid);
+                    ch.remoteExtraMap.put(WKChannelExtras.botCreatorUid, result.bot_creator_uid);
                     WKIM.getInstance().getChannelManager().saveOrUpdateChannel(ch);
                 }
                 if (iUserInfo != null) {

--- a/wkuikit/src/main/java/com/chat/uikit/user/service/UserModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/user/service/UserModel.java
@@ -408,7 +408,7 @@ public class UserModel extends WKBaseModel {
                     WKChannelMember member = buildMemberFromUserInfo(result.group_member);
                     WKIM.getInstance().getChannelMembersManager().save(member);
                 }
-                if (result.robot == 1) {
+                if (result.robot == 1 && !TextUtils.isEmpty(result.bot_creator_uid)) {
                     WKChannel ch = WKIM.getInstance().getChannelManager().getChannel(uid, WKChannelType.PERSONAL);
                     if (ch == null) {
                         ch = new WKChannel(uid, WKChannelType.PERSONAL);
@@ -416,8 +416,7 @@ public class UserModel extends WKBaseModel {
                         ch.robot = 1;
                     }
                     if (ch.remoteExtraMap == null) ch.remoteExtraMap = new java.util.HashMap<>();
-                    String creatorUid = TextUtils.isEmpty(result.bot_creator_uid) ? "" : result.bot_creator_uid;
-                    ch.remoteExtraMap.put(WKChannelExtras.botCreatorUid, creatorUid);
+                    ch.remoteExtraMap.put(WKChannelExtras.botCreatorUid, result.bot_creator_uid);
                     WKIM.getInstance().getChannelManager().saveOrUpdateChannel(ch);
                 }
                 if (iUserInfo != null) {

--- a/wkuikit/src/main/java/com/chat/uikit/user/service/UserModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/user/service/UserModel.java
@@ -408,7 +408,7 @@ public class UserModel extends WKBaseModel {
                     WKChannelMember member = buildMemberFromUserInfo(result.group_member);
                     WKIM.getInstance().getChannelMembersManager().save(member);
                 }
-                if (result.robot == 1 && !TextUtils.isEmpty(result.bot_creator_uid)) {
+                if (result.robot == 1) {
                     WKChannel ch = WKIM.getInstance().getChannelManager().getChannel(uid, WKChannelType.PERSONAL);
                     if (ch == null) {
                         ch = new WKChannel(uid, WKChannelType.PERSONAL);
@@ -416,7 +416,8 @@ public class UserModel extends WKBaseModel {
                         ch.robot = 1;
                     }
                     if (ch.remoteExtraMap == null) ch.remoteExtraMap = new java.util.HashMap<>();
-                    ch.remoteExtraMap.put(WKChannelExtras.botCreatorUid, result.bot_creator_uid);
+                    String creatorUid = TextUtils.isEmpty(result.bot_creator_uid) ? "" : result.bot_creator_uid;
+                    ch.remoteExtraMap.put(WKChannelExtras.botCreatorUid, creatorUid);
                     WKIM.getInstance().getChannelManager().saveOrUpdateChannel(ch);
                 }
                 if (iUserInfo != null) {


### PR DESCRIPTION
## Summary
- Fix NPE in WKVideoProvider.resetCellListener when view is recycled during partial refresh (Bugly #11047)
- Allow bot owner to revoke messages sent by their own bot, aligning with iOS implementation (Closes #43)
- Cancel server config dialog trigger when navigating away from MyFragment

## Test plan
- [ ] Send a video message, trigger partial refresh (e.g. status change) — no crash
- [ ] Create a bot, send a message in group, long-press — revoke option appears and works
- [ ] On "Me" page, tap avatar to enter profile, press back — no server config dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)