### PR TITLE
feat(conversation): 1v1 未读消息显示与群聊@我同等的高优先级深红提示

### DIFF
--- a/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
@@ -1210,6 +1210,11 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
                 }
             }
         }
+        // 一对一未读消息本地判定为高优先级：与群聊“有人@我”走同一深红提示
+        WKUIConversationMsg uiMsg = conversationMsg.uiConversationMsg;
+        if (!hasMention && uiMsg != null && uiMsg.channelType == WKChannelType.PERSONAL && uiMsg.unreadCount > 0) {
+            hasMention = true;
+        }
         if (!hasMention) {
             contentTv.setTextColor(ContextCompat.getColor(getContext(), R.color.color999));
             contentTv.setTypeface(null, Typeface.NORMAL);
@@ -1275,6 +1280,12 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
         }
         if (item.uiConversationMsg.getRemoteMsgExtra() != null) {
             draft = item.uiConversationMsg.getRemoteMsgExtra().draft;
+        }
+        // 一对一未读消息本地判定为高优先级：与群聊“有人@我”走同一深红提示
+        if (!mention && item.uiConversationMsg != null
+                && item.uiConversationMsg.channelType == WKChannelType.PERSONAL
+                && item.uiConversationMsg.unreadCount > 0) {
+            mention = true;
         }
         boolean isSetChatPwd = isSetChatPwd(item.uiConversationMsg.getWkChannel());
         if (isSetChatPwd) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
@@ -735,6 +735,9 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
         if (chatConversationMsg.isRefreshChannelInfo) {
             showChannel(baseViewHolder, item);
             showThreadPreviews(baseViewHolder, item);
+            // 频道信息（包括 mute）变化会影响 1v1 高优先级提示的判定（!isMuted1v1），
+            // 故同步重跑 showReminders，避免 mute/取消 mute 后深红 [未读] 标签残留/滞后。
+            showReminders(baseViewHolder, chatConversationMsg);
             chatConversationMsg.isRefreshChannelInfo = false;
         }
         if (chatConversationMsg.isRefreshStatus) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
@@ -1210,11 +1210,6 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
                 }
             }
         }
-        // 一对一未读消息本地判定为高优先级：与群聊“有人@我”走同一深红提示
-        WKUIConversationMsg uiMsg = conversationMsg.uiConversationMsg;
-        if (!hasMention && uiMsg != null && uiMsg.channelType == WKChannelType.PERSONAL && uiMsg.unreadCount > 0) {
-            hasMention = true;
-        }
         if (!hasMention) {
             contentTv.setTextColor(ContextCompat.getColor(getContext(), R.color.color999));
             contentTv.setTypeface(null, Typeface.NORMAL);
@@ -1281,11 +1276,21 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
         if (item.uiConversationMsg.getRemoteMsgExtra() != null) {
             draft = item.uiConversationMsg.getRemoteMsgExtra().draft;
         }
-        // 一对一未读消息本地判定为高优先级：与群聊“有人@我”走同一深红提示
+        // 一对一未读消息本地判定为高优先级：与群聊“有人@我”走同一深红提示。
+        // 三个前提：
+        //  1）走 getRenderUnreadCount 过滤路径，避免跨 Space 污染的未读（badge 已归零、预览已 null）又点亮深红；
+        //  2）排除系统账号（系统团队/文件助手），它们不是“有人在等回复”；
+        //  3）排除免打扰的 1v1。
+        boolean isMuted1v1 = item.uiConversationMsg.getWkChannel() != null
+                && item.uiConversationMsg.getWkChannel().mute == 1;
+        boolean is1v1Priority = false;
         if (!mention && item.uiConversationMsg != null
                 && item.uiConversationMsg.channelType == WKChannelType.PERSONAL
-                && item.uiConversationMsg.unreadCount > 0) {
+                && !WKSystemAccount.isSystemAccount(item.uiConversationMsg.channelID)
+                && !isMuted1v1
+                && getRenderUnreadCount(item) > 0) {
             mention = true;
+            is1v1Priority = true;
         }
         boolean isSetChatPwd = isSetChatPwd(item.uiConversationMsg.getWkChannel());
         if (isSetChatPwd) {
@@ -1299,7 +1304,7 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
         TextView approveTv = helper.getView(R.id.approveTv);
 
         if (mention) {
-            mentionTv.setText(R.string.last_msg_remind);
+            mentionTv.setText(is1v1Priority ? R.string.last_msg_unread_priority : R.string.last_msg_remind);
             mentionTv.setVisibility(View.VISIBLE);
         } else {
             mentionTv.setVisibility(View.GONE);

--- a/wkuikit/src/main/res/values-en/strings.xml
+++ b/wkuikit/src/main/res/values-en/strings.xml
@@ -176,6 +176,7 @@
     <string name="group_members">Group Members(%s)</string>
     <string name="last_msg_draft">[Draft]</string>
     <string name="last_msg_remind">[@me]</string>
+    <string name="last_msg_unread_priority">[unread]</string>
     <string name="last_msg_card">[business card]</string>
     <string name="nickname">Nickname：</string>
     <string name="other_is_typing">typing</string>

--- a/wkuikit/src/main/res/values/strings.xml
+++ b/wkuikit/src/main/res/values/strings.xml
@@ -178,6 +178,7 @@
     <string name="group_members">群成员(%s)</string>
     <string name="last_msg_draft">[草稿]</string>
     <string name="last_msg_remind">[有人@我]</string>
+    <string name="last_msg_unread_priority">[未读]</string>
     <string name="last_msg_card">[名片]</string>
     <string name="nickname">昵称：</string>
     <string name="other_is_typing">对方正在输入</string>


### PR DESCRIPTION
## 需求

会话列表里，群聊中「有人@我」会显示醒目的深红色高优先级提示（`reminderColor #FF5353` + `[有人@我]` 文案）。但**一对一（1v1）聊天的未读消息没有这个提示**——而 1v1 中对方发来的每条消息，本质上都等价于「@我」（点对点直达）。

产品口径（方案 A）：只要是 1v1 未读（unread>0），即视同高优先级。

Closes #86

## 设计原则

深红提示不是群聊专属样式，它是一个**注意力分级信号**——「有人在等我响应」。在人机协同场景里，核心是帮人从消息洪流里识别出真正需要关注的信息。1v1 里"对方发消息"即等价 mention，因此**复用同一视觉信号（深红色）**，触发条件在 1v1 退化为 `unread>0`。

但语义上 1v1 未读 ≠ 群聊被 @，所以文案用独立的 `[未读]/[unread]`，不复用 `[有人@我]/[@me]`。

## 改动

**纯前端本地判定，不改后端、不改 schema。**

`wkuikit/.../chat/adapter/ChatConversationAdapter.java`，仅 `showReminders()`（`TYPE_NORMAL` 路径，1v1 行实际渲染处）：

高优先级判定从"仅命中群聊 mention reminder"扩展为"命中 mention reminder **或** 满足全部下列条件的 1v1"：

```java
channelType == PERSONAL
    && !WKSystemAccount.isSystemAccount(channelID)   // 排除系统团队/文件助手
    && !isMuted1v1                                    // 排除免打扰 1v1
    && getRenderUnreadCount(item) > 0                 // 走 Space 过滤路径，不用 raw unreadCount
```

三个关键修正（对齐 review）：
1. **走 `getRenderUnreadCount()` 而非 raw `unreadCount`**：适配器既有契约用 `getRenderUnreadCount()` 把跨 Space 污染的未读清零、`getSpaceFilteredWkMsg()` 隐藏跨 Space 预览。若读 raw 字段，一个 badge 已归零、预览已 null 的跨 Space 私聊仍会点亮深红，夸大紧急度。改后与 `setUnreadCount` 的路由一致。
2. **删除 `showCompactReminders()` 里的 PERSONAL 分支（死代码）**：`getDefItemViewType` 只把 `channelType == GROUP` 路由到 `TYPE_COMPACT`，PERSONAL 一律走 `TYPE_NORMAL` → `showReminders`，所以 compact 里的 PERSONAL 判断永远进不去。
3. **独立文案 + 排除系统账号/免打扰**：见上。

## 验证状态

- ✅ 人工核对：`getRenderUnreadCount` / `WKSystemAccount.isSystemAccount` / `channelID` / `getWkChannel().mute` 均为本文件已引用的现成字段与方法，深红渲染闭环 `mention=true → mentionTv` 正确。
- ⚠️ **未能本地编译验证**：当前开发环境无 Java 运行时 / Android SDK，`./gradlew` 无法执行。改动无新增依赖，依赖 CI 的 `:wkuikit` 编译确认。

## 一致性铁律（提醒 iOS/Web 端对齐）

三端须共用同一深红色值（`#FF5353`）与同一判定语义 `(群聊 && 有@我reminder) || (1v1 && 非系统 && 非免打扰 && 过滤后未读>0)`，且都要走各自的 Space 过滤后未读，而非 raw 未读。iOS（octo-ios）、Web（octo-web）需在各自会话列表渲染处做等价改动。

