### PR TITLE
feat(channel-search): OpenSearch 频道搜索 + 子区查找入口 + 图片搜索切新接口 (v1.3.5)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
         applicationId appId
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 35
-        versionName "1.3.4"
+        versionCode 36
+        versionName "1.3.5"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/wkbase/src/main/java/com/chat/base/search/channel/ChannelSearchBodyBuilder.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/ChannelSearchBodyBuilder.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel
+
+import com.alibaba.fastjson.JSONObject
+import com.chat.base.search.channel.dto.AroundRequest
+import com.chat.base.search.channel.dto.ChannelSearchReq
+import com.chat.base.search.channel.dto.SearchFilters
+
+/**
+ * 把强类型请求结构序列化为 FastJSON [JSONObject]，对齐 octo-server `modules/messages_search/validate.go`。
+ *
+ * - keyword、cursor 为空时**不写入** body，避免被服务端 `keywordOrFilterRequired` 校验误判（[ChannelSearchReq]
+ *   允许 keyword 为空 + filters 非空的"纯过滤"模式）。
+ * - SearchFilters 完全为空时整个 filters 字段省略。
+ * - 客户端不进行二次校验（如 keyword 长度），交由服务端 400 反馈，避免与服务端规则漂移。
+ */
+internal object ChannelSearchBodyBuilder {
+
+    fun build(req: ChannelSearchReq, allowKeyword: Boolean = true): JSONObject {
+        val body = JSONObject()
+        body["channel_type"] = req.channelType.toInt()
+        body["channel_id"] = req.channelId
+        if (allowKeyword && !req.keyword.isNullOrEmpty()) {
+            body["keyword"] = req.keyword
+        }
+        req.filters?.takeUnless { it.isEmpty() }?.let { body["filters"] = filtersToJson(it) }
+        body["sort"] = req.sort
+        body["page_size"] = req.pageSize
+        if (!req.cursor.isNullOrEmpty()) body["cursor"] = req.cursor
+        return body
+    }
+
+    fun buildAround(req: AroundRequest): JSONObject {
+        val body = JSONObject()
+        body["channel_type"] = req.channelType.toInt()
+        body["channel_id"] = req.channelId
+        body["anchor_message_id"] = req.anchorMessageId
+        req.filters?.takeUnless { it.isEmpty() }?.let { body["filters"] = filtersToJson(it) }
+        body["page_size"] = req.pageSize
+        return body
+    }
+
+    private fun filtersToJson(f: SearchFilters): JSONObject {
+        val out = JSONObject()
+        f.senderIds?.takeIf { it.isNotEmpty() }?.let { out["sender_ids"] = it }
+        f.sentAtFrom?.takeIf { it.isNotEmpty() }?.let { out["sent_at_from"] = it }
+        f.sentAtTo?.takeIf { it.isNotEmpty() }?.let { out["sent_at_to"] = it }
+        return out
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/ChannelSearchErrorParser.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/ChannelSearchErrorParser.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel
+
+import com.alibaba.fastjson.JSON
+import com.chat.base.search.channel.dto.SearchErrorBody
+
+/**
+ * 解析 octo-server `modules/messages_search` 的错误信封：
+ * `{ "error": { "code": "err.server.messages_search.xxx", "message": "...", "details": {...}, "http_status": N } }`
+ *
+ * 旧的 `{ "status": N, "msg": "..." }` 形态由 [com.chat.base.net.ResponseExceptionHandle] 处理，
+ * 不在此覆盖。
+ */
+internal object ChannelSearchErrorParser {
+
+    data class ParsedError(
+        val code: String,
+        val message: String,
+        val retryAfterSec: Int,
+    )
+
+    fun parse(errJson: String?): ParsedError? {
+        if (errJson.isNullOrBlank()) return null
+        return runCatching {
+            val body = JSON.parseObject(errJson, SearchErrorBody::class.java) ?: return null
+            val err = body.error ?: return null
+            if (err.code.isBlank()) return null
+            ParsedError(
+                code = err.code,
+                message = err.message,
+                retryAfterSec = (err.details?.get("retry_after") as? Number)?.toInt() ?: 0,
+            )
+        }.getOrNull()
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/ChannelSearchModel.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/ChannelSearchModel.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel
+
+import com.chat.base.base.WKBaseModel
+import com.chat.base.net.IRequestResultErrorInfoListener
+import com.chat.base.search.channel.dto.AroundRequest
+import com.chat.base.search.channel.dto.AroundResult
+import com.chat.base.search.channel.dto.ChannelSearchReq
+import com.chat.base.search.channel.dto.CombinedHit
+import com.chat.base.search.channel.dto.CursorList
+import com.chat.base.search.channel.dto.FileHit
+import com.chat.base.search.channel.dto.MediaHit
+import com.chat.base.search.channel.dto.MessageHit
+import com.chat.base.search.channel.dto.SearchErrorCode
+import io.reactivex.rxjava3.core.Observable
+
+/**
+ * 频道内搜索数据编排层。负责：
+ *  - 序列化请求体（[ChannelSearchBodyBuilder]）
+ *  - 发起 5 个 `/v1/messages/_search*` 请求
+ *  - 把服务端结构化错误码解析进 [ChannelSearchOutcome]
+ *
+ * 本地兜底不在此层处理。UI 层根据 [uiAction] 判断是否调用 IMSDK
+ * `WKIM.msgManager.searchWithChannel` 取本地结果，并在 [ChannelSearchOutcome.success] 时把
+ * `fromLocalFallback=true` 标记上。
+ *
+ * `X-Space-Id` 由 `CommonRequestParamInterceptor` 自动注入。
+ */
+object ChannelSearchModel : WKBaseModel() {
+
+    private val service by lazy { createService(ChannelSearchService::class.java) }
+
+    fun searchMessages(
+        req: ChannelSearchReq,
+        callback: (ChannelSearchOutcome<CursorList<MessageHit>>) -> Unit,
+    ) {
+        dispatch(service.searchMessages(ChannelSearchBodyBuilder.build(req)), callback)
+    }
+
+    fun searchAll(
+        req: ChannelSearchReq,
+        callback: (ChannelSearchOutcome<CursorList<CombinedHit>>) -> Unit,
+    ) {
+        dispatch(service.searchAll(ChannelSearchBodyBuilder.build(req)), callback)
+    }
+
+    fun searchMedia(
+        req: ChannelSearchReq,
+        callback: (ChannelSearchOutcome<CursorList<MediaHit>>) -> Unit,
+    ) {
+        // 服务端：_search_media keyword 必须为空，否则 400 VALIDATION_FAILED。
+        dispatch(service.searchMedia(ChannelSearchBodyBuilder.build(req, allowKeyword = false)), callback)
+    }
+
+    fun searchFiles(
+        req: ChannelSearchReq,
+        callback: (ChannelSearchOutcome<CursorList<FileHit>>) -> Unit,
+    ) {
+        dispatch(service.searchFiles(ChannelSearchBodyBuilder.build(req)), callback)
+    }
+
+    fun searchAround(
+        req: AroundRequest,
+        callback: (ChannelSearchOutcome<AroundResult>) -> Unit,
+    ) {
+        dispatch(service.searchAround(ChannelSearchBodyBuilder.buildAround(req)), callback)
+    }
+
+    private fun <T : Any> dispatch(observable: Observable<T>, callback: (ChannelSearchOutcome<T>) -> Unit) {
+        requestAndErrorBack(observable, object : IRequestResultErrorInfoListener<T> {
+            override fun onSuccess(result: T) {
+                callback(ChannelSearchOutcome.success(result))
+            }
+
+            override fun onFail(code: Int, msg: String, errJson: String) {
+                callback(mapFailure(code, msg, errJson))
+            }
+        })
+    }
+
+    private fun <T : Any> mapFailure(httpStatus: Int, msg: String, errJson: String): ChannelSearchOutcome<T> {
+        val parsed = ChannelSearchErrorParser.parse(errJson)
+        if (parsed != null) {
+            return ChannelSearchOutcome.failure(
+                httpStatus = httpStatus,
+                errorCode = parsed.code,
+                errorMessage = parsed.message.ifBlank { msg },
+                retryAfterSec = parsed.retryAfterSec,
+            )
+        }
+        // 无结构化 error body：按 HTTP 状态码兜底分类。
+        val fallbackCode = when (httpStatus) {
+            in 500..599 -> SearchErrorCode.UPSTREAM_UNAVAILABLE
+            429 -> SearchErrorCode.RATE_LIMITED
+            404 -> SearchErrorCode.NOT_FOUND
+            400 -> SearchErrorCode.VALIDATION_FAILED
+            0 -> ChannelSearchOutcome.LOCAL_ERROR_NETWORK   // ResponseExceptionHandle 对网络异常通常给非 HTTP code
+            else -> SearchErrorCode.INTERNAL
+        }
+        return ChannelSearchOutcome.failure(httpStatus = httpStatus, errorCode = fallbackCode, errorMessage = msg)
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/ChannelSearchModel.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/ChannelSearchModel.kt
@@ -104,12 +104,14 @@ object ChannelSearchModel : WKBaseModel() {
             )
         }
         // 无结构化 error body：按 HTTP 状态码兜底分类。
-        val fallbackCode = when (httpStatus) {
-            in 500..599 -> SearchErrorCode.UPSTREAM_UNAVAILABLE
-            429 -> SearchErrorCode.RATE_LIMITED
-            404 -> SearchErrorCode.NOT_FOUND
-            400 -> SearchErrorCode.VALIDATION_FAILED
-            0 -> ChannelSearchOutcome.LOCAL_ERROR_NETWORK   // ResponseExceptionHandle 对网络异常通常给非 HTTP code
+        // 注意：ResponseExceptionHandle 对非 HttpException（连接失败、超时、DNS 等传输层异常）分配 code = -1；
+        // 任何非正数都视作传输层错误，走 LOCAL_ERROR_NETWORK → FALLBACK_TO_LOCAL，触发本地 IMSDK 兜底搜索。
+        val fallbackCode = when {
+            httpStatus in 500..599 -> SearchErrorCode.UPSTREAM_UNAVAILABLE
+            httpStatus == 429 -> SearchErrorCode.RATE_LIMITED
+            httpStatus == 404 -> SearchErrorCode.NOT_FOUND
+            httpStatus == 400 -> SearchErrorCode.VALIDATION_FAILED
+            httpStatus <= 0 -> ChannelSearchOutcome.LOCAL_ERROR_NETWORK
             else -> SearchErrorCode.INTERNAL
         }
         return ChannelSearchOutcome.failure(httpStatus = httpStatus, errorCode = fallbackCode, errorMessage = msg)

--- a/wkbase/src/main/java/com/chat/base/search/channel/ChannelSearchOutcome.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/ChannelSearchOutcome.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel
+
+import com.chat.base.search.channel.dto.SearchErrorCode
+
+/**
+ * Model 层 → UI 层的统一返回。`ok=true` 时 [data] 非空；`ok=false` 时 [errorCode] 必填。
+ * 调用方按 [errorCode] 决定 UI 行为（toast / 顶部 banner / 输入禁用倒计时 / 本地兜底）。
+ */
+class ChannelSearchOutcome<T>(
+    val ok: Boolean,
+    val data: T? = null,
+    val httpStatus: Int = 0,
+    /** 服务端结构化错误码或本地态错误，[ChannelSearchOutcome] 内部枚举常量见 [SearchErrorCode] 与 [LOCAL_ERROR_*]。 */
+    val errorCode: String? = null,
+    val errorMessage: String? = null,
+    /** 仅在 [SearchErrorCode.RATE_LIMITED] 时由服务端 details.retry_after 写入。 */
+    val retryAfterSec: Int = 0,
+    /** 是否为本地 IMSDK 兜底结果（仅消息维度）。UI 据此显示"离线结果"banner。 */
+    val fromLocalFallback: Boolean = false,
+) {
+    companion object {
+        /** 网络层异常（连接失败 / 超时），与服务端无关。UI 也应回退到本地兜底。 */
+        const val LOCAL_ERROR_NETWORK = "client.channel_search.network"
+        const val LOCAL_ERROR_PARSE = "client.channel_search.parse"
+        const val LOCAL_ERROR_UNKNOWN = "client.channel_search.unknown"
+
+        fun <T> success(data: T, fromLocalFallback: Boolean = false): ChannelSearchOutcome<T> =
+            ChannelSearchOutcome(ok = true, data = data, httpStatus = 200, fromLocalFallback = fromLocalFallback)
+
+        fun <T> failure(
+            httpStatus: Int,
+            errorCode: String,
+            errorMessage: String? = null,
+            retryAfterSec: Int = 0,
+        ): ChannelSearchOutcome<T> =
+            ChannelSearchOutcome(
+                ok = false,
+                httpStatus = httpStatus,
+                errorCode = errorCode,
+                errorMessage = errorMessage,
+                retryAfterSec = retryAfterSec,
+            )
+    }
+}
+
+/** 服务端错误码归类成几个 UI 该响应的桶。 */
+enum class ChannelSearchUiAction {
+    /** 5xx / 网络异常：触发本地回退（仅消息维度），UI 顶部 banner 提示。 */
+    FALLBACK_TO_LOCAL,
+
+    /** 429 服务端限流：按 retry_after 倒计时禁用输入框，倒计时结束后用户可重试。 */
+    RATE_LIMITED,
+
+    /** 503 disabled：搜索功能未启用，禁用入口或显示 empty state，不再触发请求。 */
+    FEATURE_DISABLED,
+
+    /** 404 not_found：频道在 Space 维度不可见，阻断该 tab，提示"无法搜索"。 */
+    BLOCK_NOT_FOUND,
+
+    /** 400 validation_failed：客户端构造请求时出错，应埋点上报；UI Toast"搜索条件无效"。 */
+    VALIDATION_ERROR,
+
+    /** 500/未知 internal：通用错误，Toast"搜索失败，请重试"。 */
+    GENERIC_ERROR,
+}
+
+/** [errorCode] → UI 行为映射，UI 层直接消费。 */
+fun ChannelSearchOutcome<*>.uiAction(): ChannelSearchUiAction = when (errorCode) {
+    SearchErrorCode.UPSTREAM_UNAVAILABLE,
+    ChannelSearchOutcome.LOCAL_ERROR_NETWORK -> ChannelSearchUiAction.FALLBACK_TO_LOCAL
+
+    SearchErrorCode.RATE_LIMITED -> ChannelSearchUiAction.RATE_LIMITED
+    SearchErrorCode.DISABLED -> ChannelSearchUiAction.FEATURE_DISABLED
+    SearchErrorCode.NOT_FOUND -> ChannelSearchUiAction.BLOCK_NOT_FOUND
+    SearchErrorCode.VALIDATION_FAILED,
+    SearchErrorCode.DEPTH_EXCEEDED -> ChannelSearchUiAction.VALIDATION_ERROR
+
+    else -> ChannelSearchUiAction.GENERIC_ERROR
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/ChannelSearchService.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/ChannelSearchService.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel
+
+import com.alibaba.fastjson.JSONObject
+import com.chat.base.search.channel.dto.AroundResult
+import com.chat.base.search.channel.dto.CombinedHit
+import com.chat.base.search.channel.dto.CursorList
+import com.chat.base.search.channel.dto.FileHit
+import com.chat.base.search.channel.dto.MediaHit
+import com.chat.base.search.channel.dto.MessageHit
+import io.reactivex.rxjava3.core.Observable
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+/**
+ * 频道内搜索（OpenSearch 直读）。5 个端点路径均相对于 `<baseUrl>/v1/`。
+ *
+ * `X-Space-Id` 由 [com.chat.base.net.CommonRequestParamInterceptor] 自动注入，
+ * 单聊（channel_type=1）必带。
+ */
+interface ChannelSearchService {
+    @POST("messages/_search")
+    fun searchMessages(@Body body: JSONObject): Observable<CursorList<MessageHit>>
+
+    @POST("messages/_search_all")
+    fun searchAll(@Body body: JSONObject): Observable<CursorList<CombinedHit>>
+
+    @POST("messages/_search_media")
+    fun searchMedia(@Body body: JSONObject): Observable<CursorList<MediaHit>>
+
+    @POST("messages/_search_files")
+    fun searchFiles(@Body body: JSONObject): Observable<CursorList<FileHit>>
+
+    @POST("messages/_search_around")
+    fun searchAround(@Body body: JSONObject): Observable<AroundResult>
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/MessageHitMapper.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/MessageHitMapper.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel
+
+import com.chat.base.entity.GlobalChannel
+import com.chat.base.entity.GlobalMessage
+import com.chat.base.msgitem.WKContentType
+import com.chat.base.search.channel.dto.MessageHit
+
+/**
+ * 把服务端 [MessageHit] 适配成现有 `SearchMessageAdapter` 消费的 [GlobalMessage]。
+ * snippet 已带 `<mark>…</mark>` 高亮，adapter 内部识别 HTML 后渲染紫色。
+ *
+ * 由于服务端只回 sender_id（不带 sender_name / channel_name 等聊天框需要的元信息），
+ * 调用方负责传入本地解析后的 channelName。
+ */
+fun MessageHit.toGlobalMessage(
+    channelID: String,
+    channelType: Byte,
+    channelName: String,
+): GlobalMessage {
+    val gm = GlobalMessage()
+    gm.message_seq = message_seq
+    gm.from_uid = sender_id
+    gm.timestamp = Rfc3339.toEpochSeconds(sent_at)
+    val payload = HashMap<String, Any>()
+    payload["type"] = WKContentType.WK_TEXT
+    payload["content"] = snippet
+    gm.payload = payload
+    gm.channel = GlobalChannel().apply {
+        channel_id = channelID
+        channel_type = channelType
+        channel_name = channelName
+    }
+    return gm
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/Rfc3339.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/Rfc3339.kt
@@ -23,11 +23,14 @@ import java.util.TimeZone
 /**
  * RFC3339 → epoch 秒。最小可用，不引入 java.time（项目 minSdk=23 且 coreLibraryDesugaring 未开）。
  *
- * 接受形态：`2026-06-29T10:30:00Z` / `2026-06-29T10:30:00+08:00` / 不带时区。
+ * 接受形态：`2026-06-29T10:30:00Z` / `2026-06-29T10:30:00+08:00` / `2026-06-29T10:30:00.123Z`
+ * / `2026-06-29T10:30:00.123456+08:00` / 不带时区。
+ * 分数秒（`.SSS…`）按 RFC3339 规定为任意精度，我们不需要亚秒精度，直接在归一化阶段剥离。
  * 解析失败返回 0。
  */
 object Rfc3339 {
     private val OFFSET_COLON = Regex("([+-])(\\d{2}):(\\d{2})$")
+    private val FRACTION = Regex("\\.\\d+")
     private val PATTERNS = listOf(
         "yyyy-MM-dd'T'HH:mm:ssZ",
         "yyyy-MM-dd'T'HH:mm:ss",
@@ -35,9 +38,11 @@ object Rfc3339 {
 
     fun toEpochSeconds(s: String?): Long {
         if (s.isNullOrEmpty()) return 0L
-        // SimpleDateFormat 的 Z 模式接受 +0000，不接受 Z 字面量或 +08:00。先标准化。
+        // SimpleDateFormat 的 Z 模式接受 +0000，不接受 Z 字面量或 +08:00；也不接受任意精度分数秒。
+        // 依次剥离：Z → +0000，+08:00 → +0800，.SSS… → 去掉（服务端可能发 1-9 位任意精度）。
         val normalized = s.replace("Z", "+0000")
             .let { OFFSET_COLON.replace(it) { m -> "${m.groupValues[1]}${m.groupValues[2]}${m.groupValues[3]}" } }
+            .let { FRACTION.replace(it, "") }
         for (pattern in PATTERNS) {
             val sdf = SimpleDateFormat(pattern, Locale.US).apply {
                 timeZone = TimeZone.getTimeZone("UTC")

--- a/wkbase/src/main/java/com/chat/base/search/channel/Rfc3339.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/Rfc3339.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel
+
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * RFC3339 → epoch 秒。最小可用，不引入 java.time（项目 minSdk=23 且 coreLibraryDesugaring 未开）。
+ *
+ * 接受形态：`2026-06-29T10:30:00Z` / `2026-06-29T10:30:00+08:00` / 不带时区。
+ * 解析失败返回 0。
+ */
+object Rfc3339 {
+    private val OFFSET_COLON = Regex("([+-])(\\d{2}):(\\d{2})$")
+    private val PATTERNS = listOf(
+        "yyyy-MM-dd'T'HH:mm:ssZ",
+        "yyyy-MM-dd'T'HH:mm:ss",
+    )
+
+    fun toEpochSeconds(s: String?): Long {
+        if (s.isNullOrEmpty()) return 0L
+        // SimpleDateFormat 的 Z 模式接受 +0000，不接受 Z 字面量或 +08:00。先标准化。
+        val normalized = s.replace("Z", "+0000")
+            .let { OFFSET_COLON.replace(it) { m -> "${m.groupValues[1]}${m.groupValues[2]}${m.groupValues[3]}" } }
+        for (pattern in PATTERNS) {
+            val sdf = SimpleDateFormat(pattern, Locale.US).apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+                isLenient = false
+            }
+            runCatching { sdf.parse(normalized)?.time?.div(1000) }.getOrNull()?.let { return it }
+        }
+        return 0L
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/dto/AroundRequest.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/dto/AroundRequest.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel.dto
+
+class AroundRequest(
+    val channelType: Byte,
+    val channelId: String,
+    val anchorMessageId: String,
+    val filters: SearchFilters? = null,
+    val pageSize: Int = ChannelSearchReq.DEFAULT_PAGE_SIZE,
+)

--- a/wkbase/src/main/java/com/chat/base/search/channel/dto/AroundResult.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/dto/AroundResult.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel.dto
+
+/** `/_search_around` 返回锚点上下文。before/after 均按时间正序（oldest-first）。 */
+class AroundResult {
+    var before: List<MessageHit> = emptyList()
+    lateinit var anchor: MessageHit
+    var after: List<MessageHit> = emptyList()
+    var has_more_before: Boolean = false
+    var has_more_after: Boolean = false
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/dto/ChannelSearchReq.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/dto/ChannelSearchReq.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel.dto
+
+/**
+ * 通用请求体，覆盖 _search / _search_all / _search_media / _search_files 四个端点。
+ * _search_around 走 [AroundRequest]。
+ *
+ * 服务端约束：
+ *  - keyword ≤ 64 UTF-8 码点；_search_media 必须为空。
+ *  - sender_ids ≤ 50 个，会自动剔除空串。
+ *  - sent_at_* 支持 YYYY-MM-DD 或 RFC3339；from ≤ to。
+ *  - page_size ∈ [1, 100]，默认 20。
+ *  - cursor 为服务端 HMAC 签名的不透明字符串，客户端禁止解析或拼接。
+ */
+class ChannelSearchReq(
+    val channelType: Byte,
+    val channelId: String,
+    val keyword: String? = null,
+    val filters: SearchFilters? = null,
+    val sort: String = SORT_TIME_DESC,
+    val pageSize: Int = DEFAULT_PAGE_SIZE,
+    val cursor: String? = null,
+) {
+    companion object {
+        const val DEFAULT_PAGE_SIZE = 20
+        const val MAX_PAGE_SIZE = 100
+        const val MAX_KEYWORD_RUNES = 64
+        const val MAX_SENDER_IDS = 50
+
+        const val SORT_TIME_DESC = "time_desc"
+        const val SORT_TIME_ASC = "time_asc"
+        const val SORT_RELEVANCE = "relevance"
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/dto/CombinedHit.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/dto/CombinedHit.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel.dto
+
+/**
+ * `/_search_all` 单条结果。message 与 file 互斥（按 result_type 判断），永远只填其中一个。
+ */
+class CombinedHit {
+    lateinit var result_type: String           // "message" | "file"
+    lateinit var sorted_at: String             // RFC3339；与所选 sort 排序键一致，用于游标
+    var message: MessageHit? = null
+    var file: FileHit? = null
+
+    fun isMessage(): Boolean = result_type == TYPE_MESSAGE
+    fun isFile(): Boolean = result_type == TYPE_FILE
+
+    companion object {
+        const val TYPE_MESSAGE = "message"
+        const val TYPE_FILE = "file"
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/dto/CursorList.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/dto/CursorList.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel.dto
+
+class CursorList<T> {
+    var data: List<T> = emptyList()
+    var pagination: Pagination = Pagination()
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/dto/FileHit.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/dto/FileHit.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel.dto
+
+/** 频道内文件命中。`/_search_files` 与 `/_search_all` 中 result_type=file 时使用。 */
+class FileHit {
+    lateinit var message_id: String
+    var message_seq: Long = 0L
+    lateinit var file_name: String
+    var file_size_bytes: Long = 0L
+    var file_ext: String = ""                  // 无前导点
+    var download_url: String = ""
+    var preview_url: String? = null            // 当前服务端始终 null
+    lateinit var sender_id: String
+    var sender_name: String? = null
+    var sender_avatar_url: String? = null
+    lateinit var sent_at: String               // RFC3339
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/dto/MediaHit.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/dto/MediaHit.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel.dto
+
+/** 频道内图片/视频命中。`/_search_media` 返回。 */
+class MediaHit {
+    lateinit var message_id: String
+    var message_seq: Long = 0L
+    lateinit var media_kind: String            // "image" | "video"
+    var thumb_url: String = ""
+    var width: Int = 0
+    var height: Int = 0
+    var duration_ms: Long = 0L                 // video 才有
+    lateinit var sender_id: String
+    var sender_name: String? = null
+    lateinit var sent_at: String               // RFC3339
+    lateinit var month_bucket: String          // YYYY-MM，UI 用于 sticky header 分组
+
+    fun isVideo(): Boolean = media_kind == "video"
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/dto/MessageHit.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/dto/MessageHit.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel.dto
+
+import android.text.TextUtils
+
+/**
+ * 单条文本/转发消息搜索命中。`/_search` 与 `/_search_all` 中 result_type=message 时使用。
+ */
+class MessageHit {
+    lateinit var message_id: String
+    var message_seq: Long = 0L
+    lateinit var message_kind: String          // "text" | "forward"
+    var snippet: String = ""                   // 已带 <mark>…</mark> 高亮的片段，可能为空
+    lateinit var sender_id: String
+    var sender_name: String? = null
+    var sender_avatar_url: String? = null
+    lateinit var sent_at: String               // RFC3339
+    var outer_preview: OuterPreview? = null
+    var inner_messages: List<InnerMessage>? = null
+    var channel_id: String = ""
+
+    /** 服务端 snippet 内 <mark> 标签替换为客户端紫色 font，与 GlobalMessage.getHtmlText 同色规则。 */
+    fun getHighlightedHtml(): String {
+        if (TextUtils.isEmpty(snippet)) return ""
+        return snippet.replace("<mark>", "<font color=#7761F4>")
+            .replace("</mark>", "</font>")
+    }
+
+    fun isForward(): Boolean = message_kind == "forward"
+}
+
+class OuterPreview {
+    var child_count: Int = 0
+}
+
+class InnerMessage {
+    lateinit var message_id: String
+    var type: Int = 0
+    var search_text: String? = null
+    var sender_id: String? = null
+    var sender_name: String? = null
+    var sent_at: String? = null
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/dto/Pagination.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/dto/Pagination.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel.dto
+
+class Pagination {
+    var has_more: Boolean = false
+    var next_cursor: String = ""
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/dto/SearchErrorBody.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/dto/SearchErrorBody.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel.dto
+
+/**
+ * 服务端错误信封：
+ * `{ "error": { "code": "...", "message": "...", "details": {...}, "hint": "...", "http_status": N } }`
+ *
+ * 由 [com.chat.base.search.channel.ChannelSearchErrorParser] 解析。
+ */
+class SearchErrorBody {
+    var error: SearchErrorDetail? = null
+}
+
+class SearchErrorDetail {
+    var code: String = ""
+    var message: String = ""
+    var details: Map<String, Any>? = null
+    var hint: String? = null
+    var http_status: Int = 0
+}
+
+/** 服务端固定错误码（与 octo-server/pkg/errcode/messages_search.go 对齐）。 */
+object SearchErrorCode {
+    const val VALIDATION_FAILED = "err.server.messages_search.validation_failed"
+    const val UPSTREAM_UNAVAILABLE = "err.server.messages_search.upstream_unavailable"
+    const val INTERNAL = "err.server.messages_search.internal"
+    const val RATE_LIMITED = "err.server.messages_search.rate_limited"
+    const val NOT_FOUND = "err.server.messages_search.not_found"
+    const val DISABLED = "err.server.messages_search.disabled"
+    const val DEPTH_EXCEEDED = "err.server.messages_search.depth_exceeded"
+}

--- a/wkbase/src/main/java/com/chat/base/search/channel/dto/SearchFilters.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/dto/SearchFilters.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel.dto
+
+class SearchFilters(
+    val senderIds: List<String>? = null,
+    val sentAtFrom: String? = null,
+    val sentAtTo: String? = null,
+) {
+    fun isEmpty(): Boolean =
+        senderIds.isNullOrEmpty() && sentAtFrom.isNullOrEmpty() && sentAtTo.isNullOrEmpty()
+}

--- a/wkbase/src/test/java/com/chat/base/search/channel/ChannelSearchBodyBuilderTest.kt
+++ b/wkbase/src/test/java/com/chat/base/search/channel/ChannelSearchBodyBuilderTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel
+
+import com.chat.base.search.channel.dto.AroundRequest
+import com.chat.base.search.channel.dto.ChannelSearchReq
+import com.chat.base.search.channel.dto.SearchFilters
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChannelSearchBodyBuilderTest {
+
+    @Test
+    fun build_minimal_request_only_required_fields() {
+        val req = ChannelSearchReq(channelType = 2, channelId = "g1234", keyword = "hello")
+        val body = ChannelSearchBodyBuilder.build(req)
+
+        assertEquals(2, body["channel_type"])
+        assertEquals("g1234", body["channel_id"])
+        assertEquals("hello", body["keyword"])
+        assertEquals("time_desc", body["sort"])
+        assertEquals(20, body["page_size"])
+        assertFalse("cursor 缺省时不应写入 body", body.containsKey("cursor"))
+        assertFalse("filters 为空时不应写入 body", body.containsKey("filters"))
+    }
+
+    @Test
+    fun build_omits_empty_keyword() {
+        val req = ChannelSearchReq(
+            channelType = 2,
+            channelId = "g1",
+            keyword = null,
+            filters = SearchFilters(senderIds = listOf("u1")),
+        )
+        val body = ChannelSearchBodyBuilder.build(req)
+        assertFalse(body.containsKey("keyword"))
+    }
+
+    @Test
+    fun build_strips_empty_filters_block() {
+        val req = ChannelSearchReq(
+            channelType = 2,
+            channelId = "g1",
+            keyword = "x",
+            filters = SearchFilters(senderIds = emptyList(), sentAtFrom = "", sentAtTo = ""),
+        )
+        val body = ChannelSearchBodyBuilder.build(req)
+        assertFalse(body.containsKey("filters"))
+    }
+
+    @Test
+    fun build_passes_filters_snake_case() {
+        val req = ChannelSearchReq(
+            channelType = 1,
+            channelId = "u1@u2",
+            keyword = "hello",
+            filters = SearchFilters(
+                senderIds = listOf("u1", "u2"),
+                sentAtFrom = "2026-06-01",
+                sentAtTo = "2026-06-30",
+            ),
+        )
+        val body = ChannelSearchBodyBuilder.build(req)
+        val filters = body.getJSONObject("filters")
+        assertEquals(listOf("u1", "u2"), filters["sender_ids"])
+        assertEquals("2026-06-01", filters["sent_at_from"])
+        assertEquals("2026-06-30", filters["sent_at_to"])
+    }
+
+    @Test
+    fun build_writes_cursor_byte_exact() {
+        val cursor = "eyJ0cyI6MTcwMDAwMDAwMH0.abcd1234"   // 模拟服务端不透明游标
+        val req = ChannelSearchReq(channelType = 2, channelId = "g1", keyword = "x", cursor = cursor)
+        val body = ChannelSearchBodyBuilder.build(req)
+        assertEquals("游标必须原样回传不得改动", cursor, body["cursor"])
+    }
+
+    @Test
+    fun build_search_media_strips_keyword_via_allowKeyword_false() {
+        val req = ChannelSearchReq(channelType = 2, channelId = "g1", keyword = "should-be-dropped")
+        val body = ChannelSearchBodyBuilder.build(req, allowKeyword = false)
+        assertFalse("media 端点 keyword 必须为空", body.containsKey("keyword"))
+    }
+
+    @Test
+    fun buildAround_minimal() {
+        val req = AroundRequest(channelType = 2, channelId = "g1", anchorMessageId = "12345")
+        val body = ChannelSearchBodyBuilder.buildAround(req)
+        assertEquals(2, body["channel_type"])
+        assertEquals("g1", body["channel_id"])
+        assertEquals("12345", body["anchor_message_id"])
+        assertEquals(20, body["page_size"])
+        assertNull(body["keyword"])
+        assertNull(body["cursor"])
+        assertNull(body["sort"])
+    }
+}

--- a/wkbase/src/test/java/com/chat/base/search/channel/ChannelSearchErrorParserTest.kt
+++ b/wkbase/src/test/java/com/chat/base/search/channel/ChannelSearchErrorParserTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel
+
+import com.chat.base.search.channel.dto.SearchErrorCode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ChannelSearchErrorParserTest {
+
+    @Test
+    fun parses_validation_failed() {
+        val json = """
+            {"error":{
+                "code":"err.server.messages_search.validation_failed",
+                "message":"keyword too long",
+                "details":{"field":"keyword","reason":"max_length","max_length":64},
+                "http_status":400
+            }}
+        """.trimIndent()
+        val parsed = ChannelSearchErrorParser.parse(json)!!
+        assertEquals(SearchErrorCode.VALIDATION_FAILED, parsed.code)
+        assertEquals("keyword too long", parsed.message)
+        assertEquals(0, parsed.retryAfterSec)
+    }
+
+    @Test
+    fun parses_rate_limited_with_retry_after() {
+        val json = """
+            {"error":{
+                "code":"err.server.messages_search.rate_limited",
+                "message":"too many requests",
+                "details":{"retry_after":3},
+                "http_status":429
+            }}
+        """.trimIndent()
+        val parsed = ChannelSearchErrorParser.parse(json)!!
+        assertEquals(SearchErrorCode.RATE_LIMITED, parsed.code)
+        assertEquals(3, parsed.retryAfterSec)
+    }
+
+    @Test
+    fun returns_null_on_legacy_status_msg_envelope() {
+        // 旧 ResponseExceptionHandle 的 { status, msg } 形态没有 error 字段，应该解析为 null
+        val legacy = """{"status":400,"msg":"bad request"}"""
+        assertNull(ChannelSearchErrorParser.parse(legacy))
+    }
+
+    @Test
+    fun returns_null_on_blank_or_garbage() {
+        assertNull(ChannelSearchErrorParser.parse(null))
+        assertNull(ChannelSearchErrorParser.parse(""))
+        assertNull(ChannelSearchErrorParser.parse("not-json"))
+        assertNull(ChannelSearchErrorParser.parse("{}"))
+        assertNull(ChannelSearchErrorParser.parse("""{"error":{}}"""))
+        assertNull(ChannelSearchErrorParser.parse("""{"error":{"code":""}}"""))
+    }
+}

--- a/wkbase/src/test/java/com/chat/base/search/channel/ChannelSearchOutcomeTest.kt
+++ b/wkbase/src/test/java/com/chat/base/search/channel/ChannelSearchOutcomeTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel
+
+import com.chat.base.search.channel.dto.SearchErrorCode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChannelSearchOutcomeTest {
+
+    @Test
+    fun success_carries_data_and_no_error() {
+        val out = ChannelSearchOutcome.success("ok-data")
+        assertTrue(out.ok)
+        assertEquals("ok-data", out.data)
+        assertNull(out.errorCode)
+        assertEquals(200, out.httpStatus)
+        assertFalse(out.fromLocalFallback)
+    }
+
+    @Test
+    fun success_can_mark_fallback() {
+        val out = ChannelSearchOutcome.success("local", fromLocalFallback = true)
+        assertTrue(out.ok)
+        assertTrue(out.fromLocalFallback)
+    }
+
+    @Test
+    fun failure_carries_error_only() {
+        val out = ChannelSearchOutcome.failure<String>(
+            httpStatus = 503,
+            errorCode = SearchErrorCode.UPSTREAM_UNAVAILABLE,
+        )
+        assertFalse(out.ok)
+        assertNull(out.data)
+        assertEquals(503, out.httpStatus)
+        assertEquals(SearchErrorCode.UPSTREAM_UNAVAILABLE, out.errorCode)
+    }
+
+    // --- uiAction 映射，与计划里 7 个错误码的 UI 行为表对齐 ---
+
+    @Test
+    fun uiAction_upstream_unavailable_triggers_local_fallback() {
+        val out = ChannelSearchOutcome.failure<String>(503, SearchErrorCode.UPSTREAM_UNAVAILABLE)
+        assertEquals(ChannelSearchUiAction.FALLBACK_TO_LOCAL, out.uiAction())
+    }
+
+    @Test
+    fun uiAction_local_network_also_triggers_fallback() {
+        val out = ChannelSearchOutcome.failure<String>(0, ChannelSearchOutcome.LOCAL_ERROR_NETWORK)
+        assertEquals(ChannelSearchUiAction.FALLBACK_TO_LOCAL, out.uiAction())
+    }
+
+    @Test
+    fun uiAction_rate_limited_does_not_trigger_fallback() {
+        val out = ChannelSearchOutcome.failure<String>(429, SearchErrorCode.RATE_LIMITED, retryAfterSec = 1)
+        assertEquals(ChannelSearchUiAction.RATE_LIMITED, out.uiAction())
+    }
+
+    @Test
+    fun uiAction_disabled_disables_feature() {
+        val out = ChannelSearchOutcome.failure<String>(503, SearchErrorCode.DISABLED)
+        assertEquals(ChannelSearchUiAction.FEATURE_DISABLED, out.uiAction())
+    }
+
+    @Test
+    fun uiAction_not_found_blocks() {
+        val out = ChannelSearchOutcome.failure<String>(404, SearchErrorCode.NOT_FOUND)
+        assertEquals(ChannelSearchUiAction.BLOCK_NOT_FOUND, out.uiAction())
+    }
+
+    @Test
+    fun uiAction_validation_failed_is_validation_error() {
+        val out = ChannelSearchOutcome.failure<String>(400, SearchErrorCode.VALIDATION_FAILED)
+        assertEquals(ChannelSearchUiAction.VALIDATION_ERROR, out.uiAction())
+    }
+
+    @Test
+    fun uiAction_depth_exceeded_classified_as_validation() {
+        val out = ChannelSearchOutcome.failure<String>(400, SearchErrorCode.DEPTH_EXCEEDED)
+        assertEquals(ChannelSearchUiAction.VALIDATION_ERROR, out.uiAction())
+    }
+
+    @Test
+    fun uiAction_internal_falls_to_generic() {
+        val out = ChannelSearchOutcome.failure<String>(500, SearchErrorCode.INTERNAL)
+        assertEquals(ChannelSearchUiAction.GENERIC_ERROR, out.uiAction())
+    }
+}

--- a/wkbase/src/test/java/com/chat/base/search/channel/Rfc3339Test.kt
+++ b/wkbase/src/test/java/com/chat/base/search/channel/Rfc3339Test.kt
@@ -56,4 +56,27 @@ class Rfc3339Test {
         assertEquals(0L, Rfc3339.toEpochSeconds("not-a-date"))
         assertEquals(0L, Rfc3339.toEpochSeconds("2026/06/29 10:30:00"))
     }
+
+    @Test
+    fun parses_millisecond_fraction_utc() {
+        // 服务端常见形态 sent_at="2026-06-29T10:30:00.123Z"，亚秒精度直接截断。
+        assertEquals(1782729000L, Rfc3339.toEpochSeconds("2026-06-29T10:30:00.123Z"))
+    }
+
+    @Test
+    fun parses_microsecond_fraction_utc() {
+        // RFC3339 允许任意精度分数秒（6 位、9 位都常见）。
+        assertEquals(1782729000L, Rfc3339.toEpochSeconds("2026-06-29T10:30:00.123456Z"))
+        assertEquals(1782729000L, Rfc3339.toEpochSeconds("2026-06-29T10:30:00.123456789Z"))
+    }
+
+    @Test
+    fun parses_millisecond_fraction_with_offset() {
+        assertEquals(1782729000L, Rfc3339.toEpochSeconds("2026-06-29T18:30:00.500+08:00"))
+    }
+
+    @Test
+    fun parses_millisecond_fraction_naive_as_utc() {
+        assertEquals(1782729000L, Rfc3339.toEpochSeconds("2026-06-29T10:30:00.999"))
+    }
 }

--- a/wkbase/src/test/java/com/chat/base/search/channel/Rfc3339Test.kt
+++ b/wkbase/src/test/java/com/chat/base/search/channel/Rfc3339Test.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.channel
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class Rfc3339Test {
+
+    @Test
+    fun parses_utc_zulu() {
+        // 2026-06-29T10:30:00Z → 2026-06-29 10:30:00 UTC → epoch 1782729000
+        assertEquals(1782729000L, Rfc3339.toEpochSeconds("2026-06-29T10:30:00Z"))
+    }
+
+    @Test
+    fun parses_positive_offset() {
+        // 2026-06-29T18:30:00+08:00 == 2026-06-29T10:30:00Z
+        assertEquals(1782729000L, Rfc3339.toEpochSeconds("2026-06-29T18:30:00+08:00"))
+    }
+
+    @Test
+    fun parses_negative_offset() {
+        // 2026-06-29T02:30:00-08:00 == 2026-06-29T10:30:00Z
+        assertEquals(1782729000L, Rfc3339.toEpochSeconds("2026-06-29T02:30:00-08:00"))
+    }
+
+    @Test
+    fun parses_naive_as_utc() {
+        // 无时区时按 UTC 解释
+        assertEquals(1782729000L, Rfc3339.toEpochSeconds("2026-06-29T10:30:00"))
+    }
+
+    @Test
+    fun returns_zero_on_null_or_empty() {
+        assertEquals(0L, Rfc3339.toEpochSeconds(null))
+        assertEquals(0L, Rfc3339.toEpochSeconds(""))
+    }
+
+    @Test
+    fun returns_zero_on_garbage() {
+        assertEquals(0L, Rfc3339.toEpochSeconds("not-a-date"))
+        assertEquals(0L, Rfc3339.toEpochSeconds("2026/06/29 10:30:00"))
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKIMUtils.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKIMUtils.java
@@ -260,8 +260,23 @@ public class WKIMUtils {
                         // payload: {type:1002, content, extra:[{uid,name},...]}, iOS 解析参考
                         // WKSystemMessageCell.m:80-102). 只有 my uid 在 extra 列表里时才触发 sync,
                         // 否则是其他成员被加, 我的 memberships 没变.
-                        GroupModel.getInstance().groupMembersSync(msgList.get(i).channelID, null);
-                        if (isMyUidInGroupMemberMsgExtra(msgList.get(i))) {
+                        //
+                        // C+ 兜底 (bot invite 服务端 version 分配 bug):
+                        // 服务端给 bot invite 分配的 channel_member.version 会低于群内真人
+                        // 当前 max (实测 low ~1000, 稳定复现于多个群), 走
+                        // `WHERE version > local_max` 的增量 sync 永远拉不到该 row.
+                        // iOS 通过打开群设置时调 `/groups/xx/members` (无 version 过滤)
+                        // upsert 自愈, Android SDK 只对 super group 走这条路径 (
+                        // ChannelMembersManager.getWithPageOrSearch 里 `if (groupType==1)`).
+                        // 兜底: 走 groupMembersSyncAndVerify — 增量拉完后校验 1002 extra
+                        // 里被邀请的 uid 是否落盘, 缺任何一个即触发 v=0 全量 upsert.
+                        // extra 解析失败传 null, 保守走全量 (对齐 iOS 群设置页自愈语义).
+                        final com.xinbida.wukongim.entity.WKMsg addMsg = msgList.get(i);
+                        final java.util.List<String> invitedUids = parseGroupMemberAddExtraUids(addMsg);
+                        GroupModel.getInstance().groupMembersSyncAndVerify(
+                                addMsg.channelID,
+                                invitedUids.isEmpty() ? null : invitedUids);
+                        if (isMyUidInGroupMemberMsgExtra(addMsg)) {
                             needsMembershipRefresh = true;
                         }
                     } else if (msgList.get(i).type == WKContentType.removeGroupMembersMsg) {
@@ -1010,6 +1025,32 @@ public class WKIMUtils {
             // 实际生产中 server 格式稳定, 走这条路径的概率近 0.
         }
         return false;
+    }
+
+    /**
+     * 解析 1002 群加人消息 {@code content.extra[].uid} 列表.
+     * 用于 C+ 兜底: 增量 sync 完成后校验这些 uid 是否落盘, 缺失即触发 v=0 全量.
+     *
+     * <p>返回空列表 (而不是 null) 便于调用方直接 {@code isEmpty()} 判定.
+     * JSON 解析异常时同样返回空列表, 调用方应当把 "空" 视作 "无法确认已落盘"
+     * 从而保守触发全量 (对齐 iOS 群设置页自愈的语义, 宁可多拉一次).
+     */
+    private java.util.List<String> parseGroupMemberAddExtraUids(WKMsg msg) {
+        java.util.List<String> uids = new java.util.ArrayList<>();
+        if (msg == null || TextUtils.isEmpty(msg.content)) return uids;
+        try {
+            JSONObject json = new JSONObject(msg.content);
+            JSONArray extra = json.optJSONArray("extra");
+            if (extra == null) return uids;
+            for (int i = 0, n = extra.length(); i < n; i++) {
+                JSONObject item = extra.optJSONObject(i);
+                if (item == null) continue;
+                String uid = item.optString("uid");
+                if (!TextUtils.isEmpty(uid)) uids.add(uid);
+            }
+        } catch (Throwable ignored) {
+        }
+        return uids;
     }
 
     /**

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/MessageRecordActivity.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/MessageRecordActivity.kt
@@ -152,7 +152,9 @@ class MessageRecordActivity : WKBaseActivity<ActMessageRecordLayoutBinding>() {
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable) {
                 val text = s.toString()
-                if (TextUtils.isEmpty(text)) {
+                // 进入过 4-tab 结果页之后就锁死；清空关键词不要再退回快捷入口，
+                // 让媒体 / 文件 tab 继续按 supportsBrowseWithoutKeyword 浏览全部。
+                if (text.isEmpty() && !resultPagerReady) {
                     showEmptyState()
                 } else {
                     showResultState()

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/MessageRecordActivity.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/MessageRecordActivity.kt
@@ -23,39 +23,50 @@ import android.text.TextUtils
 import android.text.TextWatcher
 import android.view.View
 import android.view.inputmethod.EditorInfo
+import androidx.activity.viewModels
 import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
 import com.chad.library.adapter.base.BaseQuickAdapter
+import com.chat.base.adapter.WKFragmentStateAdapter
 import com.chat.base.base.WKBaseActivity
 import com.chat.base.endpoint.EndpointCategory
 import com.chat.base.endpoint.EndpointManager
-import com.chat.base.endpoint.EndpointSID
-import com.chat.base.endpoint.entity.ChatViewMenu
 import com.chat.base.endpoint.entity.SearchChatContentMenu
-import com.chat.base.entity.GlobalMessage
-import com.chat.base.entity.GlobalSearchReq
-import com.chat.base.msgitem.WKContentType
-import com.chat.base.net.HttpResponseCode
-import com.chat.base.search.GlobalSearchModel
 import com.chat.base.ui.Theme
 import com.chat.base.utils.SoftKeyboardUtils
-import com.chat.base.utils.WKReader
 import com.chat.base.views.FullyGridLayoutManager
 import com.chat.uikit.R
+import com.chat.uikit.chat.search.channel.ChannelSearchAllFragment
+import com.chat.uikit.chat.search.channel.ChannelSearchFileFragment
+import com.chat.uikit.chat.search.channel.ChannelSearchMediaFragment
+import com.chat.uikit.chat.search.channel.ChannelSearchMessageFragment
+import com.chat.uikit.chat.search.channel.ChannelSearchViewModel
 import com.chat.uikit.databinding.ActMessageRecordLayoutBinding
-import com.scwang.smart.refresh.layout.api.RefreshLayout
-import com.scwang.smart.refresh.layout.listener.OnRefreshLoadMoreListener
-import com.xinbida.wukongim.WKIM
+import com.google.android.material.tabs.TabLayout
+import com.google.android.material.tabs.TabLayoutMediator
 import com.xinbida.wukongim.entity.WKChannel
 import com.xinbida.wukongim.entity.WKChannelType
-import com.xinbida.wukongim.entity.WKMsg
 
+/**
+ * 频道内搜索（聊天页"查找聊天记录"入口）。
+ *
+ * Phase 2.1 与微信对齐：
+ *  - 空态：显示原有「按成员 / 日期 / 图片 / 文件」快捷过滤入口（[searchTypeLayout]）；
+ *  - 用户输入关键词后：隐藏快捷入口，切换到 4-tab 结果页（[searchResultLayout]：全部 / 消息 / 媒体 / 文件）。
+ *
+ * 内部仍走 [ChannelSearchViewModel]：keyword 经 300ms debounce 后通过 SharedFlow 通知 Fragment 重置查询。
+ * Intent 协议与 Phase 1 完全兼容：`channel_id` + `channel_type` (+ 可选 `keyword`)。
+ */
 class MessageRecordActivity : WKBaseActivity<ActMessageRecordLayoutBinding>() {
     private lateinit var channelID: String
     private var channelType: Byte = WKChannelType.PERSONAL
+    private var initialKeyword: String = ""
+
     private lateinit var searchTypeAdapter: SearchTypeAdapter
-    private lateinit var messageAdapter: SearchMessageAdapter
-    private var keyword = ""
-    private var page = 1
+    private var resultPagerReady = false
+
+    private val viewModel: ChannelSearchViewModel by viewModels()
+
     override fun getViewBinding(): ActMessageRecordLayoutBinding {
         return ActMessageRecordLayoutBinding.inflate(layoutInflater)
     }
@@ -63,49 +74,69 @@ class MessageRecordActivity : WKBaseActivity<ActMessageRecordLayoutBinding>() {
     override fun initPresenter() {
         channelID = intent.getStringExtra("channel_id")!!
         channelType = intent.getByteExtra("channel_type", WKChannelType.PERSONAL)
-        keyword = intent.getStringExtra("keyword") ?: ""
+        initialKeyword = intent.getStringExtra("keyword") ?: ""
     }
 
     override fun initView() {
         Theme.setPressedBackground(wkVBinding.cancelTv)
-        wkVBinding.refreshLayout.setEnableRefresh(false)
-        wkVBinding.refreshLayout.setEnableLoadMore(true)
         wkVBinding.searchIv.colorFilter = PorterDuffColorFilter(
-            ContextCompat.getColor(
-                this, R.color.popupTextColor
-            ), PorterDuff.Mode.MULTIPLY
+            ContextCompat.getColor(this, R.color.popupTextColor), PorterDuff.Mode.MULTIPLY
         )
-        messageAdapter = SearchMessageAdapter()
-        initAdapter(wkVBinding.recyclerView, messageAdapter)
-        val channel = WKChannel()
-        channel.channelID = channelID
-        channel.channelType = channelType
+
+        setupTypeFilterRow()
+        // 4-tab 容器懒装配：只在用户首次输入关键词时才 attach，避免空态加载 Fragment 浪费。
+    }
+
+    private fun setupTypeFilterRow() {
+        val channel = WKChannel().apply {
+            channelID = this@MessageRecordActivity.channelID
+            channelType = this@MessageRecordActivity.channelType
+        }
         val list = EndpointManager.getInstance()
             .invokes<SearchChatContentMenu>(EndpointCategory.wkSearchChatContent, channel)
         var i = 0
-        val size: Int = list.size
-        while (i < size) {
+        while (i < list.size) {
             if (list[i] == null || TextUtils.isEmpty(list[i].text)) {
                 list.removeAt(i)
-                i--
+                continue
             }
             i++
         }
         searchTypeAdapter = SearchTypeAdapter(list)
-        val layoutManager = FullyGridLayoutManager(this, 3)
-        wkVBinding.typeRecyclerView.layoutManager = layoutManager
+        wkVBinding.typeRecyclerView.layoutManager = FullyGridLayoutManager(this, 3)
         wkVBinding.typeRecyclerView.adapter = searchTypeAdapter
     }
 
-    override fun initListener() {
-        wkVBinding.refreshLayout.setOnRefreshLoadMoreListener(object : OnRefreshLoadMoreListener {
-            override fun onLoadMore(refreshLayout: RefreshLayout) {
-                page++
-                searchMessage()
+    private fun ensureResultPagerAttached() {
+        if (resultPagerReady) return
+        val fragments = listOf<Fragment>(
+            ChannelSearchAllFragment.newInstance(channelID, channelType),
+            ChannelSearchMessageFragment.newInstance(channelID, channelType),
+            ChannelSearchMediaFragment.newInstance(channelID, channelType),
+            ChannelSearchFileFragment.newInstance(channelID, channelType),
+        )
+        val titles = listOf(
+            getString(R.string.channel_search_tab_all),
+            getString(R.string.channel_search_tab_message),
+            getString(R.string.channel_search_tab_media),
+            getString(R.string.channel_search_tab_file),
+        )
+        wkVBinding.searchPager.adapter = WKFragmentStateAdapter(this, fragments)
+        wkVBinding.searchPager.offscreenPageLimit = fragments.size
+        TabLayoutMediator(wkVBinding.searchTabLayout, wkVBinding.searchPager) { tab, pos ->
+            tab.text = titles[pos]
+        }.attach()
+        wkVBinding.searchTabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: TabLayout.Tab) {
+                viewModel.setTabIndex(tab.position)
             }
-
-            override fun onRefresh(refreshLayout: RefreshLayout) {}
+            override fun onTabUnselected(tab: TabLayout.Tab) {}
+            override fun onTabReselected(tab: TabLayout.Tab) {}
         })
+        resultPagerReady = true
+    }
+
+    override fun initListener() {
         wkVBinding.searchEt.imeOptions = EditorInfo.IME_ACTION_SEARCH
         wkVBinding.searchEt.setOnEditorActionListener { _, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_SEARCH) {
@@ -114,30 +145,23 @@ class MessageRecordActivity : WKBaseActivity<ActMessageRecordLayoutBinding>() {
             }
             false
         }
+        wkVBinding.cancelTv.setOnClickListener { finish() }
 
-        wkVBinding.cancelTv.setOnClickListener { _ -> finish() }
         wkVBinding.searchEt.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
-            }
-
-            override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
-            }
-
+            override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {}
             override fun afterTextChanged(s: Editable) {
-                keyword = s.toString()
-                if (TextUtils.isEmpty(keyword)) {
-                    wkVBinding.resultView.visibility = View.GONE
-                    wkVBinding.searchTypeLayout.visibility = View.VISIBLE
+                val text = s.toString()
+                if (TextUtils.isEmpty(text)) {
+                    showEmptyState()
                 } else {
-                    page = 1
-                    searchMessage()
-                    wkVBinding.resultView.visibility = View.VISIBLE
-                    wkVBinding.searchTypeLayout.visibility = View.GONE
+                    showResultState()
                 }
+                viewModel.setKeyword(text)
             }
         })
 
-        searchTypeAdapter.setOnItemClickListener { adapter1: BaseQuickAdapter<*, *>, _: View?, position: Int ->
+        searchTypeAdapter.setOnItemClickListener { adapter1: BaseQuickAdapter<*, *>, _, position ->
             val menu = adapter1.data[position] as SearchChatContentMenu?
             if (menu?.iClick != null) {
                 SoftKeyboardUtils.getInstance().hideSoftKeyboard(this)
@@ -145,104 +169,23 @@ class MessageRecordActivity : WKBaseActivity<ActMessageRecordLayoutBinding>() {
             }
         }
 
-        messageAdapter.setOnItemClickListener { adapter1: BaseQuickAdapter<*, *>, _: View?, position: Int ->
-            val item = adapter1.getItem(position) as GlobalMessage?
-            if (item != null) {
-                val orderSeq = WKIM.getInstance().msgManager.getMessageOrderSeq(
-                    item.message_seq,
-                    item.channel.channel_id,
-                    item.channel.channel_type
-                )
-                SoftKeyboardUtils.getInstance().hideSoftKeyboard(this)
-                EndpointManager.getInstance().invoke(
-                    EndpointSID.chatView,
-                    ChatViewMenu(
-                        this,
-                        item.channel.channel_id,
-                        item.channel.channel_type,
-                        orderSeq,
-                        false
-                    )
-                )
-            }
-        }
-
-        if (keyword.isNotEmpty()) {
-            wkVBinding.searchEt.setText(keyword)
-            wkVBinding.searchEt.setSelection(keyword.length)
+        if (!TextUtils.isEmpty(initialKeyword)) {
+            wkVBinding.searchEt.setText(initialKeyword)
+            wkVBinding.searchEt.setSelection(initialKeyword.length)
+            // setText 已触发 TextWatcher，会走 showResultState + setKeyword
+        } else {
+            showEmptyState()
         }
     }
 
-    fun searchMessage() {
-        messageAdapter.keyword = keyword
-        // 本地搜索
-        val localMsgs = WKIM.getInstance().msgManager.searchWithChannel(keyword, channelID, channelType)
-        val localMessages = ArrayList<GlobalMessage>()
-        if (WKReader.isNotEmpty(localMsgs)) {
-            for (msg in localMsgs) {
-                val gm = GlobalMessage()
-                gm.message_seq = msg.messageSeq.toLong()
-                gm.from_uid = msg.fromUID ?: ""
-                gm.timestamp = msg.timestamp
-                val payloadMap = HashMap<String, Any>()
-                payloadMap["type"] = msg.type
-                payloadMap["content"] = msg.searchableWord?.takeIf { it.isNotEmpty() }
-                    ?: msg.baseContentMsgModel?.getSearchableWord()
-                    ?: ""
-                gm.payload = payloadMap
-                val gc = com.chat.base.entity.GlobalChannel()
-                gc.channel_id = channelID
-                gc.channel_type = channelType
-                val ch = WKIM.getInstance().channelManager.getChannel(channelID, channelType)
-                gc.channel_name = ch?.channelRemark?.takeIf { it.isNotEmpty() }
-                    ?: ch?.channelName ?: ""
-                gm.channel = gc
-                localMessages.add(gm)
-            }
-        }
+    private fun showEmptyState() {
+        wkVBinding.searchTypeLayout.visibility = View.VISIBLE
+        wkVBinding.searchResultLayout.visibility = View.GONE
+    }
 
-        // 远程 API 搜索
-        val contentType = ArrayList<Int>()
-        contentType.add(WKContentType.WK_TEXT)
-        contentType.add(WKContentType.WK_FILE)
-        val req =
-            GlobalSearchReq(1, keyword, channelID, channelType, "", "", contentType, page, 20, 0, 0)
-
-        GlobalSearchModel.search(req) { code, _, resp ->
-            wkVBinding.refreshLayout.finishRefresh()
-            wkVBinding.refreshLayout.finishLoadMore()
-
-            val merged = ArrayList<GlobalMessage>()
-            val seenSeqs = HashSet<Long>()
-
-            // 本地结果优先
-            if (page == 1) {
-                for (m in localMessages) {
-                    if (seenSeqs.add(m.message_seq)) merged.add(m)
-                }
-            }
-
-            // API 结果去重合并
-            if (code == HttpResponseCode.success && resp != null && WKReader.isNotEmpty(resp.messages)) {
-                for (m in resp.messages) {
-                    if (seenSeqs.add(m.message_seq)) merged.add(m)
-                }
-            }
-
-            if (merged.isEmpty()) {
-                wkVBinding.refreshLayout.setEnableLoadMore(false)
-                if (page == 1) {
-                    messageAdapter.setList(ArrayList())
-                    wkVBinding.noDataTv.visibility = View.VISIBLE
-                }
-                return@search
-            }
-            wkVBinding.noDataTv.visibility = View.GONE
-            if (page == 1) {
-                messageAdapter.setList(merged)
-            } else {
-                messageAdapter.addData(merged)
-            }
-        }
+    private fun showResultState() {
+        wkVBinding.searchTypeLayout.visibility = View.GONE
+        ensureResultPagerAttached()
+        wkVBinding.searchResultLayout.visibility = View.VISIBLE
     }
 }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/SearchMessageAdapter.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/SearchMessageAdapter.kt
@@ -30,6 +30,7 @@ import com.chat.base.utils.WKTimeUtils
 import com.chat.uikit.R
 import com.chat.uikit.chat.provider.WKFileProvider
 import com.chat.uikit.search.remote.GlobalAdapter
+import com.xinbida.wukongim.entity.WKChannelType
 
 class SearchMessageAdapter :
     BaseQuickAdapter<GlobalMessage, BaseViewHolder>(R.layout.item_global_message_layout) {
@@ -39,7 +40,10 @@ class SearchMessageAdapter :
     override fun convert(holder: BaseViewHolder, item: GlobalMessage) {
         val avatarView = holder.getView<AvatarView>(R.id.avatarView)
         avatarView.setSize(40f)
-        avatarView.showAvatar(item.channel.channel_id, item.channel.channel_type)
+        // 频道内搜索结果每行展示发送人头像（与 web / iOS 对齐）。
+        // 原本展示 channel 头像在群里是群头像、在子区里无头像，所有行视觉一致但信息量低；
+        // 改为发送人头像后每行明确"谁发的"，子区也不会再出现空头像。
+        avatarView.showAvatar(item.from_uid, WKChannelType.PERSONAL)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             holder.setText(
                 R.id.nameTv,

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/BaseChannelSearchFragment.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/BaseChannelSearchFragment.kt
@@ -85,12 +85,13 @@ abstract class BaseChannelSearchFragment : Fragment() {
 
     /** 默认不兜底；消息相关 tab 覆写。 */
     protected open fun executeLocalFallback(keyword: String) {
+        val b = _binding ?: return
         showOfflineBanner(true)
         resetList()
         showEmpty(getString(emptyResultHintRes))
         hasMore = false
         nextCursor = null
-        binding.refreshLayout.setEnableLoadMore(false)
+        b.refreshLayout.setEnableLoadMore(false)
     }
 
     override fun onCreateView(
@@ -158,21 +159,27 @@ abstract class BaseChannelSearchFragment : Fragment() {
         executeSearch(keyword, nextCursor, isReset = false)
     }
 
-    /** 子类在拿到 outcome 时调用，处理通用错误 + 本地兜底；返回 true 表示已处理。 */
+    /**
+     * 子类在拿到 outcome 时调用，处理通用错误 + 本地兜底；返回 true 表示已处理。
+     *
+     * view 已销毁（`_binding == null`）时静默返回 true——异步回调完成后 UI 已不存在，
+     * 任何 toast / binding 访问都是无意义的且会 NPE。
+     */
     protected fun handleNonSuccess(
         outcome: ChannelSearchOutcome<*>,
         isReset: Boolean,
         keyword: String,
     ): Boolean {
-        binding.refreshLayout.finishRefresh()
-        binding.refreshLayout.finishLoadMore()
+        val b = _binding ?: return true
+        b.refreshLayout.finishRefresh()
+        b.refreshLayout.finishLoadMore()
         return when (outcome.uiAction()) {
             ChannelSearchUiAction.FALLBACK_TO_LOCAL -> {
                 if (isReset) {
                     executeLocalFallback(keyword)
                 } else {
                     hasMore = false
-                    binding.refreshLayout.setEnableLoadMore(false)
+                    b.refreshLayout.setEnableLoadMore(false)
                 }
                 true
             }
@@ -196,13 +203,17 @@ abstract class BaseChannelSearchFragment : Fragment() {
         }
     }
 
-    /** 子类拿到 success 后调用，统一处理 cursor + loadMore 开关 + 空态。 */
+    /**
+     * 子类拿到 success 后调用，统一处理 cursor + loadMore 开关 + 空态。
+     * view 已销毁时静默返回，避免 NPE。
+     */
     protected fun updatePaginationState(hasMore: Boolean, nextCursor: String, isEmpty: Boolean, isReset: Boolean) {
-        binding.refreshLayout.finishRefresh()
-        binding.refreshLayout.finishLoadMore()
+        val b = _binding ?: return
+        b.refreshLayout.finishRefresh()
+        b.refreshLayout.finishLoadMore()
         this.hasMore = hasMore
         this.nextCursor = nextCursor.takeIf { it.isNotEmpty() }
-        binding.refreshLayout.setEnableLoadMore(hasMore && !this.nextCursor.isNullOrEmpty())
+        b.refreshLayout.setEnableLoadMore(hasMore && !this.nextCursor.isNullOrEmpty())
         if (isReset && isEmpty) {
             showEmpty(getString(emptyResultHintRes))
         } else if (isReset) {
@@ -211,15 +222,16 @@ abstract class BaseChannelSearchFragment : Fragment() {
     }
 
     protected fun showOfflineBanner(visible: Boolean) {
-        binding.offlineBannerTv.visibility = if (visible) View.VISIBLE else View.GONE
+        _binding?.offlineBannerTv?.visibility = if (visible) View.VISIBLE else View.GONE
     }
 
     protected fun showEmpty(text: String?) {
+        val b = _binding ?: return
         if (text.isNullOrEmpty()) {
-            binding.emptyTv.visibility = View.GONE
+            b.emptyTv.visibility = View.GONE
         } else {
-            binding.emptyTv.text = text
-            binding.emptyTv.visibility = View.VISIBLE
+            b.emptyTv.text = text
+            b.emptyTv.visibility = View.VISIBLE
         }
     }
 

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/BaseChannelSearchFragment.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/BaseChannelSearchFragment.kt
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.search.channel
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.RecyclerView
+import com.chat.base.search.channel.ChannelSearchOutcome
+import com.chat.base.search.channel.ChannelSearchUiAction
+import com.chat.base.search.channel.uiAction
+import com.chat.base.utils.WKToastUtils
+import com.chat.uikit.R
+import com.chat.uikit.databinding.FragChannelSearchListBinding
+import com.scwang.smart.refresh.layout.api.RefreshLayout
+import com.scwang.smart.refresh.layout.listener.OnRefreshLoadMoreListener
+import com.xinbida.wukongim.entity.WKChannelType
+import kotlinx.coroutines.launch
+
+/**
+ * 频道内搜索 Fragment 通用骨架。各 tab 复用 [FragChannelSearchListBinding]
+ * (refreshLayout + recyclerView + offline banner + empty state)。
+ *
+ * 子类需实现：
+ *  - [setupRecyclerView]：layoutManager + adapter
+ *  - [resetList] / [appendList]：把服务端返回的数据落进自己的 adapter
+ *  - [executeSearch]：发起一次服务端请求；reset=true 表示新关键词，false 表示翻页
+ *  - [executeLocalFallback]：服务端 503 时的本地兜底（仅消息/全部 tab 实现）
+ *
+ * Activity 通过 [ChannelSearchViewModel.queryEvents] 通知所有 Fragment 重置查询。
+ */
+abstract class BaseChannelSearchFragment : Fragment() {
+
+    protected var _binding: FragChannelSearchListBinding? = null
+    protected val binding get() = _binding!!
+
+    protected lateinit var channelID: String
+    protected var channelType: Byte = WKChannelType.PERSONAL
+
+    protected val viewModel: ChannelSearchViewModel by lazy {
+        ViewModelProvider(requireActivity())[ChannelSearchViewModel::class.java]
+    }
+
+    protected var nextCursor: String? = null
+    protected var hasMore: Boolean = true
+    protected var requestSeq: Long = 0L
+
+    /** 关键词为空时的引导文案。子类可覆写。 */
+    protected open val emptyKeywordHintRes: Int = R.string.channel_search_empty_keyword
+
+    /** 命中关键词但服务端返回空时的文案。 */
+    protected open val emptyResultHintRes: Int = R.string.nodata
+
+    protected abstract fun setupRecyclerView(recyclerView: RecyclerView)
+
+    protected abstract fun resetList()
+
+    protected abstract fun executeSearch(keyword: String, cursor: String?, isReset: Boolean)
+
+    /** 默认不兜底；消息相关 tab 覆写。 */
+    protected open fun executeLocalFallback(keyword: String) {
+        showOfflineBanner(true)
+        resetList()
+        showEmpty(getString(emptyResultHintRes))
+        hasMore = false
+        nextCursor = null
+        binding.refreshLayout.setEnableLoadMore(false)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragChannelSearchListBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        channelID = requireArguments().getString(ARG_CHANNEL_ID).orEmpty()
+        channelType = requireArguments().getByte(ARG_CHANNEL_TYPE, WKChannelType.PERSONAL)
+
+        setupRecyclerView(binding.recyclerView)
+
+        binding.refreshLayout.setEnableRefresh(false)
+        binding.refreshLayout.setEnableLoadMore(false)
+        binding.refreshLayout.setOnRefreshLoadMoreListener(object : OnRefreshLoadMoreListener {
+            override fun onLoadMore(refreshLayout: RefreshLayout) = loadMore()
+            override fun onRefresh(refreshLayout: RefreshLayout) {}
+        })
+
+        observeQueryEvents()
+    }
+
+    private fun observeQueryEvents() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.queryEvents.collect { state ->
+                    triggerReset(state.keyword)
+                }
+            }
+        }
+    }
+
+    private fun triggerReset(keyword: String) {
+        nextCursor = null
+        hasMore = true
+        showOfflineBanner(false)
+        if (keyword.isEmpty()) {
+            // 清空关键词 == 完全重置：列表清空、cursor 归零、loadMore 关闭、回到引导文案。
+            // 与 Activity 顶部"清空回到快捷过滤入口"的语义保持一致；
+            // 即使 [supportsBrowseWithoutKeyword]=true（媒体 / 文件 tab）也不做无关键词浏览，
+            // 避免清空后台仍在拉取造成视觉跳动。
+            resetList()
+            showEmpty(getString(emptyKeywordHintRes))
+            binding.refreshLayout.setEnableLoadMore(false)
+            return
+        }
+        showEmpty(null)
+        binding.refreshLayout.setEnableLoadMore(true)
+        requestSeq++
+        executeSearch(keyword, null, isReset = true)
+    }
+
+    private fun loadMore() {
+        if (!hasMore || nextCursor.isNullOrEmpty()) {
+            binding.refreshLayout.finishLoadMore()
+            binding.refreshLayout.setEnableLoadMore(false)
+            return
+        }
+        val keyword = viewModel.state.value.keyword
+        requestSeq++
+        executeSearch(keyword, nextCursor, isReset = false)
+    }
+
+    /** 子类在拿到 outcome 时调用，处理通用错误 + 本地兜底；返回 true 表示已处理。 */
+    protected fun handleNonSuccess(
+        outcome: ChannelSearchOutcome<*>,
+        isReset: Boolean,
+        keyword: String,
+    ): Boolean {
+        binding.refreshLayout.finishRefresh()
+        binding.refreshLayout.finishLoadMore()
+        return when (outcome.uiAction()) {
+            ChannelSearchUiAction.FALLBACK_TO_LOCAL -> {
+                if (isReset) {
+                    executeLocalFallback(keyword)
+                } else {
+                    hasMore = false
+                    binding.refreshLayout.setEnableLoadMore(false)
+                }
+                true
+            }
+            ChannelSearchUiAction.RATE_LIMITED -> {
+                toast(R.string.channel_search_rate_limited)
+                true
+            }
+            ChannelSearchUiAction.FEATURE_DISABLED -> {
+                toast(R.string.channel_search_disabled)
+                true
+            }
+            ChannelSearchUiAction.BLOCK_NOT_FOUND -> {
+                toast(R.string.channel_search_not_found)
+                true
+            }
+            ChannelSearchUiAction.VALIDATION_ERROR,
+            ChannelSearchUiAction.GENERIC_ERROR -> {
+                toast(R.string.channel_search_generic_error)
+                true
+            }
+        }
+    }
+
+    /** 子类拿到 success 后调用，统一处理 cursor + loadMore 开关 + 空态。 */
+    protected fun updatePaginationState(hasMore: Boolean, nextCursor: String, isEmpty: Boolean, isReset: Boolean) {
+        binding.refreshLayout.finishRefresh()
+        binding.refreshLayout.finishLoadMore()
+        this.hasMore = hasMore
+        this.nextCursor = nextCursor.takeIf { it.isNotEmpty() }
+        binding.refreshLayout.setEnableLoadMore(hasMore && !this.nextCursor.isNullOrEmpty())
+        if (isReset && isEmpty) {
+            showEmpty(getString(emptyResultHintRes))
+        } else if (isReset) {
+            showEmpty(null)
+        }
+    }
+
+    protected fun showOfflineBanner(visible: Boolean) {
+        binding.offlineBannerTv.visibility = if (visible) View.VISIBLE else View.GONE
+    }
+
+    protected fun showEmpty(text: String?) {
+        if (text.isNullOrEmpty()) {
+            binding.emptyTv.visibility = View.GONE
+        } else {
+            binding.emptyTv.text = text
+            binding.emptyTv.visibility = View.VISIBLE
+        }
+    }
+
+    private fun toast(resId: Int) {
+        WKToastUtils.getInstance().showToast(getString(resId))
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val ARG_CHANNEL_ID = "channel_id"
+        const val ARG_CHANNEL_TYPE = "channel_type"
+
+        fun makeArgs(channelID: String, channelType: Byte): Bundle = Bundle().apply {
+            putString(ARG_CHANNEL_ID, channelID)
+            putByte(ARG_CHANNEL_TYPE, channelType)
+        }
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/BaseChannelSearchFragment.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/BaseChannelSearchFragment.kt
@@ -71,6 +71,12 @@ abstract class BaseChannelSearchFragment : Fragment() {
     /** 命中关键词但服务端返回空时的文案。 */
     protected open val emptyResultHintRes: Int = R.string.nodata
 
+    /**
+     * 关键词为空时是否仍然向服务端请求"按时间倒序浏览"。
+     * 媒体 / 文件 tab 覆写为 true，与 web/iOS 行为对齐——清空关键词后展示该频道的全部媒体/文件。
+     */
+    protected open val supportsBrowseWithoutKeyword: Boolean = false
+
     protected abstract fun setupRecyclerView(recyclerView: RecyclerView)
 
     protected abstract fun resetList()
@@ -127,11 +133,9 @@ abstract class BaseChannelSearchFragment : Fragment() {
         nextCursor = null
         hasMore = true
         showOfflineBanner(false)
-        if (keyword.isEmpty()) {
-            // 清空关键词 == 完全重置：列表清空、cursor 归零、loadMore 关闭、回到引导文案。
-            // 与 Activity 顶部"清空回到快捷过滤入口"的语义保持一致；
-            // 即使 [supportsBrowseWithoutKeyword]=true（媒体 / 文件 tab）也不做无关键词浏览，
-            // 避免清空后台仍在拉取造成视觉跳动。
+        if (keyword.isEmpty() && !supportsBrowseWithoutKeyword) {
+            // 仅消息相关 tab 在清空关键词时回到引导文案；媒体 / 文件 tab 通过 supportsBrowseWithoutKeyword
+            // 显式声明无关键词浏览能力，避免出现"清空后台仍在拉取"的视觉跳动。
             resetList()
             showEmpty(getString(emptyKeywordHintRes))
             binding.refreshLayout.setEnableLoadMore(false)

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchAllFragment.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchAllFragment.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.search.channel
+
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.chad.library.adapter.base.BaseQuickAdapter
+import com.chat.base.endpoint.EndpointManager
+import com.chat.base.endpoint.EndpointSID
+import com.chat.base.endpoint.entity.ChatViewMenu
+import com.chat.base.search.channel.ChannelSearchModel
+import com.chat.base.search.channel.dto.ChannelSearchReq
+import com.chat.base.utils.SoftKeyboardUtils
+import com.chat.uikit.R
+import com.chat.uikit.chat.search.channel.adapter.ChannelCombinedHitAdapter
+import com.xinbida.wukongim.WKIM
+
+/**
+ * 全部 tab：调 `/_search_all`，混排消息与文件。
+ * 关键词为空时不发起请求，显示空态提示用户输入关键词。
+ */
+class ChannelSearchAllFragment : BaseChannelSearchFragment() {
+
+    private lateinit var adapter: ChannelCombinedHitAdapter
+
+    override val emptyKeywordHintRes = R.string.channel_search_empty_keyword
+    override val emptyResultHintRes = R.string.nodata
+
+    override fun setupRecyclerView(recyclerView: RecyclerView) {
+        adapter = ChannelCombinedHitAdapter(channelID, channelType, resolveChannelName())
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        recyclerView.adapter = adapter
+        adapter.setOnItemClickListener { a: BaseQuickAdapter<*, *>, _, position ->
+            when (val entry = a.getItem(position)) {
+                is ChannelCombinedHitAdapter.Entry.Message -> jumpToChat(entry.hit.message_seq)
+                is ChannelCombinedHitAdapter.Entry.File -> jumpToChat(entry.hit.message_seq)
+                else -> Unit
+            }
+        }
+    }
+
+    override fun resetList() {
+        adapter.setList(emptyList())
+    }
+
+    override fun executeSearch(keyword: String, cursor: String?, isReset: Boolean) {
+        val req = ChannelSearchReq(
+            channelType = channelType,
+            channelId = channelID,
+            keyword = keyword,
+            pageSize = ChannelSearchReq.DEFAULT_PAGE_SIZE,
+            cursor = cursor,
+        )
+        val seqSnapshot = requestSeq
+        ChannelSearchModel.searchAll(req) { outcome ->
+            if (seqSnapshot != requestSeq) return@searchAll
+            if (!outcome.ok) {
+                handleNonSuccess(outcome, isReset, keyword)
+                return@searchAll
+            }
+            val list = outcome.data!!
+            val entries = ChannelCombinedHitAdapter.toEntries(list.data)
+            if (isReset) adapter.setList(entries) else if (entries.isNotEmpty()) adapter.addData(entries)
+            updatePaginationState(
+                hasMore = list.pagination.has_more,
+                nextCursor = list.pagination.next_cursor,
+                isEmpty = adapter.data.isEmpty(),
+                isReset = isReset,
+            )
+        }
+    }
+
+    override fun executeLocalFallback(keyword: String) {
+        // /_search_all 的本地兜底等价于消息部分回退；文件不在本地索引中。
+        // 当前简化处理：直接展示"服务端不可用"banner + 空态，引导用户切到消息 tab 看本地结果。
+        showOfflineBanner(true)
+        adapter.setList(emptyList())
+        showEmpty(getString(emptyResultHintRes))
+        hasMore = false
+        nextCursor = null
+        binding.refreshLayout.setEnableLoadMore(false)
+    }
+
+    private fun resolveChannelName(): String {
+        val ch = WKIM.getInstance().channelManager.getChannel(channelID, channelType) ?: return ""
+        return ch.channelRemark?.takeIf { it.isNotEmpty() } ?: ch.channelName ?: ""
+    }
+
+    private fun jumpToChat(messageSeq: Long) {
+        val orderSeq = WKIM.getInstance().msgManager.getMessageOrderSeq(
+            messageSeq, channelID, channelType
+        )
+        SoftKeyboardUtils.getInstance().hideSoftKeyboard(requireActivity())
+        EndpointManager.getInstance().invoke(
+            EndpointSID.chatView,
+            ChatViewMenu(
+                requireActivity(),
+                channelID,
+                channelType,
+                orderSeq,
+                false,
+            )
+        )
+    }
+
+    companion object {
+        fun newInstance(channelID: String, channelType: Byte): ChannelSearchAllFragment =
+            ChannelSearchAllFragment().apply { arguments = makeArgs(channelID, channelType) }
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchFileFragment.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchFileFragment.kt
@@ -39,6 +39,7 @@ class ChannelSearchFileFragment : BaseChannelSearchFragment() {
     private lateinit var adapter: ChannelFileHitAdapter
 
     override val emptyResultHintRes = R.string.nodata
+    override val supportsBrowseWithoutKeyword: Boolean = true
 
     override fun setupRecyclerView(recyclerView: RecyclerView) {
         adapter = ChannelFileHitAdapter()

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchFileFragment.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchFileFragment.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.search.channel
+
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.chad.library.adapter.base.BaseQuickAdapter
+import com.chat.base.endpoint.EndpointManager
+import com.chat.base.endpoint.EndpointSID
+import com.chat.base.endpoint.entity.ChatViewMenu
+import com.chat.base.search.channel.ChannelSearchModel
+import com.chat.base.search.channel.dto.ChannelSearchReq
+import com.chat.base.search.channel.dto.FileHit
+import com.chat.base.utils.SoftKeyboardUtils
+import com.chat.uikit.R
+import com.chat.uikit.chat.search.channel.adapter.ChannelFileHitAdapter
+import com.xinbida.wukongim.WKIM
+
+/**
+ * 文件 tab：调 `/_search_files`。关键词为空时按时间倒序浏览全部文件。
+ * 点击单条暂跳转到聊天页对应消息（与消息 tab 行为一致）；后续可改为直接走 [WKFileProvider] 预览/下载。
+ */
+class ChannelSearchFileFragment : BaseChannelSearchFragment() {
+
+    private lateinit var adapter: ChannelFileHitAdapter
+
+    override val emptyResultHintRes = R.string.nodata
+
+    override fun setupRecyclerView(recyclerView: RecyclerView) {
+        adapter = ChannelFileHitAdapter()
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        recyclerView.adapter = adapter
+        adapter.setOnItemClickListener { a: BaseQuickAdapter<*, *>, _, position ->
+            val hit = a.getItem(position) as? FileHit ?: return@setOnItemClickListener
+            jumpToChat(hit)
+        }
+    }
+
+    override fun resetList() {
+        adapter.setList(emptyList())
+    }
+
+    override fun executeSearch(keyword: String, cursor: String?, isReset: Boolean) {
+        val req = ChannelSearchReq(
+            channelType = channelType,
+            channelId = channelID,
+            keyword = keyword.takeIf { it.isNotEmpty() },
+            pageSize = ChannelSearchReq.DEFAULT_PAGE_SIZE,
+            cursor = cursor,
+        )
+        val seqSnapshot = requestSeq
+        ChannelSearchModel.searchFiles(req) { outcome ->
+            if (seqSnapshot != requestSeq) return@searchFiles
+            if (!outcome.ok) {
+                handleNonSuccess(outcome, isReset, keyword)
+                return@searchFiles
+            }
+            val list = outcome.data!!
+            if (isReset) adapter.setList(list.data) else if (list.data.isNotEmpty()) adapter.addData(list.data)
+            updatePaginationState(
+                hasMore = list.pagination.has_more,
+                nextCursor = list.pagination.next_cursor,
+                isEmpty = adapter.data.isEmpty(),
+                isReset = isReset,
+            )
+        }
+    }
+
+    private fun jumpToChat(hit: FileHit) {
+        val orderSeq = WKIM.getInstance().msgManager.getMessageOrderSeq(
+            hit.message_seq, channelID, channelType
+        )
+        SoftKeyboardUtils.getInstance().hideSoftKeyboard(requireActivity())
+        EndpointManager.getInstance().invoke(
+            EndpointSID.chatView,
+            ChatViewMenu(
+                requireActivity(),
+                channelID,
+                channelType,
+                orderSeq,
+                false,
+            )
+        )
+    }
+
+    companion object {
+        fun newInstance(channelID: String, channelType: Byte): ChannelSearchFileFragment =
+            ChannelSearchFileFragment().apply { arguments = makeArgs(channelID, channelType) }
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchMediaFragment.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchMediaFragment.kt
@@ -35,11 +35,17 @@ import com.xinbida.wukongim.WKIM
 /**
  * 媒体 tab：调 `/_search_media`（keyword 必须为空）。3 列网格 + 月份 sticky header。
  * 服务端按 sent_at 倒序返回；adapter 按 month_bucket 切段插入 header。
+ *
+ * 分页策略：每页只 append 新 tail，跨页维护 [lastMonthBucket] 让 [ChannelMediaHitAdapter.toEntries]
+ * 知道"上一页最后一个月份"，避免同月跨页时插重复 header。避免早期实现的每页 setList 全量重建
+ * （O(n²) 主线程 rebind + Glide 重载 + 滚动位置丢失）。
  */
 class ChannelSearchMediaFragment : BaseChannelSearchFragment() {
 
     private lateinit var adapter: ChannelMediaHitAdapter
-    private val allMedia = ArrayList<MediaHit>()
+
+    /** 已展示媒体的最后一个 month_bucket，供下一页 append 判断是否需要新 header。 */
+    private var lastMonthBucket: String? = null
 
     override val emptyResultHintRes = R.string.nodata
     override val supportsBrowseWithoutKeyword: Boolean = true
@@ -61,7 +67,7 @@ class ChannelSearchMediaFragment : BaseChannelSearchFragment() {
     }
 
     override fun resetList() {
-        allMedia.clear()
+        lastMonthBucket = null
         adapter.setList(emptyList())
     }
 
@@ -82,13 +88,19 @@ class ChannelSearchMediaFragment : BaseChannelSearchFragment() {
                 return@searchMedia
             }
             val list = outcome.data!!
-            if (isReset) allMedia.clear()
-            allMedia.addAll(list.data)
-            adapter.setList(ChannelMediaHitAdapter.toEntries(allMedia))
+            if (isReset) lastMonthBucket = null
+            val newEntries = ChannelMediaHitAdapter.toEntries(list.data, previousBucket = lastMonthBucket)
+            if (isReset) {
+                adapter.setList(newEntries)
+            } else if (newEntries.isNotEmpty()) {
+                adapter.addData(newEntries)
+            }
+            // 用本页最后一个 hit 的 month_bucket 更新游标，供下一页判断跨月边界。
+            list.data.lastOrNull()?.let { lastMonthBucket = it.month_bucket }
             updatePaginationState(
                 hasMore = list.pagination.has_more,
                 nextCursor = list.pagination.next_cursor,
-                isEmpty = allMedia.isEmpty(),
+                isEmpty = adapter.data.isEmpty(),
                 isReset = isReset,
             )
         }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchMediaFragment.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchMediaFragment.kt
@@ -42,6 +42,7 @@ class ChannelSearchMediaFragment : BaseChannelSearchFragment() {
     private val allMedia = ArrayList<MediaHit>()
 
     override val emptyResultHintRes = R.string.nodata
+    override val supportsBrowseWithoutKeyword: Boolean = true
 
     override fun setupRecyclerView(recyclerView: RecyclerView) {
         val cellSize = (resources.displayMetrics.widthPixels - AndroidUtilities.dp(4f)) / GRID_SPAN

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchMediaFragment.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchMediaFragment.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.search.channel
+
+import androidx.recyclerview.widget.RecyclerView
+import com.chad.library.adapter.base.BaseQuickAdapter
+import com.chat.base.endpoint.EndpointManager
+import com.chat.base.endpoint.EndpointSID
+import com.chat.base.endpoint.entity.ChatViewMenu
+import com.chat.base.search.channel.ChannelSearchModel
+import com.chat.base.search.channel.dto.ChannelSearchReq
+import com.chat.base.search.channel.dto.MediaHit
+import com.chat.base.utils.AndroidUtilities
+import com.chat.base.utils.SoftKeyboardUtils
+import com.chat.base.views.FullyGridLayoutManager
+import com.chat.base.views.pinnedsectionitemdecoration.PinnedHeaderItemDecoration
+import com.chat.uikit.R
+import com.chat.uikit.chat.search.channel.adapter.ChannelMediaHitAdapter
+import com.xinbida.wukongim.WKIM
+
+/**
+ * 媒体 tab：调 `/_search_media`（keyword 必须为空）。3 列网格 + 月份 sticky header。
+ * 服务端按 sent_at 倒序返回；adapter 按 month_bucket 切段插入 header。
+ */
+class ChannelSearchMediaFragment : BaseChannelSearchFragment() {
+
+    private lateinit var adapter: ChannelMediaHitAdapter
+    private val allMedia = ArrayList<MediaHit>()
+
+    override val emptyResultHintRes = R.string.nodata
+
+    override fun setupRecyclerView(recyclerView: RecyclerView) {
+        val cellSize = (resources.displayMetrics.widthPixels - AndroidUtilities.dp(4f)) / GRID_SPAN
+        val layoutManager = FullyGridLayoutManager(requireContext(), GRID_SPAN)
+        recyclerView.layoutManager = layoutManager
+        adapter = ChannelMediaHitAdapter(cellSize)
+        recyclerView.adapter = adapter
+        recyclerView.addItemDecoration(
+            PinnedHeaderItemDecoration.Builder(ChannelMediaHitAdapter.ITEM_TYPE_HEADER)
+                .enableDivider(false).create()
+        )
+        adapter.setOnItemClickListener { a: BaseQuickAdapter<*, *>, _, position ->
+            val entry = a.getItem(position) as? ChannelMediaHitAdapter.Entry.Item ?: return@setOnItemClickListener
+            jumpToChat(entry.hit)
+        }
+    }
+
+    override fun resetList() {
+        allMedia.clear()
+        adapter.setList(emptyList())
+    }
+
+    override fun executeSearch(keyword: String, cursor: String?, isReset: Boolean) {
+        // _search_media 必须不带 keyword；服务端如果收到非空 keyword 会 400。Model 内部强制清空，这里仅说明意图。
+        val req = ChannelSearchReq(
+            channelType = channelType,
+            channelId = channelID,
+            keyword = null,
+            pageSize = ChannelSearchReq.DEFAULT_PAGE_SIZE,
+            cursor = cursor,
+        )
+        val seqSnapshot = requestSeq
+        ChannelSearchModel.searchMedia(req) { outcome ->
+            if (seqSnapshot != requestSeq) return@searchMedia
+            if (!outcome.ok) {
+                handleNonSuccess(outcome, isReset, keyword)
+                return@searchMedia
+            }
+            val list = outcome.data!!
+            if (isReset) allMedia.clear()
+            allMedia.addAll(list.data)
+            adapter.setList(ChannelMediaHitAdapter.toEntries(allMedia))
+            updatePaginationState(
+                hasMore = list.pagination.has_more,
+                nextCursor = list.pagination.next_cursor,
+                isEmpty = allMedia.isEmpty(),
+                isReset = isReset,
+            )
+        }
+    }
+
+    private fun jumpToChat(hit: MediaHit) {
+        val orderSeq = WKIM.getInstance().msgManager.getMessageOrderSeq(
+            hit.message_seq, channelID, channelType
+        )
+        SoftKeyboardUtils.getInstance().hideSoftKeyboard(requireActivity())
+        EndpointManager.getInstance().invoke(
+            EndpointSID.chatView,
+            ChatViewMenu(
+                requireActivity(),
+                channelID,
+                channelType,
+                orderSeq,
+                false,
+            )
+        )
+    }
+
+    companion object {
+        private const val GRID_SPAN = 3
+        fun newInstance(channelID: String, channelType: Byte): ChannelSearchMediaFragment =
+            ChannelSearchMediaFragment().apply { arguments = makeArgs(channelID, channelType) }
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchMessageFragment.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchMessageFragment.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.search.channel
+
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.chad.library.adapter.base.BaseQuickAdapter
+import com.chat.base.endpoint.EndpointManager
+import com.chat.base.endpoint.EndpointSID
+import com.chat.base.endpoint.entity.ChatViewMenu
+import com.chat.base.entity.GlobalChannel
+import com.chat.base.entity.GlobalMessage
+import com.chat.base.search.channel.ChannelSearchModel
+import com.chat.base.search.channel.dto.ChannelSearchReq
+import com.chat.base.search.channel.toGlobalMessage
+import com.chat.base.utils.SoftKeyboardUtils
+import com.chat.base.utils.WKReader
+import com.chat.uikit.R
+import com.chat.uikit.chat.search.SearchMessageAdapter
+import com.xinbida.wukongim.WKIM
+
+/**
+ * 消息 tab：仅文本/转发命中。服务端 503/网络 → 回退到 IMSDK 本地搜索 + 顶部 banner。
+ */
+class ChannelSearchMessageFragment : BaseChannelSearchFragment() {
+
+    private lateinit var adapter: SearchMessageAdapter
+
+    override val emptyKeywordHintRes = R.string.channel_search_empty_keyword
+    override val emptyResultHintRes = R.string.nodata
+
+    override fun setupRecyclerView(recyclerView: RecyclerView) {
+        adapter = SearchMessageAdapter()
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        recyclerView.adapter = adapter
+        adapter.setOnItemClickListener { a: BaseQuickAdapter<*, *>, _, position ->
+            val gm = a.getItem(position) as? GlobalMessage ?: return@setOnItemClickListener
+            jumpToChat(gm)
+        }
+    }
+
+    override fun resetList() {
+        adapter.setList(emptyList())
+    }
+
+    override fun executeSearch(keyword: String, cursor: String?, isReset: Boolean) {
+        adapter.keyword = keyword
+        val req = ChannelSearchReq(
+            channelType = channelType,
+            channelId = channelID,
+            keyword = keyword,
+            pageSize = ChannelSearchReq.DEFAULT_PAGE_SIZE,
+            cursor = cursor,
+        )
+        val seqSnapshot = requestSeq
+        ChannelSearchModel.searchMessages(req) { outcome ->
+            if (seqSnapshot != requestSeq) return@searchMessages
+            if (!outcome.ok) {
+                handleNonSuccess(outcome, isReset, keyword)
+                return@searchMessages
+            }
+            showOfflineBanner(false)
+            val list = outcome.data!!
+            val name = resolveChannelName()
+            val mapped = list.data.map { it.toGlobalMessage(channelID, channelType, name) }
+            if (isReset) adapter.setList(mapped) else if (mapped.isNotEmpty()) adapter.addData(mapped)
+            updatePaginationState(
+                hasMore = list.pagination.has_more,
+                nextCursor = list.pagination.next_cursor,
+                isEmpty = adapter.data.isEmpty(),
+                isReset = isReset,
+            )
+        }
+    }
+
+    override fun executeLocalFallback(keyword: String) {
+        showOfflineBanner(true)
+        val localMsgs = WKIM.getInstance().msgManager.searchWithChannel(keyword, channelID, channelType)
+        if (!WKReader.isNotEmpty(localMsgs)) {
+            adapter.setList(emptyList())
+            showEmpty(getString(emptyResultHintRes))
+            hasMore = false
+            nextCursor = null
+            binding.refreshLayout.setEnableLoadMore(false)
+            return
+        }
+        val name = resolveChannelName()
+        val mapped = ArrayList<GlobalMessage>(localMsgs.size)
+        for (msg in localMsgs) {
+            val gm = GlobalMessage()
+            gm.message_seq = msg.messageSeq.toLong()
+            gm.from_uid = msg.fromUID ?: ""
+            gm.timestamp = msg.timestamp
+            val payload = HashMap<String, Any>()
+            payload["type"] = msg.type
+            payload["content"] = msg.searchableWord?.takeIf { it.isNotEmpty() }
+                ?: msg.baseContentMsgModel?.getSearchableWord() ?: ""
+            gm.payload = payload
+            gm.channel = GlobalChannel().apply {
+                channel_id = channelID
+                channel_type = channelType
+                channel_name = name
+            }
+            mapped.add(gm)
+        }
+        adapter.setList(mapped)
+        showEmpty(null)
+        hasMore = false
+        nextCursor = null
+        binding.refreshLayout.setEnableLoadMore(false)
+    }
+
+    private fun resolveChannelName(): String {
+        val ch = WKIM.getInstance().channelManager.getChannel(channelID, channelType) ?: return ""
+        return ch.channelRemark?.takeIf { it.isNotEmpty() } ?: ch.channelName ?: ""
+    }
+
+    private fun jumpToChat(gm: GlobalMessage) {
+        val orderSeq = WKIM.getInstance().msgManager.getMessageOrderSeq(
+            gm.message_seq, gm.channel.channel_id, gm.channel.channel_type
+        )
+        SoftKeyboardUtils.getInstance().hideSoftKeyboard(requireActivity())
+        EndpointManager.getInstance().invoke(
+            EndpointSID.chatView,
+            ChatViewMenu(
+                requireActivity(),
+                gm.channel.channel_id,
+                gm.channel.channel_type,
+                orderSeq,
+                false,
+            )
+        )
+    }
+
+    companion object {
+        fun newInstance(channelID: String, channelType: Byte): ChannelSearchMessageFragment =
+            ChannelSearchMessageFragment().apply { arguments = makeArgs(channelID, channelType) }
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchViewModel.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/ChannelSearchViewModel.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.search.channel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chat.base.search.channel.dto.SearchFilters
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Activity 级共享状态：keyword、filters、当前选中 tab。
+ * 4 个子 Fragment 通过 `activityViewModels()` 订阅同一份 state，输入框只在 Activity 顶部。
+ *
+ * keyword 输入做 300ms debounce 后通过 [queryEvents] 通知所有 Fragment 重置查询，
+ * 与服务端 5 QPS / 20 burst 限流配合。
+ */
+class ChannelSearchViewModel : ViewModel() {
+
+    data class State(
+        val keyword: String = "",
+        val filters: SearchFilters? = null,
+        val tabIndex: Int = 0,
+    )
+
+    private val _state = MutableStateFlow(State())
+    val state = _state.asStateFlow()
+
+    /**
+     * Debounce 之后的"重置查询"事件。replay=1 保证后绑定的 Fragment 也能立即拿到当前关键词。
+     * 每个 Fragment 收到事件后清掉自己的 cursor + 列表，按 [state] 当前值发起新一轮请求。
+     */
+    private val _queryEvents = MutableSharedFlow<State>(replay = 1)
+    val queryEvents: SharedFlow<State> = _queryEvents.asSharedFlow()
+
+    private var debounceJob: Job? = null
+
+    fun setKeyword(value: String) {
+        if (_state.value.keyword == value) return
+        _state.value = _state.value.copy(keyword = value)
+        debounceJob?.cancel()
+        debounceJob = viewModelScope.launch {
+            delay(DEBOUNCE_MS)
+            _queryEvents.emit(_state.value)
+        }
+    }
+
+    fun setFilters(value: SearchFilters?) {
+        if (_state.value.filters == value) return
+        _state.value = _state.value.copy(filters = value)
+        viewModelScope.launch { _queryEvents.emit(_state.value) }
+    }
+
+    fun setTabIndex(index: Int) {
+        if (_state.value.tabIndex == index) return
+        _state.value = _state.value.copy(tabIndex = index)
+    }
+
+    /** Fragment 首次绑定 / Tab 首次进入时，主动取一次当前状态触发查询。 */
+    fun replayCurrent() {
+        viewModelScope.launch { _queryEvents.emit(_state.value) }
+    }
+
+    companion object {
+        const val DEBOUNCE_MS = 300L
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/adapter/ChannelCombinedHitAdapter.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/adapter/ChannelCombinedHitAdapter.kt
@@ -32,7 +32,7 @@ import com.chat.base.ui.components.AvatarView
 import com.chat.base.utils.WKTimeUtils
 import com.chat.uikit.R
 import com.chat.uikit.chat.provider.WKFileProvider
-import com.xinbida.wukongim.WKIM
+import com.xinbida.wukongim.entity.WKChannelType
 
 /**
  * `/_search_all` 混排结果适配器。message / file 两种 result_type 分别走不同 item 布局。
@@ -70,7 +70,8 @@ class ChannelCombinedHitAdapter(
     private fun bindMessage(holder: BaseViewHolder, hit: MessageHit) {
         val avatar = holder.getView<AvatarView>(R.id.avatarView)
         avatar.setSize(40f)
-        avatar.showAvatar(channelID, channelType)
+        // 与 SearchMessageAdapter 一致：搜索结果展示发送人头像，而非频道头像。
+        avatar.showAvatar(hit.sender_id, WKChannelType.PERSONAL)
         holder.setText(R.id.nameTv, channelName)
 
         val contentTv = holder.getView<TextView>(R.id.contentTv)

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/adapter/ChannelCombinedHitAdapter.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/adapter/ChannelCombinedHitAdapter.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.search.channel.adapter
+
+import android.os.Build
+import android.text.Html
+import android.text.TextUtils
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import com.chad.library.adapter.base.BaseMultiItemQuickAdapter
+import com.chad.library.adapter.base.entity.MultiItemEntity
+import com.chad.library.adapter.base.viewholder.BaseViewHolder
+import com.chat.base.search.channel.dto.CombinedHit
+import com.chat.base.search.channel.dto.FileHit
+import com.chat.base.search.channel.dto.MessageHit
+import com.chat.base.ui.components.AvatarView
+import com.chat.base.utils.WKTimeUtils
+import com.chat.uikit.R
+import com.chat.uikit.chat.provider.WKFileProvider
+import com.xinbida.wukongim.WKIM
+
+/**
+ * `/_search_all` 混排结果适配器。message / file 两种 result_type 分别走不同 item 布局。
+ *  - message 复用 [R.layout.item_global_message_layout]（与频道 / 全局搜索同视觉风格）
+ *  - file 复用 [R.layout.item_channel_search_file]
+ */
+class ChannelCombinedHitAdapter(
+    private val channelID: String,
+    private val channelType: Byte,
+    private val channelName: String,
+) : BaseMultiItemQuickAdapter<ChannelCombinedHitAdapter.Entry, BaseViewHolder>() {
+
+    init {
+        addItemType(TYPE_MESSAGE, R.layout.item_global_message_layout)
+        addItemType(TYPE_FILE, R.layout.item_channel_search_file)
+    }
+
+    sealed class Entry : MultiItemEntity {
+        data class Message(val hit: MessageHit) : Entry() {
+            override val itemType: Int = TYPE_MESSAGE
+        }
+
+        data class File(val hit: FileHit) : Entry() {
+            override val itemType: Int = TYPE_FILE
+        }
+    }
+
+    override fun convert(holder: BaseViewHolder, item: Entry) {
+        when (item) {
+            is Entry.Message -> bindMessage(holder, item.hit)
+            is Entry.File -> bindFile(holder, item.hit)
+        }
+    }
+
+    private fun bindMessage(holder: BaseViewHolder, hit: MessageHit) {
+        val avatar = holder.getView<AvatarView>(R.id.avatarView)
+        avatar.setSize(40f)
+        avatar.showAvatar(channelID, channelType)
+        holder.setText(R.id.nameTv, channelName)
+
+        val contentTv = holder.getView<TextView>(R.id.contentTv)
+        contentTv.text = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+            Html.fromHtml(hit.getHighlightedHtml(), Html.FROM_HTML_MODE_LEGACY)
+        else
+            @Suppress("DEPRECATION") Html.fromHtml(hit.getHighlightedHtml())
+
+        holder.getView<View>(R.id.fileTagIv).visibility = View.GONE
+
+        val timeTv = holder.getView<TextView>(R.id.timeTv)
+        val epochSec = com.chat.base.search.channel.Rfc3339.toEpochSeconds(hit.sent_at)
+        timeTv.text = if (epochSec > 0)
+            WKTimeUtils.getInstance().getTimeString(epochSec * 1000)
+        else ""
+    }
+
+    private fun bindFile(holder: BaseViewHolder, hit: FileHit) {
+        val iconIv = holder.getView<ImageView>(R.id.fileTagIv)
+        WKFileProvider.setFileIcon(iconIv, hit.file_ext, hit.file_name)
+
+        val nameTv = holder.getView<TextView>(R.id.nameTv)
+        val raw = hit.file_name
+        nameTv.text = if (raw.contains("<mark>")) {
+            val html = raw.replace("<mark>", "<font color=#7761F4>").replace("</mark>", "</font>")
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+                Html.fromHtml(html, Html.FROM_HTML_MODE_LEGACY)
+            else
+                @Suppress("DEPRECATION") Html.fromHtml(html)
+        } else {
+            raw
+        }
+
+        holder.setText(R.id.sizeTv, WKFileProvider.formatFileSize(hit.file_size_bytes))
+        val senderTv = holder.getView<TextView>(R.id.senderTv)
+        senderTv.text = hit.sender_name.orEmpty()
+        senderTv.visibility = if (TextUtils.isEmpty(hit.sender_name)) View.GONE else View.VISIBLE
+
+        val timeTv = holder.getView<TextView>(R.id.timeTv)
+        val epochSec = com.chat.base.search.channel.Rfc3339.toEpochSeconds(hit.sent_at)
+        timeTv.text = if (epochSec > 0)
+            WKTimeUtils.getInstance().getTimeString(epochSec * 1000)
+        else ""
+    }
+
+    companion object {
+        const val TYPE_MESSAGE = 0
+        const val TYPE_FILE = 1
+
+        fun toEntries(hits: List<CombinedHit>): List<Entry> = hits.mapNotNull { h ->
+            when {
+                h.isMessage() && h.message != null -> Entry.Message(h.message!!)
+                h.isFile() && h.file != null -> Entry.File(h.file!!)
+                else -> null
+            }
+        }
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/adapter/ChannelFileHitAdapter.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/adapter/ChannelFileHitAdapter.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.search.channel.adapter
+
+import android.os.Build
+import android.text.Html
+import android.text.TextUtils
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import com.chad.library.adapter.base.BaseQuickAdapter
+import com.chad.library.adapter.base.viewholder.BaseViewHolder
+import com.chat.base.search.channel.dto.FileHit
+import com.chat.base.utils.WKTimeUtils
+import com.chat.uikit.R
+import com.chat.uikit.chat.provider.WKFileProvider
+
+/** 频道内文件搜索结果 Adapter。复用 [WKFileProvider.setFileIcon] 与 [WKFileProvider.formatFileSize]。 */
+class ChannelFileHitAdapter :
+    BaseQuickAdapter<FileHit, BaseViewHolder>(R.layout.item_channel_search_file) {
+
+    override fun convert(holder: BaseViewHolder, item: FileHit) {
+        val iconIv = holder.getView<ImageView>(R.id.fileTagIv)
+        WKFileProvider.setFileIcon(iconIv, item.file_ext, item.file_name)
+
+        val nameTv = holder.getView<TextView>(R.id.nameTv)
+        val raw = item.file_name
+        if (raw.contains("<mark>")) {
+            val html = raw.replace("<mark>", "<font color=#7761F4>").replace("</mark>", "</font>")
+            nameTv.text = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+                Html.fromHtml(html, Html.FROM_HTML_MODE_LEGACY)
+            else
+                @Suppress("DEPRECATION") Html.fromHtml(html)
+        } else {
+            nameTv.text = raw
+        }
+
+        val sizeTv = holder.getView<TextView>(R.id.sizeTv)
+        sizeTv.text = WKFileProvider.formatFileSize(item.file_size_bytes)
+
+        val senderTv = holder.getView<TextView>(R.id.senderTv)
+        senderTv.text = item.sender_name.orEmpty()
+        senderTv.visibility = if (TextUtils.isEmpty(item.sender_name)) View.GONE else View.VISIBLE
+
+        val timeTv = holder.getView<TextView>(R.id.timeTv)
+        val epochSec = com.chat.base.search.channel.Rfc3339.toEpochSeconds(item.sent_at)
+        timeTv.text = if (epochSec > 0)
+            WKTimeUtils.getInstance().getTimeString(epochSec * 1000)
+        else ""
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/adapter/ChannelMediaHitAdapter.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/adapter/ChannelMediaHitAdapter.kt
@@ -17,6 +17,7 @@
 package com.chat.uikit.chat.search.channel.adapter
 
 import android.view.View
+import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
@@ -67,12 +68,18 @@ class ChannelMediaHitAdapter(private val cellSize: Int) :
         when (item) {
             is Entry.Header -> holder.setText(R.id.monthHeaderTv, item.monthBucket)
             is Entry.Item -> {
+                // 把单元格 root 撑到 cellSize × cellSize：仅改 ImageView 大小不够，因为 layout 根布局
+                // 以前用 match_parent，会让 GridLayoutManager 把整行拉到 RV 高度，出现"上面一行全是空白"的现象。
+                val root = holder.itemView
+                root.layoutParams = (root.layoutParams ?: ViewGroup.LayoutParams(cellSize, cellSize))
+                    .also { it.width = cellSize; it.height = cellSize }
                 val iv = holder.getView<ImageView>(R.id.thumbIv)
-                iv.layoutParams.width = cellSize
-                iv.layoutParams.height = cellSize
                 GlideUtils.getInstance().showImg(context, item.hit.thumb_url, iv)
+                val playIv = holder.getView<ImageView>(R.id.playIv)
                 val durationTv = holder.getView<TextView>(R.id.durationTv)
-                if (item.hit.isVideo() && item.hit.duration_ms > 0) {
+                val isVideo = item.hit.isVideo()
+                playIv.visibility = if (isVideo) View.VISIBLE else View.GONE
+                if (isVideo && item.hit.duration_ms > 0) {
                     durationTv.text = formatDuration(item.hit.duration_ms)
                     durationTv.visibility = View.VISIBLE
                 } else {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/adapter/ChannelMediaHitAdapter.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/adapter/ChannelMediaHitAdapter.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.search.channel.adapter
+
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.chad.library.adapter.base.BaseMultiItemQuickAdapter
+import com.chad.library.adapter.base.entity.MultiItemEntity
+import com.chad.library.adapter.base.viewholder.BaseViewHolder
+import com.chat.base.glide.GlideUtils
+import com.chat.base.search.channel.dto.MediaHit
+import com.chat.base.views.pinnedsectionitemdecoration.utils.FullSpanUtil
+import com.chat.uikit.R
+
+/**
+ * 频道内媒体（图片+视频）网格 Adapter。
+ *  - [ITEM_TYPE_HEADER]: 月份分组头（YYYY-MM），sticky 由 PinnedHeaderItemDecoration(1) 处理
+ *  - [ITEM_TYPE_MEDIA] : 单个媒体格子
+ *
+ * 数据排好序后 [setData]：相邻同月份的 hit 之间不再插 header。
+ */
+class ChannelMediaHitAdapter(private val cellSize: Int) :
+    BaseMultiItemQuickAdapter<ChannelMediaHitAdapter.Entry, BaseViewHolder>() {
+
+    init {
+        addItemType(ITEM_TYPE_MEDIA, R.layout.item_channel_search_media)
+        addItemType(ITEM_TYPE_HEADER, R.layout.item_channel_search_media_header)
+    }
+
+    sealed class Entry : MultiItemEntity {
+        data class Header(val monthBucket: String) : Entry() {
+            override val itemType: Int = ITEM_TYPE_HEADER
+        }
+
+        data class Item(val hit: MediaHit) : Entry() {
+            override val itemType: Int = ITEM_TYPE_MEDIA
+        }
+    }
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        FullSpanUtil.onAttachedToRecyclerView(recyclerView, this, ITEM_TYPE_HEADER)
+    }
+
+    override fun onViewAttachedToWindow(holder: BaseViewHolder) {
+        super.onViewAttachedToWindow(holder)
+        FullSpanUtil.onViewAttachedToWindow(holder, this, ITEM_TYPE_HEADER)
+    }
+
+    override fun convert(holder: BaseViewHolder, item: Entry) {
+        when (item) {
+            is Entry.Header -> holder.setText(R.id.monthHeaderTv, item.monthBucket)
+            is Entry.Item -> {
+                val iv = holder.getView<ImageView>(R.id.thumbIv)
+                iv.layoutParams.width = cellSize
+                iv.layoutParams.height = cellSize
+                GlideUtils.getInstance().showImg(context, item.hit.thumb_url, iv)
+                val durationTv = holder.getView<TextView>(R.id.durationTv)
+                if (item.hit.isVideo() && item.hit.duration_ms > 0) {
+                    durationTv.text = formatDuration(item.hit.duration_ms)
+                    durationTv.visibility = View.VISIBLE
+                } else {
+                    durationTv.visibility = View.GONE
+                }
+            }
+        }
+    }
+
+    private fun formatDuration(ms: Long): String {
+        val totalSec = ms / 1000
+        val min = totalSec / 60
+        val sec = totalSec % 60
+        return "%d:%02d".format(min, sec)
+    }
+
+    companion object {
+        const val ITEM_TYPE_HEADER = 1
+        const val ITEM_TYPE_MEDIA = 0
+
+        /** 给定一段已按 [MediaHit.sent_at] 倒序的命中，按 month_bucket 切分插入 header。 */
+        fun toEntries(hits: List<MediaHit>): List<Entry> {
+            val out = ArrayList<Entry>(hits.size + 8)
+            var lastBucket: String? = null
+            for (hit in hits) {
+                if (hit.month_bucket != lastBucket) {
+                    out.add(Entry.Header(hit.month_bucket))
+                    lastBucket = hit.month_bucket
+                }
+                out.add(Entry.Item(hit))
+            }
+            return out
+        }
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/adapter/ChannelMediaHitAdapter.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/channel/adapter/ChannelMediaHitAdapter.kt
@@ -100,10 +100,15 @@ class ChannelMediaHitAdapter(private val cellSize: Int) :
         const val ITEM_TYPE_HEADER = 1
         const val ITEM_TYPE_MEDIA = 0
 
-        /** 给定一段已按 [MediaHit.sent_at] 倒序的命中，按 month_bucket 切分插入 header。 */
-        fun toEntries(hits: List<MediaHit>): List<Entry> {
+        /**
+         * 给定一段已按 [MediaHit.sent_at] 倒序的命中，按 month_bucket 切分插入 header。
+         *
+         * @param previousBucket 上一页最后一个 hit 的 month_bucket；分页 append 时传入，
+         *        避免本页首个 hit 与上一页同月时插入重复 header。首页/reset 传 null。
+         */
+        fun toEntries(hits: List<MediaHit>, previousBucket: String? = null): List<Entry> {
             val out = ArrayList<Entry>(hits.size + 8)
-            var lastBucket: String? = null
+            var lastBucket: String? = previousBucket
             for (hit in hits) {
                 if (hit.month_bucket != lastBucket) {
                     out.add(Entry.Header(hit.month_bucket))

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchImgEntity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchImgEntity.java
@@ -30,6 +30,8 @@ public class SearchImgEntity implements MultiItemEntity {
     public WKMessageContent originalContent;
     public String url;
     public String date;
+    /** API 切换后 sender_name 不再来自本地 channel，存一份给收藏等回调使用。 */
+    public String senderName;
 //    public String clientMsgNo;
 //    public long oldestOrderSeq;
 //    public WKMessageContent messageContent;

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchWithImgActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchWithImgActivity.java
@@ -32,18 +32,19 @@ import com.chat.base.endpoint.EndpointSID;
 import com.chat.base.endpoint.entity.ChatChooseContacts;
 import com.chat.base.endpoint.entity.ChatViewMenu;
 import com.chat.base.endpoint.entity.ChooseChatMenu;
+import com.chat.base.entity.GlobalChannel;
 import com.chat.base.entity.GlobalMessage;
-import com.chat.base.entity.GlobalSearchReq;
 import com.chat.base.entity.ImagePopupBottomSheetItem;
 import com.chat.base.foldable.PaneMetrics;
 import com.chat.base.msgitem.WKContentType;
-import com.chat.base.net.HttpResponseCode;
-import com.chat.base.search.GlobalSearchModel;
-import com.chat.base.ui.Theme;
+import com.chat.base.search.channel.ChannelSearchModel;
+import com.chat.base.search.channel.Rfc3339;
+import com.chat.base.search.channel.dto.ChannelSearchReq;
+import com.chat.base.search.channel.dto.MediaHit;
 import com.chat.base.utils.AndroidUtilities;
 import com.chat.base.utils.WKDialogUtils;
 import com.chat.base.utils.WKReader;
-import com.chat.base.utils.WKTimeUtils;
+import com.chat.base.utils.WKToastUtils;
 import com.chat.base.views.CustomImageViewerPopup;
 import com.chat.base.views.FullyGridLayoutManager;
 import com.chat.base.views.pinnedsectionitemdecoration.PinnedHeaderItemDecoration;
@@ -57,16 +58,12 @@ import com.xinbida.wukongim.entity.WKChannel;
 import com.xinbida.wukongim.entity.WKChannelType;
 import com.xinbida.wukongim.entity.WKMsg;
 import com.xinbida.wukongim.msgmodel.WKImageContent;
-import com.xinbida.wukongim.msgmodel.WKMediaMessageContent;
 import com.xinbida.wukongim.msgmodel.WKMessageContent;
 import com.xinbida.wukongim.msgmodel.WKVideoContent;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * 3/23/21 10:07 AM
@@ -76,8 +73,9 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
     private String channelID;
     private byte channelType;
     private SearchWithImgAdapter adapter;
-    private int page = 1;
-    private final Set<Long> seenSeqs = new HashSet<>();
+    private String nextCursor = null;
+    private boolean hasMore = true;
+    private boolean loading = false;
 
     @Override
     protected ActSearchMsgImgLayoutBinding getViewBinding() {
@@ -120,13 +118,11 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
     @Override
     protected void initListener() {
         getData();
-        
+
         wkVBinding.refreshLayout.setEnableRefresh(false);
         wkVBinding.refreshLayout.setOnRefreshLoadMoreListener(new OnRefreshLoadMoreListener() {
             @Override
             public void onLoadMore(@NonNull RefreshLayout refreshLayout) {
-                //  oldestOrderSeq = adapter.getData().get(adapter.getData().size() - 1).oldestOrderSeq;
-                page++;
                 getData();
             }
 
@@ -138,7 +134,12 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
         adapter.addChildClickViewIds(R.id.imageView);
         adapter.setOnItemChildClickListener((adapter1, view1, position) -> {
             SearchImgEntity entity = (SearchImgEntity) adapter1.getData().get(position);
-            if (entity != null && entity.getItemType() == 0) {
+            if (entity == null || entity.getItemType() != 0) return;
+            // 视频跳过大图浏览器（图片专用），直接跳到聊天页查看原视频；
+            // 没有 server 封面时大图也只是空白，体验更差。
+            if (entity.originalContent instanceof WKVideoContent) {
+                showInChat(entity.message);
+            } else {
                 showImg(entity.url, (ImageView) view1);
             }
         });
@@ -150,12 +151,13 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
         List<Object> urlList = new ArrayList<>();
         List<ImageView> imgList = new ArrayList<>();
         for (int i = 0, size = adapter.getData().size(); i < size; i++) {
-            if (adapter.getData().get(i).getItemType() == 0) {
-                tempImgList.add(adapter.getData().get(i));
-                urlList.add(adapter.getData().get(i).url);
-                ImageView imageView1 = (ImageView) adapter.getViewByPosition(i, R.id.imageView);
-                imgList.add(imageView1);
-            }
+            SearchImgEntity item = adapter.getData().get(i);
+            // 大图浏览器只承载图片；视频跳过（视频走 jump-to-chat 路径）。
+            if (item.getItemType() != 0 || !(item.originalContent instanceof WKImageContent)) continue;
+            tempImgList.add(item);
+            urlList.add(item.url);
+            ImageView imageView1 = (ImageView) adapter.getViewByPosition(i, R.id.imageView);
+            imgList.add(imageView1);
         }
         int index = 0;
         for (int i = 0; i < tempImgList.size(); i++) {
@@ -169,7 +171,7 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
         List<ImagePopupBottomSheetItem> bottomEntityArrayList = new ArrayList<>();
         bottomEntityArrayList.add(new ImagePopupBottomSheetItem(getString(R.string.forward), R.mipmap.msg_forward, position -> {
             SearchImgEntity entity = (SearchImgEntity) tempImgList.get(position);
-            if (entity == null || entity.message.getMessageModel() == null) return;
+            if (entity == null || entity.originalContent == null) return;
             forward(entity);
         }));
         bottomEntityArrayList.add(new ImagePopupBottomSheetItem(getString(R.string.uikit_go_to_chat_item), R.mipmap.msg_message, position -> {
@@ -184,9 +186,15 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
             @Override
             public void onFavorite(int position) {
                 SearchImgEntity entity = (SearchImgEntity) tempImgList.get(position);
-                WKMsg msg = WKIM.getInstance().getMsgManager().getWithClientMsgNO(entity.message.client_msg_no);
-                if (msg != null) {
-                    collect(msg);
+                if (entity == null) return;
+                // 切到 API 后本地 DB 可能没有这条消息（这正是本页换接口的初衷）：
+                //  - 先按 server message_id 查本地，命中则走原 WKMsg 路径（带 from channel 完整信息）；
+                //  - 未命中时由 MediaHit 重建的 WKImageContent + entity.message 元数据兜底，仅图片支持。
+                WKMsg localMsg = WKIM.getInstance().getMsgManager().getWithMessageID(entity.message.message_idstr);
+                if (localMsg != null && localMsg.baseContentMsgModel instanceof WKImageContent) {
+                    collect(localMsg);
+                } else if (entity.originalContent instanceof WKImageContent) {
+                    collectFromEntity(entity, (WKImageContent) entity.originalContent);
                 }
             }
 
@@ -202,8 +210,8 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
     private void showInChat(GlobalMessage msg) {
         long orderSeq = WKIM.getInstance().getMsgManager().getMessageOrderSeq(
                 msg.getMessage_seq(),
-                msg.getChannel().getChannel_id(),
-                msg.getChannel().getChannel_type()
+                channelID,
+                channelType
         );
         EndpointManager.getInstance().invoke(EndpointSID.chatView, new ChatViewMenu(SearchWithImgActivity.this, channelID, channelType, orderSeq, false));
     }
@@ -230,17 +238,47 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
         EndpointManager.getInstance().invoke("favorite_add", hashMap);
     }
 
+    /** 本地 DB 没这条 msg 时，直接用 MediaHit 重建的 [entity] 凑出 favorite_add 需要的字段。 */
+    private void collectFromEntity(SearchImgEntity entity, WKImageContent img) {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("content", WKApiConfig.getShowUrl(img.url));
+        jsonObject.put("width", img.width);
+        jsonObject.put("height", img.height);
+        HashMap<String, Object> hashMap = new HashMap<>();
+        hashMap.put("type", WKContentType.WK_IMAGE);
+        String uniqueKey = !TextUtils.isEmpty(entity.message.message_idstr)
+                ? entity.message.message_idstr
+                : "";
+        hashMap.put("unique_key", uniqueKey);
+        hashMap.put("author_uid", entity.message.from_uid != null ? entity.message.from_uid : "");
+        hashMap.put("author_name", entity.senderName != null ? entity.senderName : "");
+        hashMap.put("payload", jsonObject);
+        hashMap.put("activity", this);
+        EndpointManager.getInstance().invoke("favorite_add", hashMap);
+    }
+
     private void forward(SearchImgEntity entity) {
-        WKMessageContent finalWKMessageContent = entity.originalContent != null
-                ? entity.originalContent
-                : entity.message.getMessageModel();
+        WKMessageContent finalWKMessageContent = entity.originalContent;
         if (finalWKMessageContent == null) {
             return;
         }
+        // 视频特别处理：MediaHit 只有 thumb_url（封面），没有真视频 URL；如果直接把合成的
+        // WKVideoContent（url=封面）转发出去，对方收到的"视频"会无法播放。
+        // 兜底：先按 server message_id 查本地 WKMsg，命中就用本地完整内容；查不到提示用户去聊天页操作。
+        if (finalWKMessageContent instanceof WKVideoContent) {
+            WKMsg localMsg = WKIM.getInstance().getMsgManager().getWithMessageID(entity.message.message_idstr);
+            if (localMsg != null && localMsg.baseContentMsgModel instanceof WKVideoContent) {
+                finalWKMessageContent = localMsg.baseContentMsgModel;
+            } else {
+                WKToastUtils.getInstance().showToast(getString(R.string.uikit_video_forward_unavailable));
+                return;
+            }
+        }
+        final WKMessageContent contentToSend = finalWKMessageContent;
         EndpointManager.getInstance().invoke(EndpointSID.showChooseChatView, new ChooseChatMenu(new ChatChooseContacts(list1 -> {
             if (WKReader.isNotEmpty(list1)) {
                 for (WKChannel channel : list1) {
-                    WKIM.getInstance().getMsgManager().send(finalWKMessageContent, channel);
+                    WKIM.getInstance().getMsgManager().send(contentToSend, channel);
                 }
                 ViewGroup viewGroup = (ViewGroup) findViewById(android.R.id.content).getRootView();
                 Snackbar.make(viewGroup, getString(R.string.is_forward), 1000)
@@ -248,137 +286,127 @@ public class SearchWithImgActivity extends WKBaseActivity<ActSearchMsgImgLayoutB
                         })
                         .show();
             }
-        }), finalWKMessageContent));
+        }), contentToSend));
     }
 
     private void getData() {
-        // 本地搜索
-        List<SearchImgEntity> localEntities = new ArrayList<>();
-
-        if (page == 1) {
-            seenSeqs.clear();
-            List<WKMsg> localMsgs = WKIM.getInstance().getMsgManager()
-                    .searchMsgWithChannelAndContentTypes(channelID, channelType, 0, 200,
-                            new int[]{WKContentType.WK_IMAGE, WKContentType.WK_VIDEO});
-            if (WKReader.isNotEmpty(localMsgs)) {
-                for (WKMsg msg : localMsgs) {
-                    if (com.chat.base.space.SpaceFilter.shouldSkipMessageForSpace(msg)) continue;
-                    if (msg.baseContentMsgModel == null) continue;
-                    if (!seenSeqs.add((long) msg.messageSeq)) continue;
-
-                    String showUrl = "";
-                    if (msg.baseContentMsgModel instanceof WKImageContent imgContent) {
-                        if (!TextUtils.isEmpty(imgContent.localPath) && new File(imgContent.localPath).exists()) {
-                            showUrl = imgContent.localPath;
-                        }
-                        if (TextUtils.isEmpty(showUrl)) {
-                            showUrl = WKApiConfig.getShowUrl(imgContent.url);
-                        }
-                    } else if (msg.baseContentMsgModel instanceof WKVideoContent videoContent) {
-                        if (!TextUtils.isEmpty(videoContent.coverLocalPath) && new File(videoContent.coverLocalPath).exists()) {
-                            showUrl = videoContent.coverLocalPath;
-                        }
-                        if (TextUtils.isEmpty(showUrl) && !TextUtils.isEmpty(videoContent.cover)) {
-                            showUrl = WKApiConfig.getShowUrl(videoContent.cover);
-                        }
-                    }
-                    if (TextUtils.isEmpty(showUrl)) continue;
-
-                    String date = WKTimeUtils.getInstance().time2YearMonth(msg.timestamp * 1000);
-                    addDateHeaderIfNeeded(localEntities, date);
-
-                    SearchImgEntity entity = new SearchImgEntity();
-                    entity.date = date;
-                    entity.url = showUrl;
-                    entity.originalContent = msg.baseContentMsgModel;
-
-                    GlobalMessage gm = new GlobalMessage();
-                    gm.setMessage_seq((long) msg.messageSeq);
-                    gm.setFrom_uid(msg.fromUID != null ? msg.fromUID : "");
-                    gm.setTimestamp(msg.timestamp);
-                    gm.setClient_msg_no(msg.clientMsgNO != null ? msg.clientMsgNO : "");
-                    com.chat.base.entity.GlobalChannel gc = new com.chat.base.entity.GlobalChannel();
-                    gc.setChannel_id(channelID);
-                    gc.setChannel_type(channelType);
-                    gm.setChannel(gc);
-                    HashMap<String, Object> payloadMap = new HashMap<>();
-                    payloadMap.put("type", msg.type);
-                    gm.setPayload(payloadMap);
-                    entity.message = gm;
-
-                    localEntities.add(entity);
-                }
+        if (loading || !hasMore) {
+            wkVBinding.refreshLayout.finishLoadMore();
+            if (!hasMore) {
+                wkVBinding.refreshLayout.finishLoadMoreWithNoMoreData();
             }
+            return;
         }
-
-        // API 搜索
-        ArrayList<Integer> contentType = new ArrayList<>();
-        contentType.add(WKContentType.WK_IMAGE);
-        contentType.add(WKContentType.WK_VIDEO);
-        GlobalSearchReq req = new GlobalSearchReq(1, "", channelID, channelType, "", "", contentType, page, 20, 0, 0);
-        GlobalSearchModel.INSTANCE.search(req, (code, s, globalSearch) -> {
+        loading = true;
+        // 频道内媒体走 /_search_media。keyword 必须为空（Model 内部强制），cursor 由服务端签发。
+        // 子区直接复用：传入 channelID 即对应子区频道，无需额外逻辑。
+        ChannelSearchReq req = new ChannelSearchReq(
+                channelType,
+                channelID,
+                null,
+                null,
+                ChannelSearchReq.SORT_TIME_DESC,
+                ChannelSearchReq.DEFAULT_PAGE_SIZE,
+                nextCursor
+        );
+        final boolean isReset = (nextCursor == null);
+        ChannelSearchModel.INSTANCE.searchMedia(req, outcome -> {
+            loading = false;
             wkVBinding.refreshLayout.finishLoadMore();
             wkVBinding.refreshLayout.finishRefresh();
 
-            List<SearchImgEntity> merged = new ArrayList<>(localEntities);
-
-            if (code == HttpResponseCode.success && globalSearch != null && WKReader.isNotEmpty(globalSearch.messages)) {
-                for (GlobalMessage msg : globalSearch.messages) {
-                    if (!seenSeqs.add(msg.getMessage_seq())) continue;
-
-                    WKMessageContent content = msg.getMessageModel();
-                    if (content == null) continue;
-
-                    String showUrl = "";
-                    if (content instanceof WKImageContent imgModel) {
-                        if (!TextUtils.isEmpty(imgModel.localPath) && new File(imgModel.localPath).exists()) {
-                            showUrl = imgModel.localPath;
-                        }
-                        if (TextUtils.isEmpty(showUrl)) {
-                            showUrl = WKApiConfig.getShowUrl(imgModel.url);
-                        }
-                    } else if (content instanceof WKVideoContent videoModel) {
-                        if (!TextUtils.isEmpty(videoModel.coverLocalPath) && new File(videoModel.coverLocalPath).exists()) {
-                            showUrl = videoModel.coverLocalPath;
-                        }
-                        if (TextUtils.isEmpty(showUrl) && !TextUtils.isEmpty(videoModel.cover)) {
-                            showUrl = WKApiConfig.getShowUrl(videoModel.cover);
-                        }
-                    } else {
-                        continue;
-                    }
-                    if (TextUtils.isEmpty(showUrl)) continue;
-
-                    String date = WKTimeUtils.getInstance().time2YearMonth(msg.getTimestamp() * 1000);
-                    addDateHeaderIfNeeded(merged, date);
-
-                    SearchImgEntity entity = new SearchImgEntity();
-                    entity.date = date;
-                    entity.message = msg;
-                    entity.url = showUrl;
-                    merged.add(entity);
-                }
-            }
-
-            if (merged.isEmpty()) {
-                wkVBinding.refreshLayout.finishLoadMoreWithNoMoreData();
-                if (page == 1) {
+            if (!outcome.getOk() || outcome.getData() == null) {
+                if (isReset && adapter.getData().isEmpty()) {
                     wkVBinding.refreshLayout.setEnableLoadMore(false);
                     wkVBinding.nodataTv.setVisibility(View.VISIBLE);
                 }
-            } else {
-                wkVBinding.nodataTv.setVisibility(View.GONE);
-                if (page == 1) {
-                    adapter.setList(merged);
-                } else {
-                    adapter.addData(merged);
+                return null;
+            }
+
+            List<MediaHit> hits = outcome.getData().getData();
+            List<SearchImgEntity> page = new ArrayList<>();
+            if (WKReader.isNotEmpty(hits)) {
+                for (MediaHit hit : hits) {
+                    SearchImgEntity entity = toEntity(hit);
+                    if (entity == null) continue;
+                    addDateHeaderIfNeeded(page, entity.date);
+                    page.add(entity);
                 }
+            }
+
+            hasMore = outcome.getData().getPagination().getHas_more();
+            nextCursor = hasMore ? outcome.getData().getPagination().getNext_cursor() : null;
+
+            if (isReset) {
+                if (page.isEmpty()) {
+                    wkVBinding.refreshLayout.setEnableLoadMore(false);
+                    wkVBinding.nodataTv.setVisibility(View.VISIBLE);
+                } else {
+                    wkVBinding.nodataTv.setVisibility(View.GONE);
+                    adapter.setList(page);
+                }
+            } else if (!page.isEmpty()) {
+                wkVBinding.nodataTv.setVisibility(View.GONE);
+                adapter.addData(page);
+            }
+
+            if (!hasMore) {
+                wkVBinding.refreshLayout.finishLoadMoreWithNoMoreData();
             }
             return null;
         });
     }
 
+    private SearchImgEntity toEntity(MediaHit hit) {
+        String thumb = hit.getThumb_url();
+        // 视频可能没有 server 端生成的封面（thumb_url 缺失），此时仍要保留条目：
+        // 列表里会显示 play 角标 + 灰底占位，点击跳到聊天页查看原视频，与 4-tab 媒体页对齐。
+        String showUrl = !TextUtils.isEmpty(thumb) ? WKApiConfig.getShowUrl(thumb) : "";
+
+        SearchImgEntity entity = new SearchImgEntity();
+        entity.url = showUrl;
+        entity.date = !TextUtils.isEmpty(hit.getMonth_bucket()) ? hit.getMonth_bucket() : "";
+        entity.originalContent = buildContent(hit);
+        entity.senderName = hit.getSender_name() != null ? hit.getSender_name() : "";
+
+        GlobalMessage gm = new GlobalMessage();
+        gm.setMessage_seq(hit.getMessage_seq());
+        gm.setFrom_uid(hit.getSender_id() != null ? hit.getSender_id() : "");
+        gm.setTimestamp(Rfc3339.INSTANCE.toEpochSeconds(hit.getSent_at()));
+        gm.setClient_msg_no("");
+        gm.setMessage_idstr(hit.getMessage_id() != null ? hit.getMessage_id() : "");
+        GlobalChannel gc = new GlobalChannel();
+        gc.setChannel_id(channelID);
+        gc.setChannel_type(channelType);
+        gm.setChannel(gc);
+        HashMap<String, Object> payloadMap = new HashMap<>();
+        payloadMap.put("type", hit.isVideo() ? 5 : 2);
+        gm.setPayload(payloadMap);
+        entity.message = gm;
+        return entity;
+    }
+
+    private WKMessageContent buildContent(MediaHit hit) {
+        if (hit.isVideo()) {
+            WKVideoContent video = new WKVideoContent();
+            video.cover = hit.getThumb_url();
+            video.width = hit.getWidth();
+            video.height = hit.getHeight();
+            video.second = hit.getDuration_ms() / 1000;
+            // url 字段对视频指向视频文件本身；MediaHit 仅返回封面缩略图，转发时若需要原视频
+            // 需调用方进一步通过 messageID 拉取——这里先放封面，保证基础展示不崩。
+            video.url = hit.getThumb_url();
+            return video;
+        }
+        WKImageContent img = new WKImageContent();
+        img.url = hit.getThumb_url();
+        img.width = hit.getWidth();
+        img.height = hit.getHeight();
+        return img;
+    }
+
     private void addDateHeaderIfNeeded(List<SearchImgEntity> list, String date) {
+        if (TextUtils.isEmpty(date)) return;
         String lastDate = null;
         if (WKReader.isNotEmpty(list)) {
             lastDate = list.get(list.size() - 1).date;

--- a/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchWithImgAdapter.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/search/image/SearchWithImgAdapter.java
@@ -16,6 +16,7 @@
 
 package com.chat.uikit.chat.search.image;
 
+import android.view.View;
 import android.widget.ImageView;
 
 import androidx.recyclerview.widget.RecyclerView;
@@ -27,6 +28,7 @@ import com.chat.base.glide.GlideUtils;
 import com.chat.base.utils.WKDialogUtils;
 import com.chat.base.views.pinnedsectionitemdecoration.utils.FullSpanUtil;
 import com.chat.uikit.R;
+import com.xinbida.wukongim.msgmodel.WKVideoContent;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -70,6 +72,8 @@ class SearchWithImgAdapter extends BaseMultiItemQuickAdapter<SearchImgEntity, Ba
                 imageView.getLayoutParams().width = wH;
                 imageView.getLayoutParams().height = wH;
                 GlideUtils.getInstance().showImg(getContext(), chatImgEntity.url, imageView);
+                ImageView playIv = baseViewHolder.getView(R.id.playIv);
+                playIv.setVisibility(chatImgEntity.originalContent instanceof WKVideoContent ? View.VISIBLE : View.GONE);
                 List<PopupMenuItem> list = new ArrayList<>();
                 list.add(new PopupMenuItem(getContext().getString(R.string.forward), R.mipmap.msg_forward, () -> iLick.onForward(chatImgEntity)));
                 list.add(new PopupMenuItem(getContext().getString(R.string.uikit_go_to_chat_item), R.mipmap.msg_message, () -> iLick.onClick(chatImgEntity)));

--- a/wkuikit/src/main/java/com/chat/uikit/contacts/ChooseContactsActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/contacts/ChooseContactsActivity.java
@@ -241,6 +241,11 @@ public class ChooseContactsActivity extends WKBaseActivity<ActChooseContactsLayo
                 if (addType == 1) {
                     GroupModel.getInstance().addGroupMembers(groupId, ids, names, (code, msg) -> {
                         if (code == HttpResponseCode.success) {
+                            // 增量 sync + 校验被邀请 uid 是否落盘, 缺才 v=0 全量.
+                            // 兼两个场景: (1) 服务端 bot invite 分配错误 version 导致增量拉不到;
+                            // (2) 重复邀请已在群成员时 server 静默 success 不 bump version 也不发 1002.
+                            // 正常加真人 (server bump version + 发 1002) 只多一次增量, 不触发全量.
+                            GroupModel.getInstance().groupMembersSyncAndVerify(groupId, ids);
                             setResult(RESULT_OK);
                             finish();
                         } else {
@@ -252,6 +257,8 @@ public class ChooseContactsActivity extends WKBaseActivity<ActChooseContactsLayo
                 } else {
                     GroupModel.getInstance().inviteGroupMembers(groupId, ids, (code, msg) -> {
                         if (code == HttpResponseCode.success) {
+                            // 同 addGroupMembers: 增量 + 校验, 缺才全量.
+                            GroupModel.getInstance().groupMembersSyncAndVerify(groupId, ids);
                             WKToastUtils.getInstance().showToast(getString(R.string.invitation_sent));
                             setResult(RESULT_OK);
                             finish();

--- a/wkuikit/src/main/java/com/chat/uikit/group/service/GroupModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/group/service/GroupModel.java
@@ -237,6 +237,77 @@ public class GroupModel extends WKBaseModel {
      */
     public synchronized void groupMembersSync(String groupNo, final ICommonListener iCommonListener) {
         long version = resolveSyncVersion(groupNo);
+        doMembersSyncWithVersion(groupNo, version, iCommonListener);
+    }
+
+    /**
+     * 强制以 {@code version=0} 全量拉一次群成员, 用于绕过服务端给 bot 邀请分配
+     * 错误 version (低于群内其它成员当前 max) 导致的增量 sync 拉不到 bot 的问题.
+     *
+     * <p>不建议直接调用. 推荐用 {@link #groupMembersSyncAndVerify(String, List)},
+     * 只在增量 sync 完成后校验出缺人时才走这条路径, 避免每次加人都多花一次全量流量.
+     *
+     * <p>成本: 一次群成员全量拉取 (limit=1000, 通常一个请求覆盖全部). 保存走
+     * CONFLICT_REPLACE upsert, 不会污染 DB. 成功后 recursion 走回 {@link
+     * #groupMembersSync(String, ICommonListener)}, 用 {@link #resolveSyncVersion(String)}
+     * 拿正确的 maxVersion 继续增量.
+     */
+    public void forceFullMembersSync(String groupNo) {
+        doMembersSyncWithVersion(groupNo, 0L, null);
+    }
+
+    /**
+     * 增量 sync + 校验: 增量拉完后检查 {@code expectedUids} 是否都落盘,
+     * 只要缺任何一个 (含 isDeleted=1) 就自动兜底一次 {@link #forceFullMembersSync(String)}.
+     *
+     * <p>用于两个 caller 场景, 语义完全一致:
+     * <ul>
+     *   <li>{@link com.chat.uikit.chat.manager.WKIMUtils} 收到 1002 加人消息 →
+     *       {@code expectedUids} 来自 {@code content.extra[].uid} 解析结果.
+     *       解析失败传 null, 视作"不确定谁被邀请, 保守走全量".</li>
+     *   <li>{@link com.chat.uikit.contacts.ChooseContactsActivity} 用户主动
+     *       addGroupMembers / inviteGroupMembers 成功回调 → {@code expectedUids}
+     *       就是本次操作里选中的 uid 列表. 兜底 server 对"重复邀请已在群成员"
+     *       静默 success 不发 1002 的场景.</li>
+     * </ul>
+     *
+     * <p>设计原则: 只有确实缺人才触发全量, 正常加真人 (server 正常 bump version + 发 1002)
+     * 走这里只多一次增量 sync (通常返 [] 直接结束), 不会额外触发全量.
+     *
+     * @param groupNo      群 ID
+     * @param expectedUids 期望存在的 uid 列表. {@code null} = 未知, 保守全量;
+     *                     空列表 = 无需校验, 只做增量 sync.
+     */
+    public void groupMembersSyncAndVerify(String groupNo, List<String> expectedUids) {
+        groupMembersSync(groupNo, (code, msg) -> {
+            if (code != HttpResponseCode.success) return;
+            boolean anyMissing;
+            if (expectedUids == null) {
+                anyMissing = true; // 未知邀请对象, 保守走全量
+            } else {
+                anyMissing = false;
+                for (String uid : expectedUids) {
+                    if (TextUtils.isEmpty(uid)) continue;
+                    WKChannelMember m = WKIM.getInstance().getChannelMembersManager()
+                            .getMember(groupNo, WKChannelType.GROUP, uid);
+                    if (m == null || m.isDeleted == 1) {
+                        anyMissing = true;
+                        break;
+                    }
+                }
+            }
+            if (anyMissing) {
+                forceFullMembersSync(groupNo);
+            }
+        });
+    }
+
+    /**
+     * groupMembersSync 与 forceFullMembersSync 共享的内部实现. 拆出来避免代码重复,
+     * 并让 recursion 只有一处入口 (recursion 内部走 groupMembersSync 让 resolveSyncVersion
+     * 决定后续起点).
+     */
+    private void doMembersSyncWithVersion(String groupNo, long version, final ICommonListener iCommonListener) {
         request(createService(GroupService.class).syncGroupMembers(groupNo, 1000, version), new IRequestResultListener<>() {
             @Override
             public void onSuccess(List<GroupMember> list) {
@@ -255,7 +326,6 @@ public class GroupModel extends WKBaseModel {
                 if (iCommonListener != null) iCommonListener.onResult(code, msg);
             }
         });
-
     }
 
     /**

--- a/wkuikit/src/main/java/com/chat/uikit/thread/ThreadDetailActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/thread/ThreadDetailActivity.java
@@ -32,6 +32,7 @@ import com.chat.base.utils.WKDialogUtils;
 import com.chat.base.utils.WKToastUtils;
 import com.chat.base.utils.singleclick.SingleClickUtil;
 import com.chat.uikit.R;
+import com.chat.uikit.chat.search.MessageRecordActivity;
 import com.chat.uikit.databinding.ActThreadDetailLayoutBinding;
 import com.chat.uikit.group.GroupMdActivity;
 import com.chat.base.msgitem.WKChannelMemberRole;
@@ -148,6 +149,17 @@ public class ThreadDetailActivity extends WKBaseActivity<ActThreadDetailLayoutBi
             intent.putExtra("channelId", channelId);
             intent.putExtra("channelType", WKChannelType.COMMUNITY_TOPIC);
             intent.putExtra("canEdit", isCreator || isGroupAdmin);
+            startActivity(intent);
+        });
+
+        SingleClickUtil.onSingleClick(wkVBinding.findContentLayout, v -> {
+            // 子区"查找聊天记录"入口：直接复用群聊/单聊同一个 Activity，
+            // 传入子区复合 channelId（{groupNo}____{shortId}）+ channel_type=5。
+            // 数据层 ChannelSearchModel 不需要区分 channel_type，服务端在
+            // /v1/messages/_search* 内部识别 thread。
+            Intent intent = new Intent(this, MessageRecordActivity.class);
+            intent.putExtra("channel_id", channelId);
+            intent.putExtra("channel_type", WKChannelType.COMMUNITY_TOPIC);
             startActivity(intent);
         });
 

--- a/wkuikit/src/main/res/layout/act_message_record_layout.xml
+++ b/wkuikit/src/main/res/layout/act_message_record_layout.xml
@@ -88,42 +88,30 @@
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/resultView"
+        android:id="@+id/searchResultLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="20dp"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         android:orientation="vertical"
         android:visibility="gone">
 
-        <TextView
-            android:id="@+id/noDataTv"
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/searchTabLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="30dp"
-            android:gravity="center"
-            android:visibility="gone"
-            android:text="@string/nodata" />
+            android:layout_marginTop="6dp"
+            android:background="@color/homeColor"
+            app:tabIndicatorColor="@color/popupTextColor"
+            app:tabIndicatorFullWidth="false"
+            app:tabMode="fixed"
+            app:tabSelectedTextColor="@color/popupTextColor"
+            app:tabTextColor="@color/color999" />
 
-        <com.scwang.smart.refresh.layout.SmartRefreshLayout
-            android:id="@+id/refreshLayout"
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/searchPager"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@color/transparent"
-            app:srlEnableFooterFollowWhenLoadFinished="true"
-            app:srlEnableScrollContentWhenLoaded="true">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recyclerView"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@color/transparent"
-                android:visibility="visible" />
-
-            <com.scwang.smart.refresh.footer.ClassicsFooter
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@color/homeColor"
-                app:srlTextNothing="@string/refresh_footer" />
-        </com.scwang.smart.refresh.layout.SmartRefreshLayout>
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:background="@color/homeColor" />
     </LinearLayout>
 </LinearLayout>

--- a/wkuikit/src/main/res/layout/act_thread_detail_layout.xml
+++ b/wkuikit/src/main/res/layout/act_thread_detail_layout.xml
@@ -99,6 +99,19 @@
                 <androidx.appcompat.widget.AppCompatImageView style="@style/arrow_right_iv" />
             </LinearLayout>
 
+            <LinearLayout
+                android:id="@+id/findContentLayout"
+                style="@style/layoutBg"
+                android:orientation="horizontal">
+
+                <TextView
+                    style="@style/leftTextView"
+                    android:layout_weight="1"
+                    android:text="@string/find_chat_content" />
+
+                <androidx.appcompat.widget.AppCompatImageView style="@style/arrow_right_iv" />
+            </LinearLayout>
+
             <TextView
                 android:id="@+id/archiveBtn"
                 android:layout_width="match_parent"

--- a/wkuikit/src/main/res/layout/frag_channel_search_list.xml
+++ b/wkuikit/src/main/res/layout/frag_channel_search_list.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/homeColor"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/offlineBannerTv"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="#FFFBEAA8"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingTop="8dp"
+        android:paddingEnd="16dp"
+        android:paddingBottom="8dp"
+        android:text="@string/channel_search_offline_banner"
+        android:textColor="@color/colorDark"
+        android:textSize="12sp"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/emptyTv"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="40dp"
+        android:gravity="center"
+        android:textColor="@color/color999"
+        android:textSize="13sp"
+        android:visibility="gone" />
+
+    <com.scwang.smart.refresh.layout.SmartRefreshLayout
+        android:id="@+id/refreshLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/transparent"
+        app:srlEnableFooterFollowWhenLoadFinished="true"
+        app:srlEnableRefresh="false"
+        app:srlEnableScrollContentWhenLoaded="true">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/transparent" />
+
+        <com.scwang.smart.refresh.footer.ClassicsFooter
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/homeColor"
+            app:srlTextNothing="@string/refresh_footer" />
+    </com.scwang.smart.refresh.layout.SmartRefreshLayout>
+</LinearLayout>

--- a/wkuikit/src/main/res/layout/item_channel_search_file.xml
+++ b/wkuikit/src/main/res/layout/item_channel_search_file.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/homeColor"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="16dp"
+    android:paddingTop="10dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="10dp">
+
+    <ImageView
+        android:id="@+id/fileTagIv"
+        android:layout_width="40dp"
+        android:layout_height="40dp" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/nameTv"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="middle"
+            android:maxLines="1"
+            android:textColor="@color/colorDark"
+            android:textSize="14sp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/sizeTv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/color999"
+                android:textSize="12sp" />
+
+            <TextView
+                android:id="@+id/senderTv"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_weight="1"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textColor="@color/color999"
+                android:textSize="12sp" />
+
+            <TextView
+                android:id="@+id/timeTv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:textColor="@color/color999"
+                android:textSize="12sp" />
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/wkuikit/src/main/res/layout/item_channel_search_media.xml
+++ b/wkuikit/src/main/res/layout/item_channel_search_media.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/thumbIv"
@@ -9,6 +9,14 @@
         android:layout_height="match_parent"
         android:background="@color/homeColor"
         android:scaleType="centerCrop" />
+
+    <ImageView
+        android:id="@+id/playIv"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_gravity="center"
+        android:src="@mipmap/icon_play"
+        android:visibility="gone" />
 
     <TextView
         android:id="@+id/durationTv"

--- a/wkuikit/src/main/res/layout/item_channel_search_media.xml
+++ b/wkuikit/src/main/res/layout/item_channel_search_media.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/thumbIv"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/homeColor"
+        android:scaleType="centerCrop" />
+
+    <TextView
+        android:id="@+id/durationTv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:background="#66000000"
+        android:paddingStart="6dp"
+        android:paddingTop="2dp"
+        android:paddingEnd="6dp"
+        android:paddingBottom="2dp"
+        android:textColor="@android:color/white"
+        android:textSize="10sp"
+        android:visibility="gone" />
+</FrameLayout>

--- a/wkuikit/src/main/res/layout/item_channel_search_media_header.xml
+++ b/wkuikit/src/main/res/layout/item_channel_search_media_header.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/monthHeaderTv"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/homeColor"
+    android:paddingStart="16dp"
+    android:paddingTop="12dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="8dp"
+    android:textColor="@color/color999"
+    android:textSize="13sp"
+    android:textStyle="bold" />

--- a/wkuikit/src/main/res/layout/item_search_msg_img_layout.xml
+++ b/wkuikit/src/main/res/layout/item_search_msg_img_layout.xml
@@ -5,13 +5,26 @@
     android:background="@color/homeColor"
     android:orientation="vertical">
 
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/imageView"
-        android:layout_width="100dp"
-        android:layout_height="100dp"
+    <FrameLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_marginStart="3dp"
-        android:layout_marginEnd="3dp"
-        android:scaleType="centerCrop"
         android:layout_marginTop="3dp"
-        android:src="@drawable/default_view_bg" />
+        android:layout_marginEnd="3dp">
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/imageView"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            android:scaleType="centerCrop"
+            android:src="@drawable/default_view_bg" />
+
+        <ImageView
+            android:id="@+id/playIv"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_gravity="center"
+            android:src="@mipmap/icon_play"
+            android:visibility="gone" />
+    </FrameLayout>
 </LinearLayout>

--- a/wkuikit/src/main/res/values-en/strings.xml
+++ b/wkuikit/src/main/res/values-en/strings.xml
@@ -633,5 +633,17 @@
     <string name="str_webhook_github_step1">Repo → Settings → Webhooks → Add webhook</string>
     <string name="str_webhook_github_step2">Paste the URL into Payload URL, set Content type to application/json</string>
     <string name="str_webhook_github_step3">Select events (e.g. push, pull_request) and save</string>
+    <string name="channel_search_offline_banner">Server unavailable, showing local results</string>
+    <string name="channel_search_rate_limited">Too many searches, please wait a moment</string>
+    <string name="channel_search_disabled">Search is not enabled</string>
+    <string name="channel_search_not_found">This channel is not searchable</string>
+    <string name="channel_search_generic_error">Search failed, please retry</string>
+    <string name="channel_search_tab_all">All</string>
+    <string name="channel_search_tab_message">Messages</string>
+    <string name="channel_search_tab_media">Media</string>
+    <string name="channel_search_tab_file">Files</string>
+    <string name="channel_search_empty_keyword">Enter a keyword to search</string>
+    <string name="channel_search_empty_media_browse">No images or videos in this channel</string>
+    <string name="channel_search_empty_file_browse">No files in this channel</string>
 </resources>
 

--- a/wkuikit/src/main/res/values-en/strings.xml
+++ b/wkuikit/src/main/res/values-en/strings.xml
@@ -312,6 +312,7 @@
     <string name="uikit_go_to_chat_item">Go to chat</string>
     <string name="uikit_search_for_image">Photos &amp; Videos</string>
     <string name="uikit_search_for_file">File</string>
+    <string name="uikit_video_forward_unavailable">Open the video in chat before forwarding</string>
     <string name="contacts_section_group_chat">Groups</string>
     <string name="contacts_section_added_ai">Added AI</string>
     <string name="contacts_all">All</string>

--- a/wkuikit/src/main/res/values/strings.xml
+++ b/wkuikit/src/main/res/values/strings.xml
@@ -315,6 +315,7 @@
     <string name="uikit_go_to_chat_item">定位到聊天</string>
     <string name="uikit_search_for_image">图片与视频</string>
     <string name="uikit_search_for_file">文件</string>
+    <string name="uikit_video_forward_unavailable">请到聊天页打开视频后再转发</string>
 
     <string name="space_title">Space</string>
     <string name="space_create">创建 Space</string>

--- a/wkuikit/src/main/res/values/strings.xml
+++ b/wkuikit/src/main/res/values/strings.xml
@@ -631,5 +631,17 @@
     <string name="str_webhook_github_step1">仓库 → Settings → Webhooks → Add webhook</string>
     <string name="str_webhook_github_step2">Payload URL 粘贴上面地址，Content type 选 application/json</string>
     <string name="str_webhook_github_step3">勾选需要接收的事件（如 push、pull_request），保存</string>
+    <string name="channel_search_offline_banner">服务端暂不可用，显示本地结果</string>
+    <string name="channel_search_rate_limited">搜索过于频繁，请稍后重试</string>
+    <string name="channel_search_disabled">搜索功能未开启</string>
+    <string name="channel_search_not_found">该频道无法搜索</string>
+    <string name="channel_search_generic_error">搜索失败，请重试</string>
+    <string name="channel_search_tab_all">全部</string>
+    <string name="channel_search_tab_message">消息</string>
+    <string name="channel_search_tab_media">媒体</string>
+    <string name="channel_search_tab_file">文件</string>
+    <string name="channel_search_empty_keyword">输入关键词搜索</string>
+    <string name="channel_search_empty_media_browse">该频道暂无图片或视频</string>
+    <string name="channel_search_empty_file_browse">该频道暂无文件</string>
 </resources>
 

--- a/wkuikit/src/test/java/com/chat/uikit/chat/search/channel/adapter/ChannelMediaHitAdapterTest.kt
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/search/channel/adapter/ChannelMediaHitAdapterTest.kt
@@ -61,4 +61,45 @@ class ChannelMediaHitAdapterTest {
         assertEquals(1, entries.count { it is ChannelMediaHitAdapter.Entry.Header })
         assertEquals(3, entries.count { it is ChannelMediaHitAdapter.Entry.Item })
     }
+
+    @Test
+    fun toEntries_with_previous_bucket_skips_duplicate_header_when_same_month() {
+        // 上一页最后一个是 2026-06，本页首个也是 2026-06 → 不应插重复 header。
+        val hits = listOf(hit("2026-06", 4), hit("2026-06", 5))
+        val entries = ChannelMediaHitAdapter.toEntries(hits, previousBucket = "2026-06")
+        assertEquals(2, entries.size)
+        assertTrue(entries.all { it is ChannelMediaHitAdapter.Entry.Item })
+    }
+
+    @Test
+    fun toEntries_with_previous_bucket_inserts_header_when_month_changes() {
+        // 上一页停在 2026-06，本页跨到 2026-05 → 应插一个 05 header。
+        val hits = listOf(hit("2026-05", 6), hit("2026-05", 7))
+        val entries = ChannelMediaHitAdapter.toEntries(hits, previousBucket = "2026-06")
+        assertEquals(3, entries.size)
+        assertTrue(entries[0] is ChannelMediaHitAdapter.Entry.Header)
+        assertEquals("2026-05", (entries[0] as ChannelMediaHitAdapter.Entry.Header).monthBucket)
+    }
+
+    @Test
+    fun toEntries_with_previous_bucket_and_mixed_page_boundary() {
+        // 上一页停在 2026-06；本页前 2 条仍是 06（不插 header），第 3 条切到 05（插一个 header）。
+        val hits = listOf(hit("2026-06", 8), hit("2026-06", 9), hit("2026-05", 10))
+        val entries = ChannelMediaHitAdapter.toEntries(hits, previousBucket = "2026-06")
+        assertEquals(4, entries.size)
+        assertTrue(entries[0] is ChannelMediaHitAdapter.Entry.Item)
+        assertTrue(entries[1] is ChannelMediaHitAdapter.Entry.Item)
+        assertTrue(entries[2] is ChannelMediaHitAdapter.Entry.Header)
+        assertEquals("2026-05", (entries[2] as ChannelMediaHitAdapter.Entry.Header).monthBucket)
+        assertTrue(entries[3] is ChannelMediaHitAdapter.Entry.Item)
+    }
+
+    @Test
+    fun toEntries_null_previous_bucket_matches_legacy_behavior() {
+        // 默认参数 previousBucket=null 与旧签名等价：首个 hit 一定插 header。
+        val hits = listOf(hit("2026-06", 11))
+        val entries = ChannelMediaHitAdapter.toEntries(hits)
+        assertEquals(2, entries.size)
+        assertTrue(entries[0] is ChannelMediaHitAdapter.Entry.Header)
+    }
 }

--- a/wkuikit/src/test/java/com/chat/uikit/chat/search/channel/adapter/ChannelMediaHitAdapterTest.kt
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/search/channel/adapter/ChannelMediaHitAdapterTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.search.channel.adapter
+
+import com.chat.base.search.channel.dto.MediaHit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChannelMediaHitAdapterTest {
+
+    private fun hit(monthBucket: String, idx: Int = 0): MediaHit = MediaHit().apply {
+        message_id = "m$idx"
+        message_seq = idx.toLong()
+        media_kind = "image"
+        thumb_url = "https://example.com/$idx.jpg"
+        sender_id = "u$idx"
+        sent_at = "2026-${monthBucket.takeLast(2)}-15T10:00:00Z"
+        month_bucket = monthBucket
+    }
+
+    @Test
+    fun toEntries_returns_empty_for_empty_input() {
+        assertTrue(ChannelMediaHitAdapter.toEntries(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun toEntries_inserts_header_before_each_distinct_month() {
+        val hits = listOf(hit("2026-06", 1), hit("2026-06", 2), hit("2026-05", 3))
+        val entries = ChannelMediaHitAdapter.toEntries(hits)
+        // 4 项：[Header 06, Item, Item, Header 05, Item]
+        assertEquals(5, entries.size)
+        assertTrue(entries[0] is ChannelMediaHitAdapter.Entry.Header)
+        assertEquals("2026-06", (entries[0] as ChannelMediaHitAdapter.Entry.Header).monthBucket)
+        assertTrue(entries[1] is ChannelMediaHitAdapter.Entry.Item)
+        assertTrue(entries[2] is ChannelMediaHitAdapter.Entry.Item)
+        assertTrue(entries[3] is ChannelMediaHitAdapter.Entry.Header)
+        assertEquals("2026-05", (entries[3] as ChannelMediaHitAdapter.Entry.Header).monthBucket)
+        assertTrue(entries[4] is ChannelMediaHitAdapter.Entry.Item)
+    }
+
+    @Test
+    fun toEntries_single_month_emits_one_header() {
+        val hits = (1..3).map { hit("2026-06", it) }
+        val entries = ChannelMediaHitAdapter.toEntries(hits)
+        assertEquals(4, entries.size)
+        assertEquals(1, entries.count { it is ChannelMediaHitAdapter.Entry.Header })
+        assertEquals(3, entries.count { it is ChannelMediaHitAdapter.Entry.Item })
+    }
+}


### PR DESCRIPTION
Closes #84

## Summary

- **feat(channel-search)**: 新增 OpenSearch 驱动的频道内搜索数据层 + 4-Tab 搜索结果 UI（全部 / 消息 / 媒体 / 文件），支持关键词输入实时驱动
- **feat(thread)**: 子区详情页新增"查找聊天记录"入口
- **refactor(image-search)**: 老入口切换至 `_search_media` 接口，媒体格子尺寸与视频 play 角标 UI 优化
- **fix(channel-search)**: 搜索结果头像改为发送人；清空关键词时清空浏览
- **fix(group-members)**: bot invite 后 UI 无变化，走 C+ 兜底
- **chore(release)**: 版本号升至 `1.3.5` (versionCode 36)

## 主要改动范围

- 新增 `wkbase/src/main/java/com/chat/base/search/channel/` — OpenSearch DTO / Body Builder / Service / Error Parser / Outcome / RFC3339 工具，含单测
- 新增 `wkuikit/.../chat/search/channel/` — 4 个 Fragment（All / Message / Media / File）+ ViewModel + Adapter
- 改造 `MessageRecordActivity` / `SearchWithImgActivity` 走新接口
- `ThreadDetailActivity` 增加查找聊天记录入口
- 群成员 `GroupModel` bot invite 兜底逻辑

## Test plan

- [ ] 打开会话 → 长按/入口进入查找聊天记录 → 输入关键词，4 个 Tab 结果正确加载 & 分页
- [ ] 媒体 Tab：图片/视频格子尺寸正确，视频有 play 角标
- [ ] 文件 Tab：文件项展示正常，点击可跳转
- [ ] 消息 Tab：命中消息头像为发送人头像，点击定位到原消息
- [ ] 清空关键词输入 → 结果列表清空
- [ ] 子区详情页 → "查找聊天记录" 入口可用，进入后走新搜索流程
- [ ] 群设置邀请 bot → 成员列表立即更新（无需刷新）
- [ ] 单测：ChannelSearchBodyBuilderTest / ChannelSearchErrorParserTest / ChannelSearchOutcomeTest / Rfc3339Test / ChannelMediaHitAdapterTest 全部通过
- [ ] 打 release 包，版本号显示 1.3.5 (36)