### PR TITLE
fix: space 校验 + 冷启动 + UI 优化批次

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
         applicationId appId
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 34
-        versionName "1.3.3"
+        versionCode 35
+        versionName "1.3.4"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/octoim/app/TSApplication.kt
+++ b/app/src/main/java/com/octoim/app/TSApplication.kt
@@ -61,6 +61,9 @@ class TSApplication : MultiDexApplication() {
             val defaultProcess = processName == getAppPackageName()
             if (defaultProcess) {
                 initAll()
+                // Space 串消息排查: 启动初始上下文 dump. 仅当用户开启过诊断模式才会真正落盘
+                // (DiagSink.isEnabled() 内部 gate, 未开启即纳秒级 no-op).
+                logBootDiagnostics(processName)
             }
         }
         registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
@@ -266,6 +269,49 @@ class TSApplication : MultiDexApplication() {
                 NotificationManager::class.java
             )
             notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    /**
+     * Space 串消息排查: 启动时把决策上下文 dump 到诊断日志, 让我们 review 时不用问
+     * 用户"重启时 currentSpaceId 是什么".
+     *
+     * <p>DiagSink 内部 gate, 未开启诊断模式时这些调用是纳秒级 no-op, 不影响冷启动耗时.
+     */
+    private fun logBootDiagnostics(processName: String) {
+        try {
+            com.chat.base.utils.DiagSink.write(
+                "BOOT",
+                "process=" + processName +
+                    " sdk=" + Build.VERSION.SDK_INT +
+                    " device=" + Build.MANUFACTURER + "/" + Build.MODEL +
+                    " appPkg=" + getAppPackageName()
+            )
+        } catch (t: Throwable) {
+            // 防御性: BOOT 路径不能因诊断日志失败而崩
+        }
+        try {
+            val uid = WKConfig.getInstance().uid ?: ""
+            val currentSpaceId = com.chat.base.space.SpaceFilter.getCurrentSpaceId()
+            val currentSpaceName = com.chat.base.space.SpaceNameLookup.nameOf(currentSpaceId)
+            // appconfig 可能还未加载, 容错读
+            val sysBotsCount = try {
+                WKConfig.getInstance().appConfig?.system_bot_uids?.size ?: -1
+            } catch (t: Throwable) {
+                -1
+            }
+            com.chat.base.utils.DiagSink.write(
+                "BOOT",
+                "uid.len=" + uid.length +
+                    " currentSpaceId='" + currentSpaceId + "'" +
+                    " currentSpaceName='" + (currentSpaceName ?: "") + "'" +
+                    " systemBotsCount=" + sysBotsCount
+            )
+        } catch (t: Throwable) {
+            com.chat.base.utils.DiagSink.write(
+                "BOOT",
+                "read uid/space failed: " + t.javaClass.simpleName + ":" + t.message
+            )
         }
     }
 

--- a/wkbase/src/main/java/com/chat/base/WKBaseApplication.java
+++ b/wkbase/src/main/java/com/chat/base/WKBaseApplication.java
@@ -103,6 +103,14 @@ public class WKBaseApplication {
         // AES256-GCM / KeyStore 握手（50-150ms）搬出主线程。
         WKSharedPreferencesUtil.prewarm();
 
+        // Space 串消息排查诊断器(2026-06): 早初始化, 让后续启动链路上的 SF / BOOT 埋点
+        // 一旦上一次会话开启了诊断模式(SP 持久化), 就能立刻开始采集. 不会触发 IO, 仅起
+        // HandlerThread + 读 SP, 不阻塞主线程.
+        com.chat.base.utils.DiagSink.init(context);
+        // 桥接 wkim SDK 内部诊断埋点 → DiagSink. wkim 不能反向依赖 wkbase, 通过 install-pattern
+        // 让 ConversationManager 等 SDK 内部模块的 MEMBERSHIP 状态变更也能写到统一诊断文件.
+        com.xinbida.wukongim.diag.WKDiagWriter.install(com.chat.base.utils.DiagSink::write);
+
         float density = context.getResources().getDisplayMetrics().density;
         AndroidUtilities.setDensity(density);
 

--- a/wkbase/src/main/java/com/chat/base/common/WKCommonModel.java
+++ b/wkbase/src/main/java/com/chat/base/common/WKCommonModel.java
@@ -160,11 +160,14 @@ public class WKCommonModel extends WKBaseModel {
         WKChannel localChannel = WKIM.getInstance().getChannelManager().getChannel(entity.channel.channel_id, entity.channel.channel_type);
         boolean isRefreshContacts = false;
         if (localChannel != null && !TextUtils.isEmpty(localChannel.channelID)) {
-            // 复用已有的 avatarCacheKey；若为空则首次生成，作为 MyGlideUrlWithId 的稳定 cache key。
+            // avatarCacheKey 优先级：服务端 > 本地已有 > 新生成兜底。
+            // 服务端在头像变更时翻 avatar_cache_key 版本号，客户端透传即可让 URL 末尾的
+            // ?v=<key> 变化，绕开 Glide 缓存，实现自动刷新。
             // 不能每次都生成新 key：saveChannel 触发 refreshChannelInfo → adapter 重绘 →
             // fetchChannelInfo → saveChannel → 无限循环。只在首次为空时生成一次即可打破。
-            // -P-03: avatarCacheKey 改由服务端头像变更时翻版本号驱动；本地只负责在缺失时兜底生成。
-            if (!TextUtils.isEmpty(localChannel.avatarCacheKey)) {
+            if (!TextUtils.isEmpty(entity.avatar_cache_key)) {
+                wkChannel.avatarCacheKey = entity.avatar_cache_key;
+            } else if (!TextUtils.isEmpty(localChannel.avatarCacheKey)) {
                 wkChannel.avatarCacheKey = localChannel.avatarCacheKey;
             } else {
                 wkChannel.avatarCacheKey = UUID.randomUUID().toString().replaceAll("-", "");
@@ -174,8 +177,12 @@ public class WKCommonModel extends WKBaseModel {
             if (wkChannel.follow != entity.follow || wkChannel.status != entity.status)
                 isRefreshContacts = true;
         } else {
-            // 全新 channel，生成初始 avatarCacheKey
-            wkChannel.avatarCacheKey = UUID.randomUUID().toString().replaceAll("-", "");
+            // 全新 channel，优先用服务端值，缺失时兜底
+            if (!TextUtils.isEmpty(entity.avatar_cache_key)) {
+                wkChannel.avatarCacheKey = entity.avatar_cache_key;
+            } else {
+                wkChannel.avatarCacheKey = UUID.randomUUID().toString().replaceAll("-", "");
+            }
         }
         if (hashMap == null)
             hashMap = new HashMap<>();

--- a/wkbase/src/main/java/com/chat/base/entity/ChannelInfoEntity.java
+++ b/wkbase/src/main/java/com/chat/base/entity/ChannelInfoEntity.java
@@ -46,6 +46,7 @@ public class ChannelInfoEntity {
     public int device_flag;
     public String space_id;
     public String bot_creator_uid;
+    public String avatar_cache_key;
     public Map extra;
 
 

--- a/wkbase/src/main/java/com/chat/base/space/SpaceConversationPruner.java
+++ b/wkbase/src/main/java/com/chat/base/space/SpaceConversationPruner.java
@@ -38,8 +38,9 @@ import java.util.Set;
  * <ul>
  *     <li>不改 {@link SpaceFilter} 纯函数——本类只调用它做判定，不重新实现 7 分支逻辑。</li>
  *     <li>不写 WKSDK 持久化层——只裁内存 list / 白名单 Set，DB 回放时 SpaceFilter 会自然二次校验。</li>
- *     <li>PERSONAL 频道交给 {@link SpaceFilter#shouldSkipMessageForSpace} 做消息级过滤，
- *         本类不对私聊做 channel 级剔除，避免误杀跨 Space 共享的系统 Bot（如 botfather）。</li>
+ *     <li>PERSONAL 频道也走 prune（与 GROUP 对称）；{@link SpaceFilter} 的 person 分支
+ *         内部已对系统 Bot（botfather / u_10000 / fileHelper）白名单短路放行，
+ *         真人私聊 / 普通 AI 机器人按 last-msg.content.space_id 比对剔除。</li>
  * </ul>
  *
  * <p>Pattern 来源：iOS WKConversationListVM.pruneNonCurrentSpaceGroups（PR#95）扫
@@ -58,7 +59,9 @@ public final class SpaceConversationPruner {
      * <p>规则（与 iOS 对齐）：
      * <ul>
      *     <li>currentSpaceId 为空（非 Space 模式）→ 永不剔除</li>
-     *     <li>{@link WKChannelType#PERSONAL} → 永不剔除（交给消息级过滤 / SYSTEM_BOTS 兜底）</li>
+     *     <li>{@link WKChannelType#PERSONAL} → 调 {@link SpaceFilter#shouldSkipChannelForSpace}；
+     *         person 分支会先用 SystemBotsFallback 白名单短路（botfather / u_10000 / fileHelper
+     *         全 Space 显示），再读 last-msg.content.space_id 跟当前 Space 比对</li>
      *     <li>{@link WKChannelType#GROUP} → 调 {@link SpaceFilter#shouldSkipChannelForSpace}
      *         判定；Skip == true 则剔除</li>
      *     <li>其他 channelType（COMMUNITY_TOPIC 等）不走 prune 路径（上游已过滤）</li>
@@ -71,7 +74,7 @@ public final class SpaceConversationPruner {
                                       @NonNull SpaceFilter.ChannelInfoProvider provider) {
         if (channelID == null || channelID.isEmpty()) return false;
         if (currentSpaceId == null || currentSpaceId.isEmpty()) return false;
-        if (channelType != WKChannelType.GROUP) return false;
+        if (channelType != WKChannelType.GROUP && channelType != WKChannelType.PERSONAL) return false;
         return SpaceFilter.shouldSkipChannelForSpace(channelID, channelType, currentSpaceId, provider);
     }
 

--- a/wkbase/src/main/java/com/chat/base/space/SpaceFilter.java
+++ b/wkbase/src/main/java/com/chat/base/space/SpaceFilter.java
@@ -672,8 +672,12 @@ public final class SpaceFilter {
 
     /**
      * 私聊消息级 Space 过滤诊断日志. 跨 Space 私聊串消息的决策点必打 — 字段集与
-     * {@link #diagLog} 对齐, 多打消息自身元数据(发件人、内容前 60 字符片段)便于
-     * 用户能告诉我们"是哪条消息"加速定位.
+     * {@link #diagLog} 对齐, 多打消息自身元数据 (msgType / contentLen / contentHash /
+     * fromUid / clientMsgNo / messageSeq) 便于跨端比对定位"是哪条消息".
+     *
+     * <p>隐私: 不记录消息正文; 只记 content 长度与 hashCode (32-bit, 单向不可还原),
+     * 用于区分"同 fromUid+seq 但内容不同"的消息. 对齐 PR#75 review 反馈
+     * (redact-by-default), consent 文案无需声明采集消息正文.
      */
     private static void msgDiagLog(@Nullable WKMsg msg,
                                    @Nullable String currentSpaceId,
@@ -687,19 +691,20 @@ public final class SpaceFilter {
         try {
             String cid = msg == null ? "null" : msg.channelID;
             byte ct = msg == null ? -1 : msg.channelType;
+            int msgType = msg == null ? -1 : msg.type;
             String fromUid = msg == null ? "null" : msg.fromUID;
             String clientMsgNo = msg == null ? "null" : msg.clientMsgNO;
             long msgSeq = msg == null ? 0 : msg.messageSeq;
-            String contentSnippet = "";
-            if (msg != null && msg.content != null) {
-                int len = Math.min(msg.content.length(), 60);
-                contentSnippet = msg.content.substring(0, len).replace('\n', ' ').replace('\r', ' ');
-            }
+            int contentLen = (msg == null || msg.content == null) ? 0 : msg.content.length();
+            String contentHash = (msg == null || msg.content == null)
+                    ? "0"
+                    : Integer.toHexString(msg.content.hashCode());
             String curName = SpaceNameLookup.nameOf(currentSpaceId);
             String msgSpaceName = SpaceNameLookup.nameOf(msgSpaceId);
             String line = "branch=" + branch
                     + " skip=" + skip
                     + " channelID=" + cid + " channelType=" + ct
+                    + " msgType=" + msgType
                     + " fromUid=" + fromUid
                     + " clientMsgNo=" + clientMsgNo
                     + " msgSeq=" + msgSeq
@@ -707,7 +712,8 @@ public final class SpaceFilter {
                     + " currentSpaceName='" + (curName == null ? "" : curName) + '\''
                     + " msgSpaceId=" + msgSpaceId
                     + " msgSpaceName='" + (msgSpaceName == null ? "" : msgSpaceName) + '\''
-                    + " content[0..60]='" + contentSnippet + '\''
+                    + " contentLen=" + contentLen
+                    + " contentHash=" + contentHash
                     + " caller=" + callerOf();
             com.chat.base.utils.WKLogUtils.d(LOG_TAG, "SpaceFilter-Msg# " + line);
             com.chat.base.utils.DiagSink.write("SF-MSG", line);

--- a/wkbase/src/main/java/com/chat/base/space/SpaceFilter.java
+++ b/wkbase/src/main/java/com/chat/base/space/SpaceFilter.java
@@ -483,6 +483,7 @@ public final class SpaceFilter {
      * {@code TextUtils}），在 host-side 单元测试里会抛 "Stub!"；用 try/catch
      * 包住保证测试不被日志破坏（SpaceFilter 的纯函数路径必须保持 JVM-runnable）。
      */
+    @SuppressWarnings("RestrictedApi") // 诊断专用: 跨模块访问 wkim 内部 SpaceCacheStats, 排查结束后整段删除
     private static void diagLog(String channelID,
                                  byte channelType,
                                  @Nullable String currentSpaceId,

--- a/wkbase/src/main/java/com/chat/base/space/SpaceFilter.java
+++ b/wkbase/src/main/java/com/chat/base/space/SpaceFilter.java
@@ -465,8 +465,19 @@ public final class SpaceFilter {
      * <p>debug build 打印过滤决策全部关键变量：群 id / 归属 Space / 我自己的
      * source_space_id / 我的 row 是否已缓存 / 最终分支。用来定位「同账号
      * Web 端 2 个外部群全显示，Android 只显示 1 个」的数据缺失路径——
-     * 不猜逻辑，先让日志说话。Release build 自动 no-op（{@code WKLogUtils.d}
-     * 里判 {@code WKBinder.isDebug}）。
+     * 不猜逻辑，先让日志说话。
+     *
+     * <p><b>Space 串消息排查增强(2026-06)</b>: 除 {@code WKLogUtils.d}(仅 debug 进 logcat)
+     * 之外, 命中 {@link com.chat.base.utils.DiagSink#isEnabled()} 时同步写文件,
+     * release 包用户开启诊断模式后也能采到. 关键增量字段:
+     * <ul>
+     *     <li>{@code currentSpaceName / groupSpaceName} — 反查 Space 名, 不用查表</li>
+     *     <li>{@code channelInfo.space_id} 和 {@code convSync.space_id} — 两个原始源都打,
+     *         一眼看出 groupSpaceId 命中的是哪个</li>
+     *     <li>{@code cacheStats.refreshedAt / size / containsThisGroup / authoritative} —
+     *         判断决策时缓存是否 stale, 上次根因就是这类信号缺失</li>
+     *     <li>{@code caller} — 决策点调用栈一行, 区分 channel-list / msg-arrive 路径</li>
+     * </ul>
      *
      * <p>容错：{@code WKLogUtils.d} 依赖 Android framework（{@code Log}、
      * {@code TextUtils}），在 host-side 单元测试里会抛 "Stub!"；用 try/catch
@@ -481,28 +492,91 @@ public final class SpaceFilter {
                                  @Nullable Boolean myCached,
                                  @NonNull String branch,
                                  boolean skip) {
+        // 性能 gate: 二者全关时直接 return, 避免每次过滤决策都 new Throwable + 字符串拼接.
+        // - WKLogUtils.LOGGABLE: 编译时 = isDebug, debug 包恒 true, release 恒 false
+        // - DiagSink.isEnabled(): 运行时, 用户隐藏入口开启后才 true
+        if (!com.chat.base.utils.WKLogUtils.LOGGABLE && !com.chat.base.utils.DiagSink.isEnabled()) {
+            return;
+        }
         try {
             String channelName = "";
-            if (channelType == WKChannelType.GROUP) {
-                WKChannel ch = com.xinbida.wukongim.WKIM.getInstance().getChannelManager()
-                        .getChannel(channelID, channelType);
-                if (ch != null && ch.channelName != null) channelName = ch.channelName;
+            String channelInfoSpaceId = null;
+            if (channelType == WKChannelType.GROUP || channelType == WKChannelType.COMMUNITY_TOPIC) {
+                try {
+                    WKChannel ch = WKIM.getInstance().getChannelManager()
+                            .getChannel(channelID, channelType);
+                    if (ch != null) {
+                        if (ch.channelName != null) channelName = ch.channelName;
+                        if (ch.remoteExtraMap != null) {
+                            Object v = ch.remoteExtraMap.get(CHANNEL_EXTRA_SPACE_ID);
+                            if (v != null) channelInfoSpaceId = v.toString();
+                        }
+                    }
+                } catch (Throwable ignored) {
+                }
             }
-            String line = "SpaceFilter#"
-                    + " branch=" + branch
-                    + " skip=" + skip
-                    + " channelID=" + channelID
-                    + " name=" + channelName
-                    + " channelType=" + channelType
-                    + " currentSpaceId=" + currentSpaceId
-                    + " groupSpaceId=" + groupSpaceId
-                    + " prefix=" + prefix
-                    + " mySourceSpaceId=" + mySourceSpaceId
-                    + " myMembershipCached=" + myCached;
-            com.chat.base.utils.WKLogUtils.d(LOG_TAG, line);
+            // 两个原始源单独打: 让 review 时一眼看出 groupSpaceId 命中的是 channelInfo 还是 convSync.
+            String convSyncSpaceId = null;
+            com.xinbida.wukongim.manager.ConversationManager.SpaceCacheStats stats = null;
+            try {
+                convSyncSpaceId = WKIM.getInstance().getConversationManager()
+                        .getConvSyncSpaceId(channelID);
+                stats = WKIM.getInstance().getConversationManager()
+                        .getSpaceCacheStats(channelID);
+            } catch (Throwable ignored) {
+            }
+            String curName = SpaceNameLookup.nameOf(currentSpaceId);
+            String grpName = SpaceNameLookup.nameOf(groupSpaceId);
+            String caller = callerOf();
+
+            StringBuilder sb = new StringBuilder(384);
+            sb.append("branch=").append(branch)
+                    .append(" skip=").append(skip)
+                    .append(" channelID=").append(channelID)
+                    .append(" channelType=").append(channelType)
+                    .append(" name='").append(channelName).append('\'')
+                    .append(" currentSpaceId=").append(currentSpaceId)
+                    .append(" currentSpaceName='").append(curName == null ? "" : curName).append('\'')
+                    .append(" groupSpaceId=").append(groupSpaceId)
+                    .append(" groupSpaceName='").append(grpName == null ? "" : grpName).append('\'')
+                    .append(" channelInfo.space_id=").append(channelInfoSpaceId)
+                    .append(" convSync.space_id=").append(convSyncSpaceId)
+                    .append(" prefix=").append(prefix)
+                    .append(" mySourceSpaceId=").append(mySourceSpaceId)
+                    .append(" myMembershipCached=").append(myCached);
+            if (stats != null) {
+                sb.append(" cache.size=").append(stats.spaceMapSize)
+                        .append('/').append(stats.externalMapSize)
+                        .append(" cache.refreshedAt=").append(stats.refreshedAt)
+                        .append(" cache.containsThisGroup=").append(stats.containsChannelId)
+                        .append(" cache.authoritative=").append(stats.authoritative);
+            }
+            sb.append(" caller=").append(caller);
+            String line = sb.toString();
+            com.chat.base.utils.WKLogUtils.d(LOG_TAG, "SpaceFilter# " + line);
+            com.chat.base.utils.DiagSink.write("SF", line);
         } catch (Throwable ignored) {
             // 忽略日志异常（host-side 单测或 Android stub 环境）
         }
+    }
+
+    /**
+     * 取调用 SpaceFilter 决策的栈帧一行(跳过 SpaceFilter 内部帧). 用于区分
+     * "channel-list 路径" 还是 "msg-arrive 路径" 还是 "filter-and-display" 触发的过滤.
+     */
+    private static String callerOf() {
+        try {
+            StackTraceElement[] st = new Throwable().getStackTrace();
+            for (StackTraceElement el : st) {
+                String cls = el.getClassName();
+                if (cls == null) continue;
+                if (cls.equals(SpaceFilter.class.getName())) continue;
+                if (cls.startsWith("com.chat.base.space.SpaceFilter")) continue;
+                return el.getClassName() + "." + el.getMethodName() + ":" + el.getLineNumber();
+            }
+        } catch (Throwable ignored) {
+        }
+        return "unknown";
     }
 
     private static final String LOG_TAG = "SpaceFilter";
@@ -520,11 +594,67 @@ public final class SpaceFilter {
 
     @VisibleForTesting
     public static boolean shouldSkipMessageForSpace(@Nullable WKMsg msg, @Nullable String currentSpaceId) {
-        if (msg == null) return false;
-        if (isBlank(currentSpaceId)) return false;
+        if (msg == null) {
+            msgDiagLog(null, currentSpaceId, null, "null-msg-pass", false);
+            return false;
+        }
+        if (isBlank(currentSpaceId)) {
+            msgDiagLog(msg, currentSpaceId, null, "space-empty-pass", false);
+            return false;
+        }
         String msgSpaceId = extractSpaceIdFromMsg(msg);
-        if (isBlank(msgSpaceId)) return false; // fail-open
-        return !currentSpaceId.equals(msgSpaceId);
+        if (isBlank(msgSpaceId)) {
+            msgDiagLog(msg, currentSpaceId, msgSpaceId, "fail-open-no-msg-space", false);
+            return false; // fail-open
+        }
+        boolean skip = !currentSpaceId.equals(msgSpaceId);
+        msgDiagLog(msg, currentSpaceId, msgSpaceId, skip ? "msg-space-mismatch" : "msg-space-match", skip);
+        return skip;
+    }
+
+    /**
+     * 私聊消息级 Space 过滤诊断日志. 跨 Space 私聊串消息的决策点必打 — 字段集与
+     * {@link #diagLog} 对齐, 多打消息自身元数据(发件人、内容前 60 字符片段)便于
+     * 用户能告诉我们"是哪条消息"加速定位.
+     */
+    private static void msgDiagLog(@Nullable WKMsg msg,
+                                   @Nullable String currentSpaceId,
+                                   @Nullable String msgSpaceId,
+                                   @NonNull String branch,
+                                   boolean skip) {
+        // 同 diagLog: 二者全关直接退出, 避免每条私聊消息过滤都做拼接.
+        if (!com.chat.base.utils.WKLogUtils.LOGGABLE && !com.chat.base.utils.DiagSink.isEnabled()) {
+            return;
+        }
+        try {
+            String cid = msg == null ? "null" : msg.channelID;
+            byte ct = msg == null ? -1 : msg.channelType;
+            String fromUid = msg == null ? "null" : msg.fromUID;
+            String clientMsgNo = msg == null ? "null" : msg.clientMsgNO;
+            long msgSeq = msg == null ? 0 : msg.messageSeq;
+            String contentSnippet = "";
+            if (msg != null && msg.content != null) {
+                int len = Math.min(msg.content.length(), 60);
+                contentSnippet = msg.content.substring(0, len).replace('\n', ' ').replace('\r', ' ');
+            }
+            String curName = SpaceNameLookup.nameOf(currentSpaceId);
+            String msgSpaceName = SpaceNameLookup.nameOf(msgSpaceId);
+            String line = "branch=" + branch
+                    + " skip=" + skip
+                    + " channelID=" + cid + " channelType=" + ct
+                    + " fromUid=" + fromUid
+                    + " clientMsgNo=" + clientMsgNo
+                    + " msgSeq=" + msgSeq
+                    + " currentSpaceId=" + currentSpaceId
+                    + " currentSpaceName='" + (curName == null ? "" : curName) + '\''
+                    + " msgSpaceId=" + msgSpaceId
+                    + " msgSpaceName='" + (msgSpaceName == null ? "" : msgSpaceName) + '\''
+                    + " content[0..60]='" + contentSnippet + '\''
+                    + " caller=" + callerOf();
+            com.chat.base.utils.WKLogUtils.d(LOG_TAG, "SpaceFilter-Msg# " + line);
+            com.chat.base.utils.DiagSink.write("SF-MSG", line);
+        } catch (Throwable ignored) {
+        }
     }
 
     /** 从消息中提取 space_id：优先 content JSON，其次 SDK 解码后的 baseContentMsgModel.spaceId。 */

--- a/wkbase/src/main/java/com/chat/base/space/SpaceFilter.java
+++ b/wkbase/src/main/java/com/chat/base/space/SpaceFilter.java
@@ -122,6 +122,22 @@ public final class SpaceFilter {
             return null;
         }
 
+        /**
+         * 读取 channel 最后一条消息的 space_id（仅 PERSONAL 使用）。
+         *
+         * <p>用途：PERSONAL channel（私聊 / AI 机器人）没有自己的 Space 归属，只能靠"最后一条
+         * 消息发自哪个 Space"反推会话归属。{@link #shouldSkipChannelForSpace} 的 person 分支会
+         * 调用本方法，读到 space_id 后跟 currentSpaceId 比较。返回 null 表示读不到（老消息
+         * 没带 space_id / SDK 未就绪 / 消息已删除），上层会 fail-open 等数据补齐。
+         *
+         * <p>对齐 iOS {@code WKConversationListVM shouldShowConversation:} 的"读 lastMessage
+         * content space_id 兜底过滤"路径（WKConversationListVM.m:952-979）。
+         */
+        @Nullable
+        default String getLastMsgSpaceId(String channelID, byte channelType) {
+            return null;
+        }
+
         default boolean isSpaceCacheAuthoritative() {
             return false;
         }
@@ -220,6 +236,30 @@ public final class SpaceFilter {
                 return TextUtils.isEmpty(v) ? null : v;
             } catch (Throwable ignored) {
                 // SDK 未就绪或线程异常时返回 null，让上层走 fail-open / member sync 兜底
+                return null;
+            }
+        }
+
+        /**
+         * PERSONAL channel 的 last-msg space_id 读取实现。
+         *
+         * <p>路径：{@code getUIConversationMsg → getWkMsg → extractSpaceIdFromMsg}。
+         * {@code getWkMsg()} 是 lazy load：首次访问从 MsgDbManager 查 client_msg_no 走索引
+         * （单次 ~ms），结果回缓存到 {@code WKUIConversationMsg.wkMsg}，后续无 DB 命中。
+         *
+         * <p>失败兜底：SDK 未就绪 / 会话不存在 / 消息删除 / content 不是合法 JSON → 返回 null。
+         */
+        @Override
+        public String getLastMsgSpaceId(String channelID, byte channelType) {
+            try {
+                com.xinbida.wukongim.entity.WKUIConversationMsg conv = WKIM.getInstance()
+                        .getConversationManager()
+                        .getUIConversationMsg(channelID, channelType);
+                if (conv == null) return null;
+                com.xinbida.wukongim.entity.WKMsg msg = conv.getWkMsg();
+                if (msg == null) return null;
+                return extractSpaceIdFromMsg(msg);
+            } catch (Throwable ignored) {
                 return null;
             }
         }
@@ -359,11 +399,28 @@ public final class SpaceFilter {
             return false;
         }
 
-        // 3. person-pass（旧兼容：私聊过滤交给 shouldSkipMessageForSpace）
+        // 3. PERSONAL Space 过滤（对齐 iOS WKConversationListVM:952-979）
+        //   a. SystemBot 白名单（botfather / u_10000 / fileHelper + appconfig.system_bot_uids
+        //      动态扩展）跨 Space 共享 conversation entry → 放行（每个 Space 都显示），
+        //      消息内容由 shouldSkipMessageForSpace 在 msg 级隔离。
+        //   b. 真人私聊 + 普通 AI 机器人：读 last-msg.content.space_id 跟 currentSpaceId 比对。
+        //      老消息没带 space_id → fail-open 等数据补齐（避免误杀历史会话）。
         if (channelType == WKChannelType.PERSONAL) {
-            diagLog(channelID, channelType, currentSpaceId, null, prefix, null, null,
-                    "person-pass", false);
-            return false;
+            if (SystemBotsFallback.isSystemBot(channelID)) {
+                diagLog(channelID, channelType, currentSpaceId, null, prefix, null, null,
+                        "person-system-bot-pass", false);
+                return false;
+            }
+            String msgSpaceId = provider.getLastMsgSpaceId(channelID, channelType);
+            if (isBlank(msgSpaceId)) {
+                diagLog(channelID, channelType, currentSpaceId, null, prefix, null, null,
+                        "person-fail-open-no-msg-space", false);
+                return false;
+            }
+            boolean skip = !currentSpaceId.equals(msgSpaceId);
+            diagLog(channelID, channelType, currentSpaceId, null, prefix, msgSpaceId, null,
+                    skip ? "person-space-mismatch" : "person-space-match", skip);
+            return skip;
         }
 
         // 3.5 thread-delegate: 子区（COMMUNITY_TOPIC）委托给父群判断。

--- a/wkbase/src/main/java/com/chat/base/space/SpaceNameLookup.java
+++ b/wkbase/src/main/java/com/chat/base/space/SpaceNameLookup.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.base.space;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Space id → 名字反查桥. 让 wkbase 模块的诊断日志能拿到 Space 名(实际数据在 wkuikit 的
+ * SpaceModel 缓存里), 但又不破坏 wkbase → wkuikit 这个反向依赖.
+ *
+ * <p>用法: wkuikit 在 Application 启动时调一次 {@link #install(Lookup)} 注入 lookup 闭包,
+ * 之后 wkbase 内任意位置 {@link #nameOf(String)} 拿到 Space 名(未注入时返回 null).
+ *
+ * <p>仅用于诊断/日志, 不要在业务逻辑里依赖此查找(可能未初始化、可能 null).
+ */
+public final class SpaceNameLookup {
+
+    public interface Lookup {
+        /** 返回 spaceId 对应的 Space 名, 找不到/未初始化时返回 null. */
+        @Nullable
+        String nameOf(@Nullable String spaceId);
+    }
+
+    private static volatile Lookup IMPL;
+
+    private SpaceNameLookup() {
+    }
+
+    /** 由 wkuikit 在 Application 启动时调一次. 幂等. */
+    public static void install(@Nullable Lookup lookup) {
+        IMPL = lookup;
+    }
+
+    /** wkbase 内查 Space 名. 未注入或查不到都返回 null, 永不抛异常. */
+    @Nullable
+    public static String nameOf(@Nullable String spaceId) {
+        if (spaceId == null || spaceId.isEmpty()) return null;
+        Lookup l = IMPL;
+        if (l == null) return null;
+        try {
+            return l.nameOf(spaceId);
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/utils/DiagSink.java
+++ b/wkbase/src/main/java/com/chat/base/utils/DiagSink.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.base.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.Process;
+
+import androidx.annotation.AnyThread;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Space 串消息排查专用诊断日志异步写入器.
+ *
+ * <p><b>设计目标</b>:
+ * <ul>
+ *   <li><b>业务零侵入</b>: 埋点点位调 {@link #write(String, String)}, 内部 gate + 异步.</li>
+ *   <li><b>默认关闭</b>: release/debug 都默认关闭, 用户通过隐藏入口(头像 5 次点击)显式开启.</li>
+ *   <li><b>自动失效</b>: 开启后 TTL(默认 2 小时)到期自动关, 避免遗忘.</li>
+ *   <li><b>异步写入</b>: 单线程 {@link HandlerThread}, 业务线程仅 post Runnable, 无 IO.</li>
+ *   <li><b>复用导出</b>: 写到 {@link DiagnosticLogFile} 同一个文件, 用户从"关于→导出诊断日志"导出.</li>
+ * </ul>
+ *
+ * <p><b>状态机</b>:
+ * <ol>
+ *   <li>{@link #init(Context)} —— App 启动调一次. 读 SP {@code enabled_until_ms}, 若仍在 TTL 内则
+ *       恢复上次会话的诊断模式(用户开启后即使重启 app 也继续采到 TTL 截止).</li>
+ *   <li>{@link #enable(Context, long)} —— 用户点头像 5 次后确认开启. 写 SP + 内存状态.</li>
+ *   <li>{@link #disable(Context)} —— 用户主动关闭. 清 SP + 内存状态.</li>
+ *   <li>{@link #isEnabled()} —— 任意线程检查. TTL 到期会自动 lazy-disable.</li>
+ * </ol>
+ *
+ * <p><b>排查结束后移除步骤</b>:
+ * <ol>
+ *   <li>删除调用 {@link #write(String, String)} 的所有埋点位置(grep "DiagSink.write")</li>
+ *   <li>删除本文件 {@code DiagSink.java}</li>
+ *   <li>删除 {@code MyFragment} 中的 5 次点击检测代码</li>
+ * </ol>
+ */
+public final class DiagSink {
+
+    private static final String SP_NAME = "diag_sink";
+    private static final String SP_KEY_ENABLED_UNTIL = "enabled_until_ms";
+
+    /** 默认 TTL: 2 小时. 足够用户配合排查走完一遍复现场景, 又不会忘了关. */
+    public static final long DEFAULT_TTL_MS = 2L * 60 * 60 * 1000;
+
+    private static final AtomicBoolean enabled = new AtomicBoolean(false);
+    private static final AtomicLong enabledUntilMs = new AtomicLong(0L);
+    private static volatile Handler writer;
+    private static volatile Context appCtx;
+
+    /** 与 ANR/Crash 既有格式对齐, 含毫秒. ThreadLocal 避免多线程 format 竞争. */
+    private static final ThreadLocal<SimpleDateFormat> TS_FMT = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US);
+        }
+    };
+
+    private DiagSink() {
+    }
+
+    /**
+     * App 启动时调一次. 必须在任何 {@link #write} 之前完成(否则 write 直接 no-op 不报错).
+     *
+     * <p>读 SP {@code enabled_until_ms}: 若仍在 TTL 内 → 恢复 {@code enabled=true}, 让用户
+     * 上次开启的诊断模式跨越重启依然有效. 这样用户开启后可以重启 app 复现问题, 不需要
+     * 每次重新开启.
+     */
+    public static synchronized void init(@NonNull Context ctx) {
+        if (writer != null) return;
+        appCtx = ctx.getApplicationContext();
+        HandlerThread thread = new HandlerThread("DiagSinkWriter", Process.THREAD_PRIORITY_BACKGROUND);
+        thread.start();
+        writer = new Handler(thread.getLooper());
+        try {
+            SharedPreferences sp = appCtx.getSharedPreferences(SP_NAME, Context.MODE_PRIVATE);
+            long until = sp.getLong(SP_KEY_ENABLED_UNTIL, 0L);
+            if (until > 0 && System.currentTimeMillis() < until) {
+                enabled.set(true);
+                enabledUntilMs.set(until);
+            } else if (until > 0) {
+                // TTL 已过期, 顺手清掉脏数据
+                sp.edit().remove(SP_KEY_ENABLED_UNTIL).apply();
+            }
+        } catch (Throwable ignored) {
+            // SP 不可读时静默, 默认关闭
+        }
+    }
+
+    /**
+     * 用户点击开启诊断采集.
+     *
+     * @param ctx   任意 Context, 用来访问 SP
+     * @param ttlMs 自动关闭时长(毫秒). 传 ≤ 0 时使用 {@link #DEFAULT_TTL_MS}.
+     */
+    public static void enable(@NonNull Context ctx, long ttlMs) {
+        long duration = ttlMs > 0 ? ttlMs : DEFAULT_TTL_MS;
+        long until = System.currentTimeMillis() + duration;
+        enabled.set(true);
+        enabledUntilMs.set(until);
+        try {
+            ctx.getSharedPreferences(SP_NAME, Context.MODE_PRIVATE)
+                    .edit()
+                    .putLong(SP_KEY_ENABLED_UNTIL, until)
+                    .apply();
+        } catch (Throwable ignored) {
+            // SP 写失败仅影响跨进程恢复, 当前进程仍正常采集
+        }
+    }
+
+    /** 用户主动关闭采集. */
+    public static void disable(@NonNull Context ctx) {
+        enabled.set(false);
+        enabledUntilMs.set(0L);
+        try {
+            ctx.getSharedPreferences(SP_NAME, Context.MODE_PRIVATE)
+                    .edit()
+                    .remove(SP_KEY_ENABLED_UNTIL)
+                    .apply();
+        } catch (Throwable ignored) {
+        }
+    }
+
+    /** 当前是否启用. TTL 过期会自动转为 false. 任意线程可调. */
+    @AnyThread
+    public static boolean isEnabled() {
+        if (!enabled.get()) return false;
+        long until = enabledUntilMs.get();
+        if (until > 0 && System.currentTimeMillis() > until) {
+            enabled.set(false);
+            // 注意: 这里不清 SP, 让下次 init() 走过期清理路径(避免在 isEnabled 这个高频路径上做 IO)
+            return false;
+        }
+        return true;
+    }
+
+    /** TTL 截止时间戳(epoch ms). 0 表示未启用. UI 用来计算"还剩多久". */
+    public static long getEnabledUntilMs() {
+        return enabledUntilMs.get();
+    }
+
+    /**
+     * 写一行诊断日志. 任意线程调用, 立即返回(只 post 到 writer 线程), 不做 IO.
+     *
+     * <p>未启用时直接 return, 是单次 {@code AtomicBoolean.get()} + 可能的过期检查, 纳秒级开销.
+     *
+     * @param tag     类别标签, 建议常量化(SF / SF-MSG / BOOT / SPACE-SWITCH / CONV-SYNC / MEMBERSHIP / WKIM)
+     * @param message 日志正文(不要含换行, 内部会加 {@code \n})
+     */
+    @AnyThread
+    public static void write(@NonNull String tag, @Nullable String message) {
+        if (message == null) return;
+        if (!isEnabled()) return;
+        Handler h = writer;
+        Context ctx = appCtx;
+        if (h == null || ctx == null) return;
+        long ts = System.currentTimeMillis();
+        h.post(() -> {
+            try {
+                SimpleDateFormat fmt = TS_FMT.get();
+                String stamp = (fmt != null) ? fmt.format(new Date(ts)) : Long.toString(ts);
+                String line = "[" + stamp + "] [" + tag + "] " + message + "\n";
+                DiagnosticLogFile.append(ctx, line);
+            } catch (Throwable ignored) {
+                // 写文件失败不传播
+            }
+        });
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/utils/DiagnosticLogFile.java
+++ b/wkbase/src/main/java/com/chat/base/utils/DiagnosticLogFile.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 package com.chat.base.utils;
 
 import android.content.Context;
@@ -12,34 +22,91 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileReader;
+import java.io.RandomAccessFile;
 
 /**
  * 统一的本地诊断日志文件。
  *
- * ANRWatchdog + CrashHandler 共用同一个文件，
- * 用户通过"关于 → 导出诊断日志"一键分享。
+ * <p>三类写入共用同一份文件，用户从"关于 → 导出诊断日志"一键分享：
+ * <ul>
+ *     <li>{@code CrashHandler} / {@code ANRWatchdog} —— 崩溃栈, 同步写入(崩溃前必须落盘)</li>
+ *     <li>{@link DiagSink} —— Space 串消息排查埋点, 异步写入(用户隐藏入口开启时才采)</li>
+ * </ul>
+ *
+ * <p><b>Ring buffer (5MB)</b>: 文件超过 {@link #MAX_SIZE} 时保留最新的 {@link #KEEP_SIZE} 字节,
+ * 避免冷启动早期日志被"超限即 delete"抹掉(老逻辑的硬伤)。
  */
 public final class DiagnosticLogFile {
 
     private static final String TAG = "DiagnosticLog";
     private static final String FILE_NAME = "diagnostic.log";
-    private static final int MAX_SIZE = 1024 * 1024; // 1MB
+
+    /** Ring buffer 上限: 5 MB. Crash 栈通常 2-10KB / 次, 5MB 容量足够装数百次崩溃 + 诊断采集. */
+    private static final long MAX_SIZE = 5L * 1024 * 1024;
+    /** 超限后保留的尾段大小: 2.5 MB (= MAX_SIZE / 2). */
+    private static final long KEEP_SIZE = MAX_SIZE / 2;
 
     private DiagnosticLogFile() {
     }
 
+    /**
+     * 追加原始文本到日志文件. 不加时间戳前缀(调用方自行格式化).
+     *
+     * <p>线程安全: {@code synchronized} + {@link FileOutputStream}, 多线程写不会撕裂.
+     * Crash 路径(同步调用)与 {@link DiagSink} writer 线程(异步调用)共用此方法.
+     */
     public static synchronized void append(Context context, String content) {
         if (context == null || content == null) return;
         try {
             File file = getFile(context);
-            if (file.exists() && file.length() > MAX_SIZE) {
-                file.delete();
+            rotateIfOversized(file);
+            try (FileOutputStream fos = new FileOutputStream(file, true)) {
+                fos.write(content.getBytes("UTF-8"));
+                fos.flush();
             }
-            FileOutputStream fos = new FileOutputStream(file, true);
-            fos.write(content.getBytes("UTF-8"));
-            fos.flush();
-            fos.close();
         } catch (Throwable ignored) {
+        }
+    }
+
+    /**
+     * 文件超 {@link #MAX_SIZE} 时保留最新 {@link #KEEP_SIZE} 字节.
+     *
+     * <p>实现: 读尾段到临时文件再 rename 覆盖, 避免长时间持有写锁. rename 失败时降级为
+     * 删整个文件(老行为), 保证文件不会无限增长.
+     */
+    private static void rotateIfOversized(File file) {
+        try {
+            if (!file.exists() || file.length() <= MAX_SIZE) return;
+            File tmp = new File(file.getParentFile(), FILE_NAME + ".rotate.tmp");
+            if (tmp.exists()) tmp.delete();
+            try (RandomAccessFile raf = new RandomAccessFile(file, "r");
+                 FileOutputStream out = new FileOutputStream(tmp)) {
+                long start = Math.max(0L, file.length() - KEEP_SIZE);
+                raf.seek(start);
+                // 跳过半行: 找下一个 '\n' 之后开始保留, 避免日志中间被切断不可读
+                int b;
+                while ((b = raf.read()) != -1 && b != '\n') { /* skip */ }
+                String banner = "[ROTATE] ring-buffer truncated " + file.length()
+                        + " -> keep " + KEEP_SIZE + " bytes\n";
+                out.write(banner.getBytes("UTF-8"));
+                byte[] buf = new byte[64 * 1024];
+                int n;
+                while ((n = raf.read(buf)) > 0) {
+                    out.write(buf, 0, n);
+                }
+                out.flush();
+            }
+            if (!tmp.renameTo(file)) {
+                // rename 失败兜底
+                file.delete();
+                tmp.delete();
+            }
+        } catch (Throwable e) {
+            Log.w(TAG, "rotate failed: " + e.getMessage());
+            try {
+                file.delete();
+            } catch (Throwable ignored) {
+            }
         }
     }
 
@@ -48,14 +115,14 @@ public final class DiagnosticLogFile {
         try {
             File file = getFile(context);
             if (!file.exists() || file.length() == 0) return "";
-            StringBuilder sb = new StringBuilder((int) file.length());
-            BufferedReader reader = new BufferedReader(new FileReader(file));
-            char[] buf = new char[4096];
-            int len;
-            while ((len = reader.read(buf)) != -1) {
-                sb.append(buf, 0, len);
+            StringBuilder sb = new StringBuilder((int) Math.min(file.length(), Integer.MAX_VALUE));
+            try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+                char[] buf = new char[4096];
+                int len;
+                while ((len = reader.read(buf)) != -1) {
+                    sb.append(buf, 0, len);
+                }
             }
-            reader.close();
             return sb.toString();
         } catch (Throwable e) {
             return "";

--- a/wkim/src/main/java/com/xinbida/wukongim/diag/WKDiagWriter.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/diag/WKDiagWriter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.xinbida.wukongim.diag;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * SDK 内部诊断日志桥. wkim 模块无法直接依赖 wkbase 的 DiagSink(依赖方向相反),
+ * 通过此 install-pattern 让 wkbase 在 Application 启动时注入实现.
+ *
+ * <p>未注入时所有 write 调用是 no-op, 不会抛异常. wkim 内的 conv-sync / membership
+ * 等关键状态变更点直接调用 {@link #write(String, String)} 上报, 无需 import wkbase.
+ *
+ * <p>用法:
+ * <pre>{@code
+ * // wkbase 中, Application 启动时:
+ * WKDiagWriter.install((tag, msg) -> DiagSink.write(tag, msg));
+ *
+ * // wkim 内任意位置:
+ * WKDiagWriter.write("MEMBERSHIP", "action=apply size=23");
+ * }</pre>
+ */
+public final class WKDiagWriter {
+
+    public interface Writer {
+        void write(@NonNull String tag, @Nullable String message);
+    }
+
+    private static volatile Writer IMPL;
+
+    private WKDiagWriter() {
+    }
+
+    /** wkbase 在 Application 启动时调一次. 幂等. */
+    public static void install(@Nullable Writer writer) {
+        IMPL = writer;
+    }
+
+    /** wkim 内任意位置写日志. 未 install 时 no-op, 永不抛异常. */
+    public static void write(@NonNull String tag, @Nullable String message) {
+        Writer w = IMPL;
+        if (w == null) return;
+        try {
+            w.write(tag, message);
+        } catch (Throwable ignored) {
+        }
+    }
+}

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
@@ -417,8 +417,13 @@ public class ConversationManager extends BaseManager {
 
     public void setSyncConversationListener(ISyncConversationChatBack iSyncConversationChatBack) {
         if (iSyncConversationChat == null) {
+            // 上层 listener 还没注册（如 Phase-B postPhaseB 的 WKIMUtils.initIMListener 还在 IO 线程排队）
+            // 仍调一次 onBack(null) 让调用方的回调链能跑——WKConnection.markConnected /
+            // SyncGate.done / SpaceSyncCoordinator.complete 都挂在 onBack 上，
+            // 否则 permit 锁死 10s（STUCK_RESET_MS），冷启动会话列表只剩 SYSTEM_BOTS 兜底。
             WKLoggerUtils.getInstance().e("未设置同步最近会话事件");
-            if (com.xinbida.wukongim.BuildConfig.DEBUG) android.util.Log.e("MsgDebug", "[SYNC_BUG] iSyncConversationChat is NULL! callback will NOT fire, connectStatus will stay syncMsg forever");
+            if (com.xinbida.wukongim.BuildConfig.DEBUG) android.util.Log.e("MsgDebug", "[SYNC_BUG] iSyncConversationChat is NULL! firing onBack(null) to release upstream permit");
+            if (iSyncConversationChatBack != null) iSyncConversationChatBack.onBack(null);
             return;
         }
         //  C · sync 去重：CAS 抢 permit。5 条触发路径并发打进来时只有 1 条会真正

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
@@ -730,18 +730,27 @@ public class ConversationManager extends BaseManager {
 
     /**
      * 用服务端返回的全量 space_memberships 覆盖内存缓存，彻底消除 Space 消息串问题。
-     * memberships 为 null 时表示老后端未部署此字段，跳过不处理（保持向后兼容）。
+     *
+     * <p>权威性语义（PR #75 review @Jerry-Xin 提出的边界）：
+     * <ul>
+     *   <li>{@code memberships == null}：老后端未部署此字段，跳过不处理（authoritative
+     *       保持原值，向后兼容）。</li>
+     *   <li>{@code memberships.isEmpty()}：新后端权威返回"无 memberships"，应当标记
+     *       {@code authoritative=true} 并持久化，否则 SpaceFilter 的
+     *       {@code my-row-not-cached-fail-open} 路径会继续展示陈旧 / 跨 Space 会话。</li>
+     *   <li>非空 list：新后端权威覆盖，{@code authoritative=true}（已有逻辑）。</li>
+     * </ul>
      */
     public void applySpaceMemberships(List<WKSpaceMembership> memberships) {
         if (memberships == null) return;
         if (memberships.isEmpty()) {
             spaceCacheSnapshot = new SpaceCacheSnapshot(
-                    new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), false);
+                    new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), true);
             spaceCacheRefreshedAt = System.currentTimeMillis();
             saveSpaceCacheToDisk(new ConcurrentHashMap<>(), new ConcurrentHashMap<>());
             try {
                 com.xinbida.wukongim.diag.WKDiagWriter.write("MEMBERSHIP",
-                        "action=apply-empty before=cleared after=0/0 authoritative=false");
+                        "action=apply-empty before=cleared after=0/0 authoritative=true");
             } catch (Throwable ignored) {
             }
             notifySpaceCacheUpdated();

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
@@ -965,15 +965,21 @@ public class ConversationManager extends BaseManager {
     }
 
     /**
-     * 诊断用: 返回 space cache 当前状态快照. 任意线程可调, 无锁(读 volatile 字段).
+     * <b>内部诊断 API — 请勿在业务代码中调用。</b>
      *
-     * <p>排查 Space 串消息时, 单看 SpaceFilter 决策日志不够 —— 还需要知道决策时缓存数据
-     * 新不新、有没有这条群的记录. 这个 stats 让一行日志就能定位 stale-cache 类问题.
+     * <p>仅供 Space 串消息排查期间 {@code SpaceFilter.diagLog} / {@code DiagSink} 写日志使用。
+     * 待 server PR #154 cross-space 诊断闭环上线、SpaceFilter 决策切换到 realtime msg
+     * payload 中的权威 space_id 后，本方法连同 {@link SpaceCacheStats} 会一并删除——
+     * 任何依赖这个 API 写业务的代码都会在那时编译失败。
+     *
+     * <p>诊断用: 返回 space cache 当前状态快照. 任意线程可调, 无锁(读 volatile 字段).
      *
      * @param channelID 要查询的频道 ID(可空). 非空时 {@link SpaceCacheStats#containsChannelId}
      *                  反映 spaceMap 是否含有该 ID.
+     * @hide
      */
     @androidx.annotation.NonNull
+    @androidx.annotation.RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     public SpaceCacheStats getSpaceCacheStats(@androidx.annotation.Nullable String channelID) {
         ensureSpaceCacheLoaded();
         SpaceCacheSnapshot snap = spaceCacheSnapshot;
@@ -987,7 +993,13 @@ public class ConversationManager extends BaseManager {
                 contains);
     }
 
-    /** {@link #getSpaceCacheStats(String)} 的返回值. 不可变快照. */
+    /**
+     * <b>内部诊断 DTO — 请勿在业务代码中引用。</b> 见 {@link #getSpaceCacheStats(String)} 注释,
+     * 与该方法同生命周期, 排查结束后一并删除.
+     *
+     * @hide
+     */
+    @androidx.annotation.RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     public static final class SpaceCacheStats {
         /** 当前 spaceMap 条目数(我所在的群数, 含 my_source 关系). */
         public final int spaceMapSize;

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
@@ -107,6 +107,21 @@ public class ConversationManager extends BaseManager {
     private volatile SpaceCacheSnapshot spaceCacheSnapshot =
             new SpaceCacheSnapshot(new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), false);
 
+    /**
+     * 最近一次 {@link #spaceCacheSnapshot} 被刷新/替换/单条预填的 wall-clock 时间(epoch ms).
+     *
+     * <p>诊断用: Space 串消息排查时, 单看 {@code SpaceFilter} 决策日志不够, 还需要知道
+     * "我决策时缓存数据有多新". 这个字段让 review 时能区分:
+     * <ul>
+     *     <li>缓存刚刚刷新(几秒内) → 数据应当权威, 决策错误是逻辑问题</li>
+     *     <li>缓存很久没刷新(几分钟前) → 可能是 stale, 决策错误是 race</li>
+     * </ul>
+     *
+     * <p>0 表示从未刷新(进程刚启动 + 磁盘 cache 也没读到). 用 {@code volatile long} 而非
+     * {@code AtomicLong}: 单次赋值无需 CAS, volatile 保证可见性即可.
+     */
+    private volatile long spaceCacheRefreshedAt = 0L;
+
     private static final String SPACE_PREFS_NAME = "wk_space_memberships";
     private static final String PREF_KEY_SPACE_MAP = "space_map";
     private static final String PREF_KEY_EXTERNAL_MAP = "external_map";
@@ -706,6 +721,7 @@ public class ConversationManager extends BaseManager {
             } else {
                 snapshot.externalMap.remove(channelID);
             }
+            spaceCacheRefreshedAt = System.currentTimeMillis();
         } catch (Throwable t) {
             // 单条 conv 的预填失败不应阻断批量落盘；下一次 sync 或 channelInfo 异步路径会补齐。
             WKLoggerUtils.getInstance().e(TAG, "prefillSpaceExtrasFromConvSync failed: " + t.getMessage());
@@ -721,11 +737,19 @@ public class ConversationManager extends BaseManager {
         if (memberships.isEmpty()) {
             spaceCacheSnapshot = new SpaceCacheSnapshot(
                     new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), false);
+            spaceCacheRefreshedAt = System.currentTimeMillis();
             saveSpaceCacheToDisk(new ConcurrentHashMap<>(), new ConcurrentHashMap<>());
+            try {
+                com.xinbida.wukongim.diag.WKDiagWriter.write("MEMBERSHIP",
+                        "action=apply-empty before=cleared after=0/0 authoritative=false");
+            } catch (Throwable ignored) {
+            }
             notifySpaceCacheUpdated();
             return;
         }
         try {
+            int beforeSpace = spaceCacheSnapshot.spaceMap.size();
+            int beforeExt = spaceCacheSnapshot.externalMap.size();
             ConcurrentHashMap<String, String> newSpaceMap = new ConcurrentHashMap<>();
             ConcurrentHashMap<String, String> newExternalMap = new ConcurrentHashMap<>();
             for (WKSpaceMembership m : memberships) {
@@ -738,7 +762,16 @@ public class ConversationManager extends BaseManager {
                 }
             }
             spaceCacheSnapshot = new SpaceCacheSnapshot(newSpaceMap, newExternalMap, true);
+            spaceCacheRefreshedAt = System.currentTimeMillis();
             saveSpaceCacheToDisk(newSpaceMap, newExternalMap);
+            try {
+                com.xinbida.wukongim.diag.WKDiagWriter.write("MEMBERSHIP",
+                        "action=apply-full entries=" + memberships.size()
+                                + " before=" + beforeSpace + "/" + beforeExt
+                                + " after=" + newSpaceMap.size() + "/" + newExternalMap.size()
+                                + " authoritative=true");
+            } catch (Throwable ignored) {
+            }
             if (com.xinbida.wukongim.BuildConfig.DEBUG) {
                 String caller = Thread.currentThread().getStackTrace().length > 3
                         ? Thread.currentThread().getStackTrace()[3].toString() : "unknown";
@@ -776,9 +809,18 @@ public class ConversationManager extends BaseManager {
      */
     public void clearConvSyncSpaceCache() {
         try {
+            int beforeSpace = spaceCacheSnapshot.spaceMap.size();
+            int beforeExt = spaceCacheSnapshot.externalMap.size();
             spaceCacheSnapshot = new SpaceCacheSnapshot(new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), false);
+            // 清空视为"没数据", 时间戳归零, 让诊断日志能区分"刚清空"与"从未加载".
+            spaceCacheRefreshedAt = 0L;
             spaceCacheLoadedFromDisk = false;
             coldStartSyncDone = false;
+            try {
+                com.xinbida.wukongim.diag.WKDiagWriter.write("MEMBERSHIP",
+                        "action=clear before=" + beforeSpace + "/" + beforeExt + " after=0/0");
+            } catch (Throwable ignored) {
+            }
         } catch (Throwable t) {
             WKLoggerUtils.getInstance().e(TAG, "clearConvSyncSpaceCache failed: " + t.getMessage());
         }
@@ -818,6 +860,7 @@ public class ConversationManager extends BaseManager {
             }
             spaceCacheSnapshot = new SpaceCacheSnapshot(spaceMap, extMap,
                     prefs.getBoolean(PREF_KEY_AUTHORITATIVE, false));
+            spaceCacheRefreshedAt = System.currentTimeMillis();
             if (com.xinbida.wukongim.BuildConfig.DEBUG) {
                 android.util.Log.d("ConvSync", "[loadSpaceCacheFromDisk] spaceMap=" + spaceMap.size()
                         + " externalMap=" + extMap.size());
@@ -919,5 +962,51 @@ public class ConversationManager extends BaseManager {
     public boolean isSpaceCacheAuthoritative() {
         ensureSpaceCacheLoaded();
         return spaceCacheSnapshot.authoritative;
+    }
+
+    /**
+     * 诊断用: 返回 space cache 当前状态快照. 任意线程可调, 无锁(读 volatile 字段).
+     *
+     * <p>排查 Space 串消息时, 单看 SpaceFilter 决策日志不够 —— 还需要知道决策时缓存数据
+     * 新不新、有没有这条群的记录. 这个 stats 让一行日志就能定位 stale-cache 类问题.
+     *
+     * @param channelID 要查询的频道 ID(可空). 非空时 {@link SpaceCacheStats#containsChannelId}
+     *                  反映 spaceMap 是否含有该 ID.
+     */
+    @androidx.annotation.NonNull
+    public SpaceCacheStats getSpaceCacheStats(@androidx.annotation.Nullable String channelID) {
+        ensureSpaceCacheLoaded();
+        SpaceCacheSnapshot snap = spaceCacheSnapshot;
+        boolean contains = channelID != null && !channelID.isEmpty()
+                && snap.spaceMap.containsKey(channelID);
+        return new SpaceCacheStats(
+                snap.spaceMap.size(),
+                snap.externalMap.size(),
+                spaceCacheRefreshedAt,
+                snap.authoritative,
+                contains);
+    }
+
+    /** {@link #getSpaceCacheStats(String)} 的返回值. 不可变快照. */
+    public static final class SpaceCacheStats {
+        /** 当前 spaceMap 条目数(我所在的群数, 含 my_source 关系). */
+        public final int spaceMapSize;
+        /** 当前 externalMap 条目数(我以外部成员身份加入的群数). */
+        public final int externalMapSize;
+        /** 最近一次 cache 替换/单条预填的 epoch ms. 0 = 从未刷新. */
+        public final long refreshedAt;
+        /** 当前 cache 是否是权威源(true 表示来自 space_memberships 全量响应). */
+        public final boolean authoritative;
+        /** 查询的 channelID 是否在 spaceMap 里. 调用时 channelID 为 null 则为 false. */
+        public final boolean containsChannelId;
+
+        SpaceCacheStats(int spaceMapSize, int externalMapSize, long refreshedAt,
+                        boolean authoritative, boolean containsChannelId) {
+            this.spaceMapSize = spaceMapSize;
+            this.externalMapSize = externalMapSize;
+            this.refreshedAt = refreshedAt;
+            this.authoritative = authoritative;
+            this.containsChannelId = containsChannelId;
+        }
     }
 }

--- a/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
+++ b/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
@@ -206,6 +206,20 @@ public class WKUIKitApplication {
         // 必须在 WKIM 的首次连接成功回调之前完成——放到同步 init 段开头最安全。
         com.chat.uikit.chat.SpaceSyncCoordinator.installSyncGate();
 
+        // Space 串消息诊断日志 — wkbase 不能反向依赖 wkuikit, 用 install 桥让
+        // SpaceFilter 日志能反查 Space 名. SpaceModel 缓存为 null 时返回 null,
+        // 不触发网络请求, 永远安全.
+        com.chat.base.space.SpaceNameLookup.install(spaceId -> {
+            if (spaceId == null || spaceId.isEmpty()) return null;
+            java.util.List<com.chat.uikit.space.SpaceEntity> list =
+                    com.chat.uikit.space.SpaceModel.getInstance().getCachedSpaces();
+            if (list == null) return null;
+            for (com.chat.uikit.space.SpaceEntity s : list) {
+                if (s != null && spaceId.equals(s.space_id)) return s.name;
+            }
+            return null;
+        });
+
         //  (P-04) · App Startup Initializer 分阶段化
         //   Phase-A（同步，上面已完成）：initKitModuleListener——纯内存映射，必须在
         //       Intent 到达 ChatActivity 之前就绪。

--- a/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
+++ b/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
@@ -221,12 +221,17 @@ public class WKUIKitApplication {
         //
         // initIM() 必须同步执行：ViewPager2 重构后 ChatFragment 布局阶段即触发 DB 查询，
         // 若 initIM 仍在后台异步，重启时 UI 跑在 init 前面导致会话列表空白。
+        //
+        // initIMListener() 也必须同步执行（与 initIM 同帧）：
+        //   addOnSyncConversationListener 在这里注册。如果异步化（如曾经的 postPhaseB），
+        //   WKConnection 连接成功后 SyncGate.allow→setSyncConversationListener 会因
+        //   iSyncConversationChat==null 静默 return，SyncGate.done() 永不调用 →
+        //   permit 锁死 10s（STUCK_RESET_MS），ChatFragment 冷启动会话列表
+        //   只剩 SYSTEM_BOTS 兜底的 3-4 个 Bot。ConversationManager 侧已加
+        //   onBack(null) 兜底，这里再做主防：listener 必须在连接之前就位。
         parseLocalSensitiveWords();
         initIM();
-
-        AppStartup.postPhaseB("wkim", () -> {
-            WKIMUtils.getInstance().initIMListener();
-        });
+        WKIMUtils.getInstance().initIMListener();
 
         // Phase-C — sensitive_words / prohibit words 网络同步 + 阅后即焚清理（首屏不依赖）
         AppStartup.postPhaseC("post-wkim-idle", () -> {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -101,6 +101,7 @@ import com.chat.base.space.SpaceFilter;
 import com.chat.base.ui.Theme;
 import com.chat.base.ui.components.NumberTextView;
 import com.chat.base.ui.components.SystemMsgBackgroundColorSpan;
+import com.chat.base.ui.components.AvatarView;
 import com.chat.base.utils.ActManagerUtils;
 import com.chat.base.utils.AndroidUtilities;
 import com.chat.base.utils.LayoutHelper;
@@ -174,6 +175,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
@@ -910,6 +912,16 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
 
             if ((member != null && member.isDeleted == 1) || channelType == WKChannelType.CUSTOMER_SERVICE)
                 return;
+            // 对齐 iOS：点击群聊顶部标题/头像区域时主动翻新头像 cacheKey，
+            // 让列表 / 头部 AvatarView 重新加载，绕过服务端不下发 avatar_cache_key 的限制。
+            if (channelType == WKChannelType.GROUP) {
+                WKChannel ch = WKIM.getInstance().getChannelManager().getChannel(channelId, channelType);
+                if (ch != null) {
+                    AvatarView.clearCache(channelId, channelType);
+                    ch.avatarCacheKey = UUID.randomUUID().toString().replace("-", "");
+                    WKIM.getInstance().getChannelManager().setRefreshChannel(ch, true);
+                }
+            }
             Intent intent;
             if (channelType == WKChannelType.COMMUNITY_TOPIC) {
                 intent = new Intent(ChatActivity.this, ThreadDetailActivity.class);

--- a/wkuikit/src/main/java/com/chat/uikit/chat/SpaceSyncCoordinator.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/SpaceSyncCoordinator.java
@@ -116,6 +116,7 @@ public final class SpaceSyncCoordinator {
         // 1) per-path debounce
         Long last = lastTriggerAt.get(tag);
         if (last != null && (now - last) < debounceMs) {
+            diagLog(tag, "debounced", now - last);
             return false;
         }
 
@@ -125,17 +126,21 @@ public final class SpaceSyncCoordinator {
             long started = syncStartedAt;
             if (started != 0L && (now - started) > STUCK_RESET_MS) {
                 syncing.compareAndSet(true, false);
+                diagLog(tag, "stuck-reset", now - started);
             } else {
+                diagLog(tag, "rejected-syncing", now - started);
                 return false;
             }
         }
 
         // 3) 抢 permit
         if (!syncing.compareAndSet(false, true)) {
+            diagLog(tag, "lost-race", 0L);
             return false;
         }
         syncStartedAt = now;
         lastTriggerAt.put(tag, now);
+        diagLog(tag, "begin", 0L);
         return true;
     }
 
@@ -145,8 +150,31 @@ public final class SpaceSyncCoordinator {
      */
     @AnyThread
     public void complete() {
+        long started = syncStartedAt;
+        long elapsed = started > 0 ? SystemClock.elapsedRealtime() - started : -1L;
         syncing.compareAndSet(true, false);
         syncStartedAt = 0L;
+        diagLog("*", "complete", elapsed);
+    }
+
+    /**
+     * Space 串消息排查埋点 — 把每条 sync 路径的状态转换记到 DiagSink. 业务零侵入,
+     * 仅在 DiagSink 启用时落盘. tag="performSpaceSwitch" 对应用户主动切换 Space,
+     * 是排查"切 Space 后还在显示旧 Space 消息"的关键时间点.
+     */
+    private static void diagLog(@NonNull String tag, @NonNull String event, long elapsedMs) {
+        try {
+            String currentSpaceId = com.chat.base.space.SpaceFilter.getCurrentSpaceId();
+            String currentSpaceName = com.chat.base.space.SpaceNameLookup.nameOf(currentSpaceId);
+            com.chat.base.utils.DiagSink.write(
+                    "SPACE-SYNC",
+                    "tag=" + tag + " event=" + event
+                            + " elapsedMs=" + elapsedMs
+                            + " currentSpaceId=" + currentSpaceId
+                            + " currentSpaceName='" + (currentSpaceName == null ? "" : currentSpaceName) + "'"
+            );
+        } catch (Throwable ignored) {
+        }
     }
 
     /** 当前是否有 sync 正在进行。用于 UX overlay 判断是否显示 spinner。 */

--- a/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKIMUtils.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKIMUtils.java
@@ -270,6 +270,14 @@ public class WKIMUtils {
                         // 不在订阅列表 → 收不到 1003. 我收到的 1003 永远是别人被踢, 我的
                         // memberships 没变, 不触发 sync.
                         GroupModel.getInstance().groupMembersSync(msgList.get(i).channelID, null);
+                        // 防御性兜底: 如果未来 server 改了 IMRemoveSubscriber/发通知的顺序,
+                        // 或出现 race 让我自己也收到了 1003, isMyUidInGroupMemberMsgExtra
+                        // 命中即触发 refresh, 避免 stale group 在 SpaceFilter 缓存里串台.
+                        // 当前 server 实现下这条分支永远不会进, 触发也只会被
+                        // SpaceSyncCoordinator debounce 掉, 零副作用.
+                        if (isMyUidInGroupMemberMsgExtra(msgList.get(i))) {
+                            needsMembershipRefresh = true;
+                        }
                     } else {
                         if (msgList.get(i).type != WKContentType.WK_INSIDE_MSG) {
                             isAlertMsg = true;

--- a/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKIMUtils.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKIMUtils.java
@@ -57,6 +57,7 @@ import com.chat.base.views.pwdview.NumPwdDialog;
 import com.chat.uikit.R;
 import com.chat.uikit.WKUIKitApplication;
 import com.chat.uikit.chat.ChatActivity;
+import com.chat.uikit.chat.SpaceSyncCoordinator;
 import com.chat.uikit.contacts.service.FriendModel;
 import com.chat.uikit.db.WKContactsDB;
 import com.chat.uikit.enity.ProhibitWord;
@@ -85,6 +86,7 @@ import com.xinbida.wukongim.msgmodel.WKTextContent;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.json.JSONArray;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -233,18 +235,40 @@ public class WKIMUtils {
             byte channelType = WKChannelType.PERSONAL;
             WKMsg sensitiveWordsMsg = null;
             String loginUID = WKConfig.getInstance().getUid();
+            // 方案 B (跨 Space 串台兜底): 本批次内若有任一群成员关系变更事件,
+            // 循环结束后触发一次 conv/sync 增量刷新 space_memberships,
+            // 让 SpaceFilter 在后续 realtime 消息到达时能给出权威判定,
+            // 避免新加入群的首条消息撞 fail-open 串到当前 Space.
+            // 详见 triggerSpaceMembershipsRefresh() javadoc.
+            boolean needsMembershipRefresh = false;
             if (WKReader.isNotEmpty(msgList)) {
                 channelID = msgList.get(msgList.size() - 1).channelID;
                 channelType = msgList.get(msgList.size() - 1).channelType;
                 for (int i = 0, size = msgList.size(); i < size; i++) {
                     inferSpaceIdForBotMessage(msgList.get(i));
                     if (msgList.get(i).type == WKContentType.setNewGroupAdmin) {
+                        // admin 角色变更不影响 my memberships, 不触发 sync
                         GroupModel.getInstance().groupMembersSync(msgList.get(i).channelID, null);
                     } else if (msgList.get(i).type == WKContentType.groupSystemInfo) {
+                        // 群属性变更 (名称/公告/禁言); 也可能是 group create 通知
+                        // (server SendGroupCreate 走 octo-lib, 客户端无法区分子类型). 保守触发 sync.
                         WKCommonModel.getInstance().getChannel(msgList.get(i).channelID, WKChannelType.GROUP, null);
                         GroupModel.getInstance().groupMembersSync(msgList.get(i).channelID, null);
-                    } else if (msgList.get(i).type == WKContentType.addGroupMembersMsg || msgList.get(i).type == WKContentType.removeGroupMembersMsg) {
-                        //同步信息
+                        needsMembershipRefresh = true;
+                    } else if (msgList.get(i).type == WKContentType.addGroupMembersMsg) {
+                        // 群加人. server 发给所有群成员包括被加者本人 (service.go:1506,
+                        // payload: {type:1002, content, extra:[{uid,name},...]}, iOS 解析参考
+                        // WKSystemMessageCell.m:80-102). 只有 my uid 在 extra 列表里时才触发 sync,
+                        // 否则是其他成员被加, 我的 memberships 没变.
+                        GroupModel.getInstance().groupMembersSync(msgList.get(i).channelID, null);
+                        if (isMyUidInGroupMemberMsgExtra(msgList.get(i))) {
+                            needsMembershipRefresh = true;
+                        }
+                    } else if (msgList.get(i).type == WKContentType.removeGroupMembersMsg) {
+                        // 群减人. server 先 IMRemoveSubscriber 把被踢用户从频道踢掉
+                        // (service.go:1700-1704), 再发 1003 通知 (1707-1713). 被踢用户已经
+                        // 不在订阅列表 → 收不到 1003. 我收到的 1003 永远是别人被踢, 我的
+                        // memberships 没变, 不触发 sync.
                         GroupModel.getInstance().groupMembersSync(msgList.get(i).channelID, null);
                     } else {
                         if (msgList.get(i).type != WKContentType.WK_INSIDE_MSG) {
@@ -293,6 +317,12 @@ public class WKIMUtils {
                         }
                     }
                 }
+            }
+            // 方案 B: 本批次有任一群成员关系变更 → 触发一次 memberships 增量刷新.
+            // 放在 for 循环外, 多个事件汇聚成一次 sync; SpaceSyncCoordinator 进一步
+            // 做 500ms per-path debounce, 突发场景 (一次拉进多个群) 不会发多次请求.
+            if (needsMembershipRefresh) {
+                triggerSpaceMembershipsRefresh();
             }
             boolean isVibrate = true;
             boolean playNewMsgMedia = true;
@@ -931,6 +961,85 @@ public class WKIMUtils {
         } catch (Exception ignored) {
         }
         return null;
+    }
+
+    /**
+     * 方案 B · 判定 1002/1003 群成员变更消息中 {@code extra} 字段是否包含登录用户的 uid.
+     *
+     * <p>JSON 结构 (server modules/group/event.go:645-651 构造, iOS WKSystemMessageCell.m:80-102 解析):
+     * <pre>{@code
+     * {
+     *   "type": 1002,
+     *   "content": "...",
+     *   "extra": [{"uid": "u1", "name": "n1"}, ...]
+     * }
+     * }</pre>
+     *
+     * <p>用于判定 "群加人事件是不是把我自己加进去". 命中即说明我的 memberships
+     * 发生变化, 需触发 conv/sync 刷新. 不命中说明是别的成员被加, 跳过 sync.
+     *
+     * <p>容错: msg/content/json 任一环节异常都返回 false, fallback 到不刷新——
+     * 比 fail-open 漏过更糟的是误触发额外 sync, 但 false 路径下一次 1005 / cold-start
+     * sync 也能补齐, 实际影响有限.
+     */
+    private boolean isMyUidInGroupMemberMsgExtra(WKMsg msg) {
+        if (msg == null || TextUtils.isEmpty(msg.content)) return false;
+        String myUid = WKConfig.getInstance().getUid();
+        if (TextUtils.isEmpty(myUid)) return false;
+        try {
+            JSONObject json = new JSONObject(msg.content);
+            JSONArray extra = json.optJSONArray("extra");
+            if (extra == null) return false;
+            for (int i = 0, n = extra.length(); i < n; i++) {
+                JSONObject item = extra.optJSONObject(i);
+                if (item == null) continue;
+                if (myUid.equals(item.optString("uid"))) {
+                    return true;
+                }
+            }
+        } catch (Throwable ignored) {
+            // JSON 异常: payload 格式与预期不符, 保守返回 false.
+            // 实际生产中 server 格式稳定, 走这条路径的概率近 0.
+        }
+        return false;
+    }
+
+    /**
+     * 方案 B · 群成员关系变更后, 触发一次 conv/sync 增量刷新 space_memberships,
+     * 让 SpaceFilter 在后续 realtime 消息到达时能给出权威空间归属判定,
+     * 避免新加入群的首条消息撞 SpaceFilter fail-open 分支被错挂到当前 Space.
+     *
+     * <p>背景: server PR #154 把 conversation/sync 响应的 {@code space_memberships}
+     * 设为 SpaceFilter 的权威源。客户端现有 3 个 conv/sync 触发点:
+     * <ol>
+     *   <li>冷启动 — WKConnection 连接成功后</li>
+     *   <li>Space 切换 — {@code performSpaceSwitch}</li>
+     *   <li>resync — {@code spaceResyncRunnable}</li>
+     * </ol>
+     * 但 "用户被加入新群" 不在任何一个触发点上 — 服务端发 {@code groupSystemInfo}
+     * 后, 现有逻辑只触发 {@code groupMembersSync} (member 级), 不刷新 memberships
+     * (space 级)。下一条该群消息到达时, SpaceFilter 4 个数据源全空 → fail-open →
+     * 串台。
+     *
+     * <p>本方法补齐第 4 个触发点: "本地已知 membership 发生变化时"。
+     *
+     * <p>线程: 走 IO + SpaceSyncCoordinator (500ms per-path debounce, 与其他
+     * sync 路径共享全局重入守卫), 一次拉多群的突发场景只发 1 次 sync.
+     *
+     * <p>过渡性: 若 server 后续在 realtime msg payload 里直接带 space_id, SDK
+     * 收到消息时同步写 convSyncSpaceMap, SpaceFilter 直接拿到权威值, 本方法
+     * 可整体删除. 在那之前, 这是客户端关闭 race window 的最经济方案.
+     */
+    private void triggerSpaceMembershipsRefresh() {
+        if (!SpaceSyncCoordinator.getInstance().tryBegin("groupMembershipChange")) {
+            // 已有 sync 在路上 / 500ms 内已触发过 → drop, 让前一次 sync 的结果覆盖
+            return;
+        }
+        Schedulers.io().scheduleDirect(() -> {
+            WKIM.getInstance().getConversationManager().setSyncConversationListener(result -> {
+                SpaceSyncCoordinator.getInstance().complete();
+            });
+        });
     }
 
     /**

--- a/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
+++ b/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
@@ -1419,13 +1419,12 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
             }
         }
         // 子区未读（allThreadConversations 独立于 allConversations）
-        long threeDaysAgoForBadge = System.currentTimeMillis() / 1000 - 3L * 24 * 60 * 60;
         for (ChatConversationMsg threadMsg : allThreadConversations) {
             if (threadMsg.uiConversationMsg == null) continue;
             if (threadMsg.uiConversationMsg.getWkChannel() != null && threadMsg.uiConversationMsg.getWkChannel().mute == 1)
                 continue;
             long ts = threadMsg.uiConversationMsg.lastMsgTimestamp;
-            if (ts <= 0 || ts <= threeDaysAgoForBadge) continue;
+            if (ts <= 0) continue;
             recentUnread += threadMsg.uiConversationMsg.unreadCount;
         }
         // 关注 Tab 未读
@@ -2862,10 +2861,7 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
 
     private static boolean isInactiveGroup(ChatConversationMsg msg) {
         if (msg.uiConversationMsg.channelType != WKChannelType.GROUP) return false;
-        long ts = msg.uiConversationMsg.lastMsgTimestamp;
-        if (ts <= 0) return true;
-        long now = System.currentTimeMillis() / 1000;
-        return (now - ts) >= 3 * 86400;
+        return msg.uiConversationMsg.lastMsgTimestamp <= 0;
     }
 
     private List<ChatConversationMsg> buildRecentDisplayList() {
@@ -2884,13 +2880,12 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
             }
         }
 
-        long threeDaysAgoSec = System.currentTimeMillis() / 1000 - 3L * 24 * 60 * 60;
         Map<String, List<com.chat.uikit.thread.service.entity.ThreadEntity>> threadCache =
                 followAdapter.getThreadDataCache();
         for (ChatConversationMsg threadMsg : allThreadConversations) {
             if (threadMsg.uiConversationMsg == null) continue;
             long ts = threadMsg.uiConversationMsg.lastMsgTimestamp;
-            if (ts <= 0 || ts <= threeDaysAgoSec) continue;
+            if (ts <= 0) continue;
 
             if (threadMsg.threadName == null || threadMsg.threadName.isEmpty()) {
                 String channelId = threadMsg.uiConversationMsg.channelID;

--- a/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
+++ b/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
@@ -1478,41 +1478,12 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
     }
 
     private void updateGroupMentionBadge() {
+        // 关注 tab 上的橘色 "@" badge 暂时下线: server 端 reminder.version 协议存在
+        // 单调性问题(详见 2026-06-27 reminder sync 根因报告), incremental sync 经常返回空,
+        // tab 级 badge 大部分时间漏报反而误导. 最近 tab 内单条会话行的 "[有人@你]"
+        // 标签独立路径(ChatConversationAdapter), 保留不动. 等 server 修完再恢复本方法.
         if (segmentTabView == null || !isAdded()) return;
-        FollowedKeysStore store = FollowedKeysStore.getInstance();
-        boolean hasMention = false;
-        List<ChatConversationMsg> source = allConversations.isEmpty()
-                ? chatConversationAdapter.getData() : allConversations;
-        for (ChatConversationMsg item : source) {
-            if (item.isSectionHeader || item.uiConversationMsg == null) continue;
-            String channelID = item.uiConversationMsg.channelID;
-            byte channelType = item.uiConversationMsg.channelType;
-            boolean isFollowed = false;
-            if (channelType == WKChannelType.GROUP) {
-                isFollowed = store.isFollowed(SidebarItemEntity.TARGET_TYPE_CHANNEL, channelID);
-            } else if (channelType == WKChannelType.PERSONAL) {
-                isFollowed = store.isFollowed(SidebarItemEntity.TARGET_TYPE_DM, channelID);
-            } else if (channelType == WKChannelType.COMMUNITY_TOPIC) {
-                isFollowed = store.isFollowed(SidebarItemEntity.TARGET_TYPE_THREAD, channelID);
-            }
-            if (!isFollowed) continue;
-
-            List<WKReminder> reminders = item.getReminders();
-            if (WKReader.isNotEmpty(reminders)) {
-                for (WKReminder r : reminders) {
-                    if (r.type == WKMentionType.WKReminderTypeMentionMe && r.done == 0) {
-                        hasMention = true;
-                        break;
-                    }
-                }
-            }
-            if (!hasMention && channelType == WKChannelType.GROUP) {
-                hasMention = ReminderDBManager.getInstance().hasUndoneReminderWithChannelPrefix(
-                        channelID, WKMentionType.WKReminderTypeMentionMe);
-            }
-            if (hasMention) break;
-        }
-        segmentTabView.setMentionBadge(0, hasMention, getString(R.string.last_msg_remind));
+        segmentTabView.setMentionBadge(0, false, null);
     }
 
     @Override

--- a/wkuikit/src/main/java/com/chat/uikit/setting/WKAboutActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/setting/WKAboutActivity.java
@@ -87,9 +87,7 @@ public class WKAboutActivity extends WKBaseActivity<ActAboutLayoutBinding> {
 
         checkNewVersion(false);
         String v = WKDeviceUtils.getInstance().getVersionName(this);
-        // 临时标记 — 装上新版后版本号会显示 "version 1.3.3-diag"; 旧版仍显示 "version 1.3.3".
-        // 排查结束后这个 -diag 后缀和上面整段诊断采集代码一起删.
-        wkVBinding.versionTv.setText(String.format("version %s-diag", v));
+        wkVBinding.versionTv.setText(String.format("version %s", v));
         wkVBinding.appNameTv.setText(R.string.app_name);
 
         // Debug 模式：连续点击版本号 5 次模拟 ANR（测试 ANRWatchdog 采集）
@@ -119,14 +117,10 @@ public class WKAboutActivity extends WKBaseActivity<ActAboutLayoutBinding> {
         }
         diagLastTapAt = now;
         android.util.Log.d("DiagSink", "icon tap count=" + diagTapCount);
-        // 倒数 3 击开始给反馈, 避免用户怀疑没点中
-        int remaining = DIAG_TAP_THRESHOLD - diagTapCount;
         if (diagTapCount >= DIAG_TAP_THRESHOLD) {
             diagTapCount = 0;
             diagLastTapAt = 0L;
             showDiagDialog();
-        } else if (remaining <= 3) {
-            WKToastUtils.getInstance().showToastNormal("还差 " + remaining + " 次");
         }
     }
 
@@ -134,24 +128,44 @@ public class WKAboutActivity extends WKBaseActivity<ActAboutLayoutBinding> {
         boolean enabled = com.chat.base.utils.DiagSink.isEnabled();
         androidx.appcompat.app.AlertDialog.Builder builder =
                 new androidx.appcompat.app.AlertDialog.Builder(this);
+        // positive 按钮颜色: 开启用品牌紫(primary), 关闭用提醒红(destructive); negative 一律用灰.
+        // 用项目已有的色值, 不引入新资源, 排查结束后整段代码删干净.
+        final int positiveColor;
         if (enabled) {
             long until = com.chat.base.utils.DiagSink.getEnabledUntilMs();
             long leftMin = Math.max(0L, (until - System.currentTimeMillis()) / 60000L);
             builder.setTitle("诊断采集进行中")
                     .setMessage("剩余约 " + leftMin + " 分钟。\n复现问题后点本页\"导出诊断日志\"分享。")
-                    .setPositiveButton("立即关闭", (d, w) -> com.chat.base.utils.DiagSink.disable(this))
+                    .setPositiveButton("立即关闭", (d, w) -> {
+                        com.chat.base.utils.DiagSink.disable(this);
+                        WKToastUtils.getInstance().showToastSuccess("诊断采集已关闭");
+                    })
                     .setNegativeButton("继续采集", null);
+            positiveColor = androidx.core.content.ContextCompat.getColor(this, com.chat.base.R.color.reminderColor);
         } else {
             builder.setTitle("开启诊断日志采集")
                     .setMessage("将开启 2 小时诊断采集来定位 Space 消息串台问题。\n开启后请复现问题，再点本页\"导出诊断日志\"分享给我们。\n2 小时后自动关闭。")
                     .setPositiveButton("开启", (d, w) -> {
                         com.chat.base.utils.DiagSink.enable(this, com.chat.base.utils.DiagSink.DEFAULT_TTL_MS);
-                        WKToastUtils.getInstance().showToastNormal("诊断采集已开启");
+                        WKToastUtils.getInstance().showToastSuccess("诊断采集已开启");
                     })
                     .setNegativeButton("取消", null);
+            positiveColor = androidx.core.content.ContextCompat.getColor(this, com.chat.base.R.color.colorAccent);
         }
         try {
-            builder.show();
+            androidx.appcompat.app.AlertDialog dialog = builder.create();
+            // 不允许点空白处关闭, 否则用户继续点图标(落在 dialog 外)会把 dialog 误关.
+            // 返回键仍可关(避免完全锁死), 强制走两个按钮做选择.
+            dialog.setCanceledOnTouchOutside(false);
+            // 按钮颜色必须在 show 之后才能拿到 view, 用 OnShowListener 兜底.
+            int negColor = androidx.core.content.ContextCompat.getColor(this, com.chat.base.R.color.color999);
+            dialog.setOnShowListener(d -> {
+                android.widget.Button pos = dialog.getButton(androidx.appcompat.app.AlertDialog.BUTTON_POSITIVE);
+                android.widget.Button neg = dialog.getButton(androidx.appcompat.app.AlertDialog.BUTTON_NEGATIVE);
+                if (pos != null) pos.setTextColor(positiveColor);
+                if (neg != null) neg.setTextColor(negColor);
+            });
+            dialog.show();
         } catch (Throwable ignored) {
         }
     }

--- a/wkuikit/src/main/java/com/chat/uikit/setting/WKAboutActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/setting/WKAboutActivity.java
@@ -41,6 +41,17 @@ public class WKAboutActivity extends WKBaseActivity<ActAboutLayoutBinding> {
     private int versionClickCount = 0;
     private long lastClickTime = 0;
 
+    // Space 串消息诊断模式隐藏入口: 连点 App 图标 5 次开启 2 小时采集.
+    // 选 aboutIconIv 是因为它独立、不在任何 clickable 容器内, 也没既有点击处理,
+    // 误触零副作用. 同页就有"导出诊断日志"按钮, 流程闭环.
+    //
+    // 窗口策略: 滑动窗口 — 每次点击都把 deadline 顺延 5 秒, 用户慢点也能凑齐.
+    // 后两次点击给 Toast 反馈, 避免"是不是没点中"的疑惑.
+    private static final int DIAG_TAP_THRESHOLD = 5;
+    private static final long DIAG_TAP_WINDOW_MS = 5000L;
+    private int diagTapCount = 0;
+    private long diagLastTapAt = 0L;
+
     @Override
     protected ActAboutLayoutBinding getViewBinding() {
         return ActAboutLayoutBinding.inflate(getLayoutInflater());
@@ -53,6 +64,7 @@ public class WKAboutActivity extends WKBaseActivity<ActAboutLayoutBinding> {
 
     @Override
     protected void initView() {
+        android.util.Log.d("DiagSink", "WKAboutActivity.initView() — diag-icon-tap installed");
 
         SingleClickUtil.onSingleClick(wkVBinding.icpTV, view1 -> {
             // 隐私政策
@@ -66,9 +78,18 @@ public class WKAboutActivity extends WKBaseActivity<ActAboutLayoutBinding> {
         });
         SingleClickUtil.onSingleClick(wkVBinding.checkNewVersionLayout, view1 -> checkNewVersion(true));
         SingleClickUtil.onSingleClick(wkVBinding.exportDiagLogLayout, view1 -> DiagnosticLogFile.share(this));
+
+        // Space 串消息诊断: 连点 App 图标 5 次(滑动窗口 5 秒)弹开关 dialog. 后 3 击给 Toast
+        // 反馈, 用户不会怀疑没点中. 排查结束后整段可删.
+        wkVBinding.aboutIconIv.setClickable(true);
+        wkVBinding.aboutIconIv.setFocusable(true);
+        wkVBinding.aboutIconIv.setOnClickListener(v -> onDiagIconTap());
+
         checkNewVersion(false);
         String v = WKDeviceUtils.getInstance().getVersionName(this);
-        wkVBinding.versionTv.setText(String.format("version %s", v));
+        // 临时标记 — 装上新版后版本号会显示 "version 1.3.3-diag"; 旧版仍显示 "version 1.3.3".
+        // 排查结束后这个 -diag 后缀和上面整段诊断采集代码一起删.
+        wkVBinding.versionTv.setText(String.format("version %s-diag", v));
         wkVBinding.appNameTv.setText(R.string.app_name);
 
         // Debug 模式：连续点击版本号 5 次模拟 ANR（测试 ANRWatchdog 采集）
@@ -86,6 +107,52 @@ public class WKAboutActivity extends WKBaseActivity<ActAboutLayoutBinding> {
                     }, 500);
                 }
             });
+        }
+    }
+
+    private void onDiagIconTap() {
+        long now = System.currentTimeMillis();
+        if (diagTapCount == 0 || (now - diagLastTapAt) > DIAG_TAP_WINDOW_MS) {
+            diagTapCount = 1;
+        } else {
+            diagTapCount++;
+        }
+        diagLastTapAt = now;
+        android.util.Log.d("DiagSink", "icon tap count=" + diagTapCount);
+        // 倒数 3 击开始给反馈, 避免用户怀疑没点中
+        int remaining = DIAG_TAP_THRESHOLD - diagTapCount;
+        if (diagTapCount >= DIAG_TAP_THRESHOLD) {
+            diagTapCount = 0;
+            diagLastTapAt = 0L;
+            showDiagDialog();
+        } else if (remaining <= 3) {
+            WKToastUtils.getInstance().showToastNormal("还差 " + remaining + " 次");
+        }
+    }
+
+    private void showDiagDialog() {
+        boolean enabled = com.chat.base.utils.DiagSink.isEnabled();
+        androidx.appcompat.app.AlertDialog.Builder builder =
+                new androidx.appcompat.app.AlertDialog.Builder(this);
+        if (enabled) {
+            long until = com.chat.base.utils.DiagSink.getEnabledUntilMs();
+            long leftMin = Math.max(0L, (until - System.currentTimeMillis()) / 60000L);
+            builder.setTitle("诊断采集进行中")
+                    .setMessage("剩余约 " + leftMin + " 分钟。\n复现问题后点本页\"导出诊断日志\"分享。")
+                    .setPositiveButton("立即关闭", (d, w) -> com.chat.base.utils.DiagSink.disable(this))
+                    .setNegativeButton("继续采集", null);
+        } else {
+            builder.setTitle("开启诊断日志采集")
+                    .setMessage("将开启 2 小时诊断采集来定位 Space 消息串台问题。\n开启后请复现问题，再点本页\"导出诊断日志\"分享给我们。\n2 小时后自动关闭。")
+                    .setPositiveButton("开启", (d, w) -> {
+                        com.chat.base.utils.DiagSink.enable(this, com.chat.base.utils.DiagSink.DEFAULT_TTL_MS);
+                        WKToastUtils.getInstance().showToastNormal("诊断采集已开启");
+                    })
+                    .setNegativeButton("取消", null);
+        }
+        try {
+            builder.show();
+        } catch (Throwable ignored) {
         }
     }
 

--- a/wkuikit/src/main/java/com/chat/uikit/setting/WKAboutActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/setting/WKAboutActivity.java
@@ -64,7 +64,6 @@ public class WKAboutActivity extends WKBaseActivity<ActAboutLayoutBinding> {
 
     @Override
     protected void initView() {
-        android.util.Log.d("DiagSink", "WKAboutActivity.initView() — diag-icon-tap installed");
 
         SingleClickUtil.onSingleClick(wkVBinding.icpTV, view1 -> {
             // 隐私政策
@@ -116,7 +115,6 @@ public class WKAboutActivity extends WKBaseActivity<ActAboutLayoutBinding> {
             diagTapCount++;
         }
         diagLastTapAt = now;
-        android.util.Log.d("DiagSink", "icon tap count=" + diagTapCount);
         if (diagTapCount >= DIAG_TAP_THRESHOLD) {
             diagTapCount = 0;
             diagLastTapAt = 0L;

--- a/wkuikit/src/main/java/com/chat/uikit/space/SpaceModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/space/SpaceModel.java
@@ -50,6 +50,18 @@ public class SpaceModel extends WKBaseModel {
         cachedMembers = null;
     }
 
+    /**
+     * 诊断用: 直接返回当前内存中缓存的 Space 列表(可能为 null, 表示尚未首次加载).
+     * 调用方需自行处理 null. 返回不可变副本以防外部修改污染缓存.
+     *
+     * <p>用途: {@code DiagSink} 写诊断日志时通过 space_id 反查 Space 名字,
+     * 让 review 时不用查表. 不触发网络请求, 拿不到就拿不到.
+     */
+    public java.util.List<SpaceEntity> getCachedSpaces() {
+        if (cachedSpaces == null) return null;
+        return new ArrayList<>(cachedSpaces);
+    }
+
     public interface ISpaceListListener {
         void onResult(List<SpaceEntity> list);
 


### PR DESCRIPTION
Closes #77

## Summary

本分支累积了 11 个 commit, 涵盖以下主题:

- **冷启动**: 同步化 WKIM listener 注册, 解决冷启只显示 SYSTEM_BOTS
- **Space 修复**: 群成员变更刷新 space_memberships; 1003 群减人事件防御性 refresh
- **诊断模式**: Space 串消息异步采集 + 关于页隐藏入口 / dialog UX / 清理临时 Log / 内部 API 标记
- **关注 Tab**: @badge 暂时下线 (等 server reminder.version 修复)
- **最近 Tab**: 放开群聊 / 子区 3 天活跃过滤, 全部展示
- **群头像**: 点击群聊顶部主动刷新头像缓存, 对齐 iOS
- 版本号 bump 到 1.3.4 (35)

## Test plan

- [ ] 冷启动: 杀进程冷启, 列表正常显示所有会话 (非只 SYSTEM_BOTS)
- [ ] Space: 1003 群减人后列表正常刷新, 跨 Space 切换无 race
- [ ] 诊断模式: 关于页隐藏入口可进入, dialog UX 正常
- [ ] 最近 Tab: 超过 3 天未活跃的群也展示, 角标包含老群未读
- [ ] 群头像: 群主换头像 → 点击群聊顶部头像/标题 → 返回最近 Tab 头像刷新
- [ ] 私聊 / 子区 / 其他 channel 类型回归无异常
