### PR TITLE
feat(chat): 批量改进 — 贴纸/预览/名称长度/撤回/release 修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,16 @@ google-services.json
 
 # Internal scripts (not part of open source)
 scripts/
+
+# Local dev / agent tooling workspace files (personal, not project-wide)
+/AGENTS.md
+/HEARTBEAT.md
+/IDENTITY.md
+/SOUL.md
+/TOOLS.md
+/USER.md
+/openclaw-workspace-state.json
+/.claude/
+/.kotlin/
+/.octospec/
+/app/prod/

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -160,6 +160,9 @@
 -keep class com.chat.base.net.entity.** { *; }
 -keep class com.chat.base.msg.model.** { *; }
 -keep class com.chat.base.msgcontent.** { *; }
+# 频道内搜索 DTO：CursorList/FileHit/MediaHit/MessageHit/CombinedHit/AroundResult/Pagination
+# 走 FastJson 反射按字段名映射 JSON，不 keep 会被 R8 重命名字段导致反序列化产物类型错乱 → checkcast CCE
+-keep class com.chat.base.search.channel.dto.** { *; }
 #----------登录模块---------------
 -keep class com.chat.login.entity.** { *; }
 #----------uikit模块--------------

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -199,6 +199,11 @@
 -keep class com.chat.label.entity.** { *; }
 #----------表情模块------------------
 -keep class com.chat.sticker.entity.** { *; }
+# 自定义贴纸 (uikit) DTO：WKSticker / ListStickerResp / StickerService
+# 走 FastJson 反射按字段名映射 JSON ({"list":[...]})，不 keep 会被 R8 重命名字段
+# 导致 collect / list 反序列化失败 → release 包"添加到我的表情"回调走 onFail
+-keep class com.chat.uikit.chat.sticker.** { *; }
+-keep interface com.chat.uikit.chat.sticker.StickerService { *; }
 #----------客服------------------
 -keep class com.chat.customerservice.entity.** { *; }
 #----------隐私安全------------------

--- a/wkbase/src/main/java/com/chat/base/msg/model/WKEmojiStickerContent.java
+++ b/wkbase/src/main/java/com/chat/base/msg/model/WKEmojiStickerContent.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.base.msg.model;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import com.xinbida.wukongim.message.type.WKMsgContentType;
+
+/**
+ * Emoji 贴图 (contentType=13)。
+ *
+ * 结构与 WKVectorStickerContent 完全一致，服务端也统一按贴图路径管理；
+ * 只是发送侧用来区分"贴图 tab 里的 emoji 贴纸"vs"lottie 贴纸"。
+ * 对齐 iOS `WKEmojiStickerContent : WKLottieStickerContent`。
+ */
+public class WKEmojiStickerContent extends WKVectorStickerContent {
+
+    public WKEmojiStickerContent() {
+        this.type = WKMsgContentType.WK_EMOJI_STICKER;
+    }
+
+    protected WKEmojiStickerContent(Parcel in) {
+        super(in);
+    }
+
+    public static final Parcelable.Creator<WKEmojiStickerContent> CREATOR = new Parcelable.Creator<WKEmojiStickerContent>() {
+        @Override
+        public WKEmojiStickerContent createFromParcel(Parcel in) {
+            return new WKEmojiStickerContent(in);
+        }
+
+        @Override
+        public WKEmojiStickerContent[] newArray(int size) {
+            return new WKEmojiStickerContent[size];
+        }
+    };
+
+    @Override
+    public String getDisplayContent() {
+        return "[emoji表情]";
+    }
+
+    @Override
+    public String getSearchableWord() {
+        return "[emoji表情]";
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/msg/model/WKVectorStickerContent.java
+++ b/wkbase/src/main/java/com/chat/base/msg/model/WKVectorStickerContent.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.base.msg.model;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import com.xinbida.wukongim.message.type.WKMsgContentType;
+import com.xinbida.wukongim.msgmodel.WKMediaMessageContent;
+import com.xinbida.wukongim.msgmodel.WKMessageContent;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * 矢量贴图 / Lottie 贴图 (contentType=12)。
+ *
+ * wire 字段对齐服务端 stickerResp / iOS WKLottieStickerContent：
+ *   url / width / height / category / placeholder / format
+ *
+ * Android 不引入 Lottie SDK：`.png/.jpg/.webp/.gif` 后缀由 Glide 直接显示，
+ * `.lim/.json`（Lottie JSON）走占位图降级。渲染逻辑集中在
+ * WKVectorStickerProvider + StickerUrlUtils，见其说明。
+ */
+public class WKVectorStickerContent extends WKMediaMessageContent implements Parcelable {
+    public int width;
+    public int height;
+    public String category;
+    public String placeholder;
+    public String format;
+
+    public WKVectorStickerContent() {
+        this.type = WKMsgContentType.WK_VECTOR_STICKER;
+    }
+
+    @Override
+    public JSONObject encodeMsg() {
+        JSONObject jsonObject = new JSONObject();
+        try {
+            jsonObject.put("url", url == null ? "" : url);
+            jsonObject.put("width", width);
+            jsonObject.put("height", height);
+            jsonObject.put("category", category == null ? "" : category);
+            jsonObject.put("placeholder", placeholder == null ? "" : placeholder);
+            jsonObject.put("format", format == null ? "lim" : format);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        return jsonObject;
+    }
+
+    @Override
+    public WKMessageContent decodeMsg(JSONObject jsonObject) {
+        this.url = jsonObject.optString("url");
+        this.width = jsonObject.optInt("width");
+        this.height = jsonObject.optInt("height");
+        this.category = jsonObject.optString("category");
+        this.placeholder = jsonObject.optString("placeholder");
+        this.format = jsonObject.has("format") ? jsonObject.optString("format") : "lim";
+        return this;
+    }
+
+    protected WKVectorStickerContent(Parcel in) {
+        super(in);
+        url = in.readString();
+        localPath = in.readString();
+        width = in.readInt();
+        height = in.readInt();
+        category = in.readString();
+        placeholder = in.readString();
+        format = in.readString();
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeString(url);
+        dest.writeString(localPath);
+        dest.writeInt(width);
+        dest.writeInt(height);
+        dest.writeString(category);
+        dest.writeString(placeholder);
+        dest.writeString(format);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<WKVectorStickerContent> CREATOR = new Creator<WKVectorStickerContent>() {
+        @Override
+        public WKVectorStickerContent createFromParcel(Parcel in) {
+            return new WKVectorStickerContent(in);
+        }
+
+        @Override
+        public WKVectorStickerContent[] newArray(int size) {
+            return new WKVectorStickerContent[size];
+        }
+    };
+
+    @Override
+    public String getDisplayContent() {
+        return "[贴图]";
+    }
+
+    @Override
+    public String getSearchableWord() {
+        return "[贴图]";
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/msgitem/WKChatBaseProvider.kt
+++ b/wkbase/src/main/java/com/chat/base/msgitem/WKChatBaseProvider.kt
@@ -1284,23 +1284,28 @@ abstract class WKChatBaseProvider : BaseItemProvider<WKUIChatMsgItemEntity>() {
                 PopupMenuItem(context.getString(R.string.base_withdraw), R.mipmap.msg_withdraw,
                     object : PopupMenuItem.IClick {
                         override fun onClick() {
-                            var msgId = mMsg.messageID
-                            if (TextUtils.isEmpty(msgId) || msgId == "0") {
-                                msgId = mMsg.clientMsgNO
-                            }
-                            //撤回消息
-                            if (!TextUtils.isEmpty(msgId)) {
+                            // 撤回消息：以 clientMsgNO 为准（服务端 message/revoke 强制要求）。
+                            // messageID 空或 "0"（刚发送尚未 IM ack 回填）时传空字符串——
+                            // 老代码把 clientMsgNO 塞给 message_id 会触发服务端 TOCTOU
+                            // 校验 verifyRevokeMessageID：strconv.ParseInt(clientMsgNo=UUID) 必失败
+                            // → ErrMessageIDSeqMismatch → 用户端表现"刚发的贴图/消息撤回无反应"
+                            // 或"要撤好几次才成功"（等 messageID 回填后才能过校验）。
+                            // 空 message_id 服务端会跳过校验并用 client_msg_no 自行反查。
+                            val realMsgId = mMsg.messageID
+                            val safeMsgId =
+                                if (TextUtils.isEmpty(realMsgId) || realMsgId == "0") ""
+                                else realMsgId
+                            if (!TextUtils.isEmpty(mMsg.clientMsgNO)) {
                                 EndpointManager.getInstance().invoke(
                                     "chat_withdraw_msg",
                                     WithdrawMsgMenu(
-                                        msgId,
+                                        safeMsgId,
                                         mMsg.channelID,
                                         mMsg.clientMsgNO,
                                         mMsg.channelType
                                     )
                                 )
                             }
-
                         }
                     })
             )

--- a/wkbase/src/main/java/com/chat/base/utils/StringUtils.java
+++ b/wkbase/src/main/java/com/chat/base/utils/StringUtils.java
@@ -529,13 +529,31 @@ public class StringUtils {
     }
 
     public static InputFilter getInputFilter(int mMax) {
+        return getInputFilter(mMax, null);
+    }
+
+    /**
+     * Attach a length limit to {@code editText} that also surfaces a throttled toast when the
+     * user tries to type past {@code maxLength}. Replaces any existing filters on the field.
+     */
+    public static void attachLengthLimit(EditText editText, int maxLength) {
+        Runnable toast = new ThrottledRunnable(2000L, () ->
+                WKToastUtils.getInstance().showToastNormal(
+                        editText.getContext().getString(R.string.str_input_length_limit, maxLength)));
+        editText.setFilters(new InputFilter[]{getInputFilter(maxLength, toast)});
+    }
+
+    /**
+     * Length-limiting {@link InputFilter} that additionally invokes {@code onTruncate} whenever
+     * the incoming edit had to be shortened or fully rejected to fit within {@code mMax}. Wrap
+     * the callback in {@link ThrottledRunnable} to avoid firing on every keystroke of a
+     * long-press or paste that overflows.
+     */
+    public static InputFilter getInputFilter(int mMax, Runnable onTruncate) {
         return (source, start, end, dest, dstart, dend) -> {
             int keep = mMax - (dest.length() - (dend - dstart));
             if (keep <= 0) {
-                //这里，用来给用户提示,当然可以替换成 更加优雅的形式
-//                    if (null != lengthListener) {
-//                        lengthListener.pass();
-//                    }
+                if (end > start && onTruncate != null) onTruncate.run();
                 return "";
             } else if (keep >= end - start) {
                 return null;
@@ -544,9 +562,11 @@ public class StringUtils {
                 if (Character.isHighSurrogate(source.charAt(keep - 1))) {
                     --keep;
                     if (keep == start) {
+                        if (onTruncate != null) onTruncate.run();
                         return "";
                     }
                 }
+                if (onTruncate != null) onTruncate.run();
                 return source.subSequence(start, keep);
             }
         };

--- a/wkbase/src/main/java/com/chat/base/utils/ThrottledRunnable.java
+++ b/wkbase/src/main/java/com/chat/base/utils/ThrottledRunnable.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.utils;
+
+import android.os.SystemClock;
+
+/**
+ * Fires {@code target} at most once per {@code intervalMs}. Extra invocations inside the
+ * window are dropped (not queued). Use for feedback that should not spam — e.g. length-limit
+ * toasts triggered on every keystroke.
+ */
+public final class ThrottledRunnable implements Runnable {
+    private final long intervalMs;
+    private final Runnable target;
+    private long lastFiredMs = 0L;
+
+    public ThrottledRunnable(long intervalMs, Runnable target) {
+        this.intervalMs = intervalMs;
+        this.target = target;
+    }
+
+    @Override
+    public void run() {
+        long now = SystemClock.uptimeMillis();
+        if (now - lastFiredMs < intervalMs) return;
+        lastFiredMs = now;
+        target.run();
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/utils/WKDialogUtils.java
+++ b/wkbase/src/main/java/com/chat/base/utils/WKDialogUtils.java
@@ -26,7 +26,6 @@ import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
-import android.text.InputFilter;
 import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.GestureDetector;
@@ -374,7 +373,7 @@ public class WKDialogUtils {
             editText.setText(oldStr);
             editText.setSelection(oldStr.length());
         }
-        editText.setFilters(new InputFilter[]{StringUtils.getInputFilter(maxLength)});
+        StringUtils.attachLengthLimit(editText, maxLength);
         SoftKeyboardUtils.getInstance().showSoftKeyBoard(context, editText);
         linearLayout.addView(editText, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, Gravity.START, 24, 0, 24, 0));
         builder.setView(linearLayout);

--- a/wkbase/src/main/res/values-en/strings.xml
+++ b/wkbase/src/main/res/values-en/strings.xml
@@ -127,6 +127,7 @@
     <string name="str_file">File</string>
     <string name="str_file_download">Download</string>
     <string name="str_file_open">Open</string>
+    <string name="str_file_preview">Preview</string>
     <string name="str_file_download_fail">File download failed</string>
     <string name="str_file_not_exist">File does not exist</string>
     <string name="str_file_too_large">File exceeds 100MB size limit</string>

--- a/wkbase/src/main/res/values-en/strings.xml
+++ b/wkbase/src/main/res/values-en/strings.xml
@@ -239,4 +239,7 @@
     <string name="richtext_image_limit">You can select up to %d images</string>
     <string name="richtext_caption_title">Add Caption</string>
     <string name="richtext_caption_hint">Say something…</string>
+
+    <!-- i18n: length-limit hint for EditText (throttled toast) -->
+    <string name="str_input_length_limit">Up to %1$d characters</string>
 </resources>

--- a/wkbase/src/main/res/values-en/strings.xml
+++ b/wkbase/src/main/res/values-en/strings.xml
@@ -245,9 +245,20 @@
     <string name="str_add_to_my_stickers">Add to My Stickers</string>
     <string name="str_sticker_add_success">Added to My Stickers</string>
     <string name="str_sticker_add_failed">Failed to add, please try again</string>
-    <string name="str_no_collect_stickers">No collected stickers. Long-press a sticker in chat to add.</string>
+    <string name="str_no_collect_stickers">No stickers yet. Tap + to add.</string>
     <string name="str_my_stickers_tab">Custom Stickers</string>
     <string name="str_emoji_tab">Emoji</string>
+    <string name="str_sticker_delete_confirm">Delete this sticker?</string>
+    <string name="str_sticker_delete_success">Deleted</string>
+    <string name="str_sticker_delete_failed">Failed to delete</string>
+    <string name="str_sticker_upload_success">Added to My Stickers</string>
+    <string name="str_sticker_upload_failed">Upload failed</string>
+    <string name="str_sticker_quota_exceeded">Sticker limit reached</string>
+    <string name="str_sticker_format_unsupported">Only gif/png/jpg/webp supported</string>
+    <string name="str_sticker_too_large">Image must be under 1MB</string>
+    <string name="str_sticker_dim_too_large">Image cannot exceed 512×512</string>
+    <string name="str_sticker_send">Send</string>
+    <string name="str_sticker_add_button">Add</string>
 
     <!-- i18n: length-limit hint for EditText (throttled toast) -->
     <string name="str_input_length_limit">Up to %1$d characters</string>

--- a/wkbase/src/main/res/values-en/strings.xml
+++ b/wkbase/src/main/res/values-en/strings.xml
@@ -240,6 +240,14 @@
     <string name="richtext_caption_title">Add Caption</string>
     <string name="richtext_caption_hint">Say something…</string>
 
+    <!-- i18n: Sticker collect -->
+    <string name="str_add_to_my_stickers">Add to My Stickers</string>
+    <string name="str_sticker_add_success">Added to My Stickers</string>
+    <string name="str_sticker_add_failed">Failed to add, please try again</string>
+    <string name="str_no_collect_stickers">No collected stickers. Long-press a sticker in chat to add.</string>
+    <string name="str_my_stickers_tab">Custom Stickers</string>
+    <string name="str_emoji_tab">Emoji</string>
+
     <!-- i18n: length-limit hint for EditText (throttled toast) -->
     <string name="str_input_length_limit">Up to %1$d characters</string>
 </resources>

--- a/wkbase/src/main/res/values/strings.xml
+++ b/wkbase/src/main/res/values/strings.xml
@@ -235,4 +235,7 @@
     <string name="richtext_image_limit">最多只能选择 %d 张图片</string>
     <string name="richtext_caption_title">添加描述</string>
     <string name="richtext_caption_hint">说点什么…</string>
+
+    <!-- i18n: 输入长度上限提示（EditText 超长时节流 toast） -->
+    <string name="str_input_length_limit">最多 %1$d 个字符</string>
 </resources>

--- a/wkbase/src/main/res/values/strings.xml
+++ b/wkbase/src/main/res/values/strings.xml
@@ -129,6 +129,7 @@
     <string name="str_file">文件</string>
     <string name="str_file_download">下载</string>
     <string name="str_file_open">打开</string>
+    <string name="str_file_preview">预览</string>
     <string name="str_file_download_fail">文件下载失败</string>
     <string name="str_file_not_exist">文件不存在</string>
     <string name="str_file_too_large">文件大小超过100MB，无法发送</string>

--- a/wkbase/src/main/res/values/strings.xml
+++ b/wkbase/src/main/res/values/strings.xml
@@ -236,6 +236,14 @@
     <string name="richtext_caption_title">添加描述</string>
     <string name="richtext_caption_hint">说点什么…</string>
 
+    <!-- i18n: Sticker collect -->
+    <string name="str_add_to_my_stickers">添加到我的表情</string>
+    <string name="str_sticker_add_success">已添加到我的表情</string>
+    <string name="str_sticker_add_failed">添加失败，请稍后重试</string>
+    <string name="str_no_collect_stickers">暂无收藏表情，长按聊天中的贴图可添加</string>
+    <string name="str_my_stickers_tab">自定义表情</string>
+    <string name="str_emoji_tab">表情</string>
+
     <!-- i18n: 输入长度上限提示（EditText 超长时节流 toast） -->
     <string name="str_input_length_limit">最多 %1$d 个字符</string>
 </resources>

--- a/wkbase/src/main/res/values/strings.xml
+++ b/wkbase/src/main/res/values/strings.xml
@@ -241,9 +241,20 @@
     <string name="str_add_to_my_stickers">添加到我的表情</string>
     <string name="str_sticker_add_success">已添加到我的表情</string>
     <string name="str_sticker_add_failed">添加失败，请稍后重试</string>
-    <string name="str_no_collect_stickers">暂无收藏表情，长按聊天中的贴图可添加</string>
+    <string name="str_no_collect_stickers">还没有表情，点 + 添加</string>
     <string name="str_my_stickers_tab">自定义表情</string>
     <string name="str_emoji_tab">表情</string>
+    <string name="str_sticker_delete_confirm">删除这个表情？</string>
+    <string name="str_sticker_delete_success">已删除</string>
+    <string name="str_sticker_delete_failed">删除失败</string>
+    <string name="str_sticker_upload_success">已添加到我的表情</string>
+    <string name="str_sticker_upload_failed">上传失败</string>
+    <string name="str_sticker_quota_exceeded">我的表情已达上限</string>
+    <string name="str_sticker_format_unsupported">仅支持 gif/png/jpg/webp</string>
+    <string name="str_sticker_too_large">图片不能超过 1MB</string>
+    <string name="str_sticker_dim_too_large">图片尺寸不能超过 512×512</string>
+    <string name="str_sticker_send">发送</string>
+    <string name="str_sticker_add_button">添加</string>
 
     <!-- i18n: 输入长度上限提示（EditText 超长时节流 toast） -->
     <string name="str_input_length_limit">最多 %1$d 个字符</string>

--- a/wkbase/src/test/java/com/chat/base/msg/model/WKStickerContentTest.java
+++ b/wkbase/src/test/java/com/chat/base/msg/model/WKStickerContentTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.base.msg.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.xinbida.wukongim.message.type.WKMsgContentType;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+/**
+ * WK_VECTOR_STICKER (12) / WK_EMOJI_STICKER (13) 消息回归保护。
+ *
+ * 关键回归点：
+ *  - type 常量必须 = 12 / 13（服务端 Web / iOS 接收都要按这个 type 路由）
+ *  - encode → decode 往返一致（字段结构与 iOS WKLottieStickerContent 对齐）
+ *  - format 未指定时默认 "lim"（对齐 iOS 行为，避免 null 字符串引发下游 NPE）
+ *  - getDisplayContent / getSearchableWord 有默认值（子区最后一条消息摘要用）
+ */
+public class WKStickerContentTest {
+
+    @Test
+    public void vectorSticker_typeIs12() {
+        WKVectorStickerContent content = new WKVectorStickerContent();
+        assertEquals(WKMsgContentType.WK_VECTOR_STICKER, content.type);
+        assertEquals(12, content.type);
+    }
+
+    @Test
+    public void emojiSticker_typeIs13() {
+        WKEmojiStickerContent content = new WKEmojiStickerContent();
+        assertEquals(WKMsgContentType.WK_EMOJI_STICKER, content.type);
+        assertEquals(13, content.type);
+    }
+
+    @Test
+    public void vectorSticker_encodeDecodeRoundTrip() throws JSONException {
+        WKVectorStickerContent origin = new WKVectorStickerContent();
+        origin.url = "https://cdn.example.com/sticker/uid123/abc.lim";
+        origin.width = 256;
+        origin.height = 256;
+        origin.category = "user";
+        origin.placeholder = "<svg>...</svg>";
+        origin.format = "lim";
+
+        JSONObject json = origin.encodeMsg();
+        assertNotNull(json);
+        assertEquals("https://cdn.example.com/sticker/uid123/abc.lim", json.optString("url"));
+        assertEquals(256, json.optInt("width"));
+        assertEquals(256, json.optInt("height"));
+        assertEquals("user", json.optString("category"));
+        assertEquals("<svg>...</svg>", json.optString("placeholder"));
+        assertEquals("lim", json.optString("format"));
+
+        WKVectorStickerContent decoded = new WKVectorStickerContent();
+        decoded.decodeMsg(json);
+        assertEquals(origin.url, decoded.url);
+        assertEquals(origin.width, decoded.width);
+        assertEquals(origin.height, decoded.height);
+        assertEquals(origin.category, decoded.category);
+        assertEquals(origin.placeholder, decoded.placeholder);
+        assertEquals(origin.format, decoded.format);
+    }
+
+    @Test
+    public void vectorSticker_formatDefaultsToLimWhenMissing() throws JSONException {
+        JSONObject json = new JSONObject();
+        json.put("url", "https://cdn.example.com/sticker/uid/x.lim");
+        // 注意：没有 format 字段
+
+        WKVectorStickerContent decoded = new WKVectorStickerContent();
+        decoded.decodeMsg(json);
+
+        assertEquals("lim", decoded.format);
+    }
+
+    @Test
+    public void vectorSticker_encodeWithNullFieldsProducesEmptyStrings() {
+        WKVectorStickerContent content = new WKVectorStickerContent();
+        // 所有字段默认 null；encode 时要转成 "" 避免服务端 fastjson decode NPE
+        JSONObject json = content.encodeMsg();
+
+        assertEquals("", json.optString("url"));
+        assertEquals("", json.optString("category"));
+        assertEquals("", json.optString("placeholder"));
+        assertEquals("lim", json.optString("format"));
+    }
+
+    @Test
+    public void emojiSticker_inheritsAllFields() throws JSONException {
+        WKEmojiStickerContent origin = new WKEmojiStickerContent();
+        origin.url = "https://cdn.example.com/sticker/uid456/emoji.png";
+        origin.width = 128;
+        origin.height = 128;
+        origin.category = "user";
+        origin.format = "png";
+
+        JSONObject json = origin.encodeMsg();
+        WKEmojiStickerContent decoded = new WKEmojiStickerContent();
+        decoded.decodeMsg(json);
+
+        assertEquals(WKMsgContentType.WK_EMOJI_STICKER, decoded.type);
+        assertEquals(origin.url, decoded.url);
+        assertEquals(origin.width, decoded.width);
+        assertEquals(origin.format, decoded.format);
+    }
+
+    @Test
+    public void vectorSticker_displayContentAndSearchableWord() {
+        WKVectorStickerContent v = new WKVectorStickerContent();
+        assertEquals("[贴图]", v.getDisplayContent());
+        assertEquals("[贴图]", v.getSearchableWord());
+
+        WKEmojiStickerContent e = new WKEmojiStickerContent();
+        assertEquals("[emoji表情]", e.getDisplayContent());
+        assertEquals("[emoji表情]", e.getSearchableWord());
+    }
+}

--- a/wkuikit/src/main/AndroidManifest.xml
+++ b/wkuikit/src/main/AndroidManifest.xml
@@ -127,6 +127,16 @@
             android:label="文件预览" />
 
         <activity
+            android:name="com.chat.uikit.chat.provider.PdfPreviewActivity"
+            android:theme="@style/Theme.AppCompat.Light"
+            android:label="PDF" />
+
+        <activity
+            android:name="com.chat.uikit.chat.provider.XlsxPreviewActivity"
+            android:theme="@style/Theme.AppCompat.Light"
+            android:label="Excel" />
+
+        <activity
             android:name="com.chat.uikit.chat.provider.FileSaveActivity"
             android:theme="@style/Theme.AppCompat.Translucent" />
 

--- a/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
+++ b/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
@@ -79,7 +79,9 @@ import com.chat.base.glide.ChooseResult;
 import com.chat.base.glide.ChooseResultModel;
 import com.chat.base.glide.GlideUtils;
 import com.chat.base.msg.IConversationContext;
+import com.chat.base.msg.model.WKEmojiStickerContent;
 import com.chat.base.msg.model.WKGifContent;
+import com.chat.base.msg.model.WKVectorStickerContent;
 import com.chat.base.msgitem.WKContentType;
 import com.chat.base.msgitem.WKMsgItemViewManager;
 import com.chat.base.net.HttpResponseCode;
@@ -107,6 +109,7 @@ import com.chat.uikit.chat.provider.WKVideoProvider;
 import com.chat.uikit.chat.msgmodel.WKMultiForwardContent;
 import com.chat.uikit.chat.provider.LoadingProvider;
 import com.chat.uikit.chat.provider.WKCardProvider;
+import com.chat.uikit.chat.provider.WKEmojiStickerProvider;
 import com.chat.uikit.chat.provider.WKEmptyProvider;
 import com.chat.uikit.chat.provider.WKImageProvider;
 import com.chat.uikit.chat.provider.WKMultiForwardProvider;
@@ -116,6 +119,7 @@ import com.chat.uikit.chat.provider.WKSensitiveWordsProvider;
 import com.chat.uikit.chat.provider.WKSpanEmptyProvider;
 import com.chat.uikit.chat.provider.WKTextProvider;
 import com.chat.uikit.chat.provider.WKRichTextProvider;
+import com.chat.uikit.chat.provider.WKVectorStickerProvider;
 import com.chat.uikit.chat.provider.WKVoiceProvider;
 import com.chat.uikit.thread.CreateThreadActivity;
 import com.chat.uikit.thread.msgmodel.WKThreadCreatedContent;
@@ -329,6 +333,11 @@ public class WKUIKitApplication {
         WKIM.getInstance().getMsgManager().registerContentMsg(WKMultiForwardContent.class);
         WKIM.getInstance().getMsgManager().registerContentMsg(WKThreadCreatedContent.class);
         WKIM.getInstance().getMsgManager().registerContentMsg(WKRichTextContent.class);
+        // 贴图 (与 iOS 对齐)：lottie 矢量贴图 (12) + emoji 贴图 (13)。
+        // 未注册时收发消息会被 ChatAdapter 强制降级为 unknown_msg(-3)
+        // 显示"未知消息，请先升级客户端后查看" —— 已在生产观测到。
+        WKIM.getInstance().getMsgManager().registerContentMsg(WKVectorStickerContent.class);
+        WKIM.getInstance().getMsgManager().registerContentMsg(WKEmojiStickerContent.class);
         //添加消息item
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.sensitiveWordsTips, new WKSensitiveWordsProvider());
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.noRelation, new WKNoRelationProvider());
@@ -343,6 +352,12 @@ public class WKUIKitApplication {
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.WK_MULTIPLE_FORWARD, new WKMultiForwardProvider());
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.WK_FILE, new WKFileProvider());
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.WK_VIDEO, new WKVideoProvider());
+        // 贴图 provider (12/13)：独立 layout + 无气泡 + Glide 静态图直显 / Lottie 走占位。
+        // 详见 WKVectorStickerProvider 说明 —— 不继承 WKImageProvider 是刻意为之
+        // （图片路径的大图预览 / 保存到相册 / 上传进度 / 圆角气泡都不适用于贴图，
+        // 且 .lim URL 走 Glide 会崩）。emoji sticker 只覆写 itemViewType。
+        WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.WK_VECTOR_STICKER, new WKVectorStickerProvider());
+        WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.WK_EMOJI_STICKER, new WKEmojiStickerProvider());
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.loading, new LoadingProvider());
         WKMsgItemViewManager.getInstance().addChatItemViewProvider(WKContentType.threadCreated, new WKThreadCreatedProvider());
         // 设置消息长按选项
@@ -355,6 +370,12 @@ public class WKUIKitApplication {
         EndpointManager.getInstance().setMethod(EndpointCategory.msgConfig + WKContentType.WK_MULTIPLE_FORWARD, object -> new MsgConfig(true));
         EndpointManager.getInstance().setMethod(EndpointCategory.msgConfig + WKContentType.WK_FILE, object -> new MsgConfig(true));
         EndpointManager.getInstance().setMethod(EndpointCategory.msgConfig + WKContentType.WK_VIDEO, object -> new MsgConfig(true));
+        // 贴图 (12/13) 长按菜单：全功能启用 —— 让 回复/删除/多选/撤回/转发/reaction/pin 都出现。
+        // 未注册时 WKChatBaseProvider.getMsgConfig 默认返回 MsgConfig(false) 全禁用，
+        // 长按贴图会看不到任何选项（用户实测 defect）。
+        // 撤回/删除内部还会按 canWithdraw / role 二次判断，别人的贴图不会误出撤回。
+        EndpointManager.getInstance().setMethod(EndpointCategory.msgConfig + WKContentType.WK_VECTOR_STICKER, object -> new MsgConfig(true));
+        EndpointManager.getInstance().setMethod(EndpointCategory.msgConfig + WKContentType.WK_EMOJI_STICKER, object -> new MsgConfig(true));
         EndpointManager.getInstance().setMethod("uikit_sql", EndpointCategory.wkDBMenus, object -> new DBMenu("uikit_sql"));
         //注册消息长按菜单配置
         EndpointManager.getInstance().setMethod(EndpointCategory.msgConfig + WKContentType.WK_VOICE, object -> new MsgConfig(false, true, true, false, false, false));
@@ -389,13 +410,23 @@ public class WKUIKitApplication {
             }
             return null;
         });
+        // 贴图消息长按菜单："添加到我的表情" —— 服务端走 /v1/sticker/user/collect
+        // （iOS 走的 /sticker/user 是"上传自己贴纸"接口，收藏他人贴图时会 400，
+        // 用户实测无反应即此原因），详见 AddToMyStickersMenuProvider 说明。
+        com.chat.uikit.chat.sticker.AddToMyStickersMenuProvider.INSTANCE.register();
+        // 预拉一次收藏列表：让 isCollected() 判断在首次长按贴图时就命中，
+        // 避免"点两次才隐藏菜单"的短暂窗口。未登录时静默失败无副作用。
+        com.chat.uikit.chat.sticker.WKStickerManager.INSTANCE.load();
         // 创建子区长按菜单
         EndpointManager.getInstance().setMethod("create_thread", EndpointCategory.wkChatPopupItem, 10, object -> {
             WKMsg wkMsg = (WKMsg) object;
-            // 仅在群聊中、thread_on开启、非系统消息时显示
+            // 仅在群聊中、thread_on开启、非系统消息、非贴图消息时显示。
+            // 贴图 (12/13) 排除：语义上"给一张贴图开子区"不合理 —— iOS 也不出。
             if (wkMsg.channelType == WKChannelType.GROUP
                     && WKConfig.getInstance().getAppConfig().thread_on == 1
-                    && !WKContentType.isSystemMsg(wkMsg.type)) {
+                    && !WKContentType.isSystemMsg(wkMsg.type)
+                    && wkMsg.type != WKContentType.WK_VECTOR_STICKER
+                    && wkMsg.type != WKContentType.WK_EMOJI_STICKER) {
                 // 已建过子区的消息: 把"创建子区"换成"进入子区「XX」", 与 iOS WKApp.m:1640-1658 对齐。
                 // 数据来源: 任意一条 threadCreated 系统消息 decode 时把 (source_message_id → this) 写进
                 // WKThreadCreatedContent 的全局 map, 这里用当前消息 id 反查命中即可。

--- a/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
+++ b/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
@@ -585,8 +585,17 @@ public class WKUIKitApplication {
                 MsgModel.getInstance().revokeMsg(withdrawMsgMenu.message_id, withdrawMsgMenu.channel_id, withdrawMsgMenu.channel_type, withdrawMsgMenu.client_msg_no, (code, msg) -> {
                     if (code != HttpResponseCode.success) {
                         WKToastUtils.getInstance().showToastNormal(msg);
-                        //  WKIM.getInstance().getMsgManager().updateMsgRevokeWithMessageID(withdrawMsgMenu.message_id, 1);
-//                        WKIM.getInstance().getMessageManager().deleteMsgByClientMsgNo(client_msg_no);
+                    } else {
+                        // 对齐 iOS 自己撤回架构：HTTP 200 后立即本地 mark 撤回状态，
+                        // 不依赖 syncExtraMsg（该接口服务端 cache bug 常返回 resultSize=0，
+                        // 客户端永久卡住）。CMD 到达后走 syncExtraMsg 兜底路径，
+                        // 因本地已 mark, WKIMUtils.revokeMsg 里 alreadyRevoked 检查会短路。
+                        // 详见 WKIMUtils#markMsgRevokedLocallyByClientMsgNO。
+                        com.chat.uikit.chat.manager.WKIMUtils.getInstance()
+                                .markMsgRevokedLocallyByClientMsgNO(
+                                        withdrawMsgMenu.client_msg_no,
+                                        WKConfig.getInstance().getUid()
+                                );
                     }
                 });
             }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -107,6 +107,9 @@ import com.chat.uikit.chat.sticker.CollectStickerAdapter
 import com.chat.uikit.chat.sticker.StickerUrlUtils
 import com.chat.uikit.chat.sticker.WKSticker
 import com.chat.uikit.chat.sticker.WKStickerManager
+import com.chat.uikit.chat.sticker.WKStickerUploader
+import com.chat.base.glide.ChooseMimeType
+import com.chat.base.glide.ChooseResult
 import com.chat.base.msg.model.WKVectorStickerContent
 import com.chat.uikit.group.GroupMemberEntity
 import com.chat.uikit.group.RemindMemberAdapter
@@ -209,6 +212,11 @@ class ChatPanelManager(
     private var trayLayout: LinearLayout? = null
     private var trayRecyclerView: RecyclerView? = null
     private var trayAdapter: WKRichTextTrayAdapter? = null
+
+    // Sticker panel adapter：仅在 buildStickerContentView 内使用，字段保留是为了未来加
+    // "重排 / 管理"等入口时不用改签名。当前长按走 StickerDetailPopup 预览，不再持有
+    // 编辑态。
+    private var stickerAdapter: CollectStickerAdapter? = null
     // 托盘发送 in-flight 防重入（对齐 Phase 1 YUJ-2872 defect b / web#227 sendingRef）：
     // 一条托盘发送在等图片异步上传期间，托盘 + 文本仍留在 UI（仅内存，进程死会丢失托盘图片，
     // 文本草稿另有持久化）。若此时用户再点发送键，会把同一批 tray + text 再打一条 → 重复
@@ -2345,6 +2353,8 @@ class ChatPanelManager(
             contentContainer.removeAllViews()
             if (index == 0) {
                 contentContainer.addView(emojiContent)
+                // 离开贴图 tab 时退出编辑态
+                stickerAdapter?.setEditMode(false)
             } else {
                 contentContainer.addView(stickerContent)
                 // 每次切到贴图 tab 都 refresh 一次收藏列表（含首次进入拉数据）。
@@ -2445,18 +2455,115 @@ class ChatPanelManager(
     }
 
     /**
-     * 我的贴图 tab：GridLayoutManager(4)，点击构造 [WKVectorStickerContent] 发送。
-     * 无收藏时显示引导文案。数据源 [WKStickerManager.stickersLiveData]。
+     * 我的贴图 tab —— 1:1 复刻 iOS `WKMyStickerContentView` 两段式交互：
+     * - 5 列 [GridLayoutManager]，首格永远是 "+"（触发相册选图上传）
+     * - 非编辑态：tap 发送 / 长按进入编辑态（haptic 中等震感）
+     * - 编辑态：cells 抖动 + × 徽章；tap 退出编辑态；tap × 二次确认删除；
+     *   长按 hold-still 500ms 弹预览；长按+移动由 [ItemTouchHelper] 接管拖拽重排
+     * - 退出编辑态：tap 空白 / 切 tab / tap sticker / tap "+"
+     * - 数据源 [WKStickerManager.stickersLiveData]，本地顺序 [com.chat.uikit.chat.sticker.StickerLocalOrderStore]
+     *
+     * [ItemTouchHelper.isLongPressDragEnabled] 置为 false —— drag 由 Adapter 内部
+     * [com.chat.uikit.chat.sticker.CollectStickerAdapter.Callbacks.startDrag] 手动
+     * 触发，因为需要区分"长按 hold-still 出预览" vs "长按+移动出 drag"。
      */
     private fun buildStickerContentView(): View {
         val activity = iConversationContext.chatActivity
         val container = FrameLayout(activity)
 
-        val recyclerView = RecyclerView(activity).apply {
-            layoutManager = GridLayoutManager(activity, 4)
+        // 拖拽重排：编辑态启用，"+" 首格禁止移动。
+        // isLongPressDragEnabled=false —— 由 Adapter 的 EditModeTouchListener 手动决定
+        // 何时 startDrag（区分"长按 hold-still 出预览"vs"长按+移动出 drag"）。
+        val touchCallback = object : ItemTouchHelper.Callback() {
+            override fun isLongPressDragEnabled(): Boolean = false
+            override fun isItemViewSwipeEnabled(): Boolean = false
+
+            override fun getMovementFlags(
+                recyclerView: RecyclerView,
+                viewHolder: RecyclerView.ViewHolder
+            ): Int {
+                if (stickerAdapter?.isEditMode() != true) return 0
+                if (viewHolder.bindingAdapterPosition == 0) return 0 // "+" 不可拖
+                val dragFlags = ItemTouchHelper.UP or ItemTouchHelper.DOWN or
+                    ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT
+                return makeMovementFlags(dragFlags, 0)
+            }
+
+            override fun onMove(
+                recyclerView: RecyclerView,
+                viewHolder: RecyclerView.ViewHolder,
+                target: RecyclerView.ViewHolder
+            ): Boolean {
+                if (target.bindingAdapterPosition == 0) return false
+                return stickerAdapter?.moveItem(
+                    viewHolder.bindingAdapterPosition,
+                    target.bindingAdapterPosition
+                ) ?: false
+            }
+
+            override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {}
+
+            override fun clearView(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder) {
+                super.clearView(recyclerView, viewHolder)
+                stickerAdapter?.currentOrderIds()?.let { WKStickerManager.reorder(it) }
+            }
         }
-        val stickerAdapter = CollectStickerAdapter()
-        recyclerView.adapter = stickerAdapter
+        val itemTouchHelper = ItemTouchHelper(touchCallback)
+
+        val adapter = CollectStickerAdapter(object : CollectStickerAdapter.Callbacks {
+            override fun onAddClick() {
+                // 编辑态点 "+"：iOS 上会先退出编辑态。Android 保持一致 —— 先退出再打开选图
+                stickerAdapter?.takeIf { it.isEditMode() }?.setEditMode(false)
+                pickAndUploadSticker(activity)
+            }
+
+            override fun onStickerClick(sticker: WKSticker, position: Int) {
+                sendCollectedSticker(sticker)
+            }
+
+            override fun onEnterEditMode() {
+                stickerAdapter?.setEditMode(true)
+                // Haptic 中等震感，对齐 iOS UIImpactFeedbackStyleMedium
+                container.performHapticFeedback(
+                    android.view.HapticFeedbackConstants.LONG_PRESS
+                )
+            }
+
+            override fun onPreviewSticker(sticker: WKSticker, position: Int) {
+                com.chat.uikit.chat.sticker.StickerDetailPopup.showForPanel(activity, sticker) {
+                    sendCollectedSticker(it)
+                }
+            }
+
+            override fun onDeleteSticker(sticker: WKSticker, position: Int) {
+                confirmDeleteSticker(activity, sticker)
+            }
+
+            override fun startDrag(viewHolder: RecyclerView.ViewHolder) {
+                itemTouchHelper.startDrag(viewHolder)
+            }
+        })
+        stickerAdapter = adapter
+
+        val recyclerView = RecyclerView(activity).apply {
+            layoutManager = GridLayoutManager(activity, 5)
+            this.adapter = adapter
+            itemAnimator = DefaultItemAnimator()
+            // tap 空白（非任何 cell）退出编辑态
+            addOnItemTouchListener(object : RecyclerView.SimpleOnItemTouchListener() {
+                override fun onInterceptTouchEvent(rv: RecyclerView, e: android.view.MotionEvent): Boolean {
+                    if (e.actionMasked == android.view.MotionEvent.ACTION_UP &&
+                        stickerAdapter?.isEditMode() == true &&
+                        rv.findChildViewUnder(e.x, e.y) == null
+                    ) {
+                        stickerAdapter?.setEditMode(false)
+                    }
+                    return false
+                }
+            })
+        }
+        itemTouchHelper.attachToRecyclerView(recyclerView)
+
         container.addView(
             recyclerView,
             FrameLayout.LayoutParams(
@@ -2472,7 +2579,7 @@ class ChatPanelManager(
             setTextSize(TypedValue.COMPLEX_UNIT_SP, 13f)
             visibility = View.GONE
             setPadding(
-                AndroidUtilities.dp(24f), 0,
+                AndroidUtilities.dp(24f), AndroidUtilities.dp(80f),
                 AndroidUtilities.dp(24f), 0
             )
         }
@@ -2480,35 +2587,72 @@ class ChatPanelManager(
             emptyTv,
             FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                Gravity.TOP
             )
         )
 
         WKStickerManager.stickersLiveData.observe(activity) { list ->
             val safeList = list ?: emptyList()
-            stickerAdapter.setList(safeList)
-            val empty = safeList.isEmpty()
-            emptyTv.visibility = if (empty) View.VISIBLE else View.GONE
-            recyclerView.visibility = if (empty) View.GONE else View.VISIBLE
-        }
-
-        stickerAdapter.setOnItemClickListener { adapter, _, position ->
-            val sticker = adapter.getItem(position) as? WKSticker ?: return@setOnItemClickListener
-            val content = WKVectorStickerContent().apply {
-                url = sticker.path
-                category = if (sticker.category.isNullOrEmpty()) "user" else sticker.category
-                placeholder = sticker.placeholder ?: ""
-                // format 优先用服务端字段，缺失则从 URL 后缀识别，再兜底 png。
-                // 避免 .gif URL 被硬贴上 format="png" 让对端渲染分支走错。
-                format = when {
-                    !sticker.format.isNullOrEmpty() -> sticker.format
-                    else -> StickerUrlUtils.extractExt(sticker.path) ?: "png"
-                }
-            }
-            iConversationContext.sendMessage(content)
+            adapter.submitList(safeList)
+            emptyTv.visibility = if (safeList.isEmpty()) View.VISIBLE else View.GONE
         }
 
         return container
+    }
+
+    /** 拉起相册选一张图 → 客户端校验 → 上传。UI 层不关心细节，交给 [WKStickerUploader]。 */
+    private fun pickAndUploadSticker(activity: android.app.Activity) {
+        GlideUtils.getInstance().chooseIMG(
+            activity, 1, false, ChooseMimeType.img, false, false,
+            object : GlideUtils.ISelectBack {
+                override fun onBack(paths: MutableList<ChooseResult>?) {
+                    val first = paths?.firstOrNull { it.path?.isNotEmpty() == true } ?: return
+                    val file = java.io.File(first.path)
+                    WKStickerUploader.upload(file, object : WKStickerUploader.Callback {
+                        override fun onSuccess(sticker: WKSticker) {
+                            // WKStickerUploader 内部已 toast 成功，此处不重复
+                        }
+                        override fun onError(messageResId: Int) {
+                            if (messageResId != 0) {
+                                com.chat.base.utils.WKToastUtils.getInstance()
+                                    .showToastNormal(activity.getString(messageResId))
+                            }
+                        }
+                    })
+                }
+                override fun onCancel() {}
+            }
+        )
+    }
+
+    /** 点击已收藏的贴纸 → 构造 [WKVectorStickerContent] 发送。 */
+    private fun sendCollectedSticker(sticker: WKSticker) {
+        val content = WKVectorStickerContent().apply {
+            url = sticker.path
+            category = if (sticker.category.isNullOrEmpty()) "user" else sticker.category
+            placeholder = sticker.placeholder ?: ""
+            format = when {
+                !sticker.format.isNullOrEmpty() -> sticker.format
+                else -> StickerUrlUtils.extractExt(sticker.path) ?: "png"
+            }
+        }
+        iConversationContext.sendMessage(content)
+    }
+
+    /** 编辑态点 × → 二次确认 → 走 API 删除。 */
+    private fun confirmDeleteSticker(activity: android.app.Activity, sticker: WKSticker) {
+        WKDialogUtils.getInstance().showDialog(
+            activity,
+            null,
+            activity.getString(R.string.str_sticker_delete_confirm),
+            true,
+            activity.getString(R.string.cancel),
+            activity.getString(R.string.sure),
+            0, 0
+        ) { which ->
+            if (which == 1) WKStickerManager.delete(sticker.sticker_id, null)
+        }
     }
 
     /**

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -103,6 +103,11 @@ import com.chat.uikit.chat.manager.WKRichTextSender
 import com.chat.uikit.chat.manager.WKSendMsgUtils
 import com.chat.uikit.chat.msgmodel.WKMultiForwardContent
 import com.chat.uikit.contacts.service.FriendModel
+import com.chat.uikit.chat.sticker.CollectStickerAdapter
+import com.chat.uikit.chat.sticker.StickerUrlUtils
+import com.chat.uikit.chat.sticker.WKSticker
+import com.chat.uikit.chat.sticker.WKStickerManager
+import com.chat.base.msg.model.WKVectorStickerContent
 import com.chat.uikit.group.GroupMemberEntity
 import com.chat.uikit.group.RemindMemberAdapter
 import com.chat.uikit.group.service.GroupModel
@@ -2303,6 +2308,94 @@ class ChatPanelManager(
     }
 
     private fun getEmojiLayout(): View {
+        val activity = iConversationContext.chatActivity
+
+        // 两个内容 View：emoji grid + 我的贴图 grid。
+        // 复用原 emoji 行为不变，另建 sticker 视图与之切换。
+        val emojiContent = buildEmojiContentView()
+        val stickerContent = buildStickerContentView()
+
+        val contentContainer = FrameLayout(activity)
+
+        // 顶部 tab bar：两个按钮 emoji / 我的贴图。
+        val tabBar = LinearLayout(activity).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(
+                AndroidUtilities.dp(8f), AndroidUtilities.dp(4f),
+                AndroidUtilities.dp(8f), AndroidUtilities.dp(4f)
+            )
+        }
+        val emojiTabBtn = buildEmojiPanelTabButton(activity.getString(R.string.str_emoji_tab))
+        val stickerTabBtn = buildEmojiPanelTabButton(activity.getString(R.string.str_my_stickers_tab))
+        tabBar.addView(
+            emojiTabBtn,
+            LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT).apply { weight = 1f }
+        )
+        tabBar.addView(
+            stickerTabBtn,
+            LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT).apply { weight = 1f }
+        )
+
+        fun selectTab(index: Int) {
+            val selColor = Theme.colorAccount
+            val normalColor = ContextCompat.getColor(activity, R.color.color999)
+            emojiTabBtn.setTextColor(if (index == 0) selColor else normalColor)
+            stickerTabBtn.setTextColor(if (index == 1) selColor else normalColor)
+            contentContainer.removeAllViews()
+            if (index == 0) {
+                contentContainer.addView(emojiContent)
+            } else {
+                contentContainer.addView(stickerContent)
+                // 每次切到贴图 tab 都 refresh 一次收藏列表（含首次进入拉数据）。
+                WKStickerManager.load()
+            }
+        }
+        emojiTabBtn.setOnClickListener { selectTab(0) }
+        stickerTabBtn.setOnClickListener { selectTab(1) }
+
+        var height = WKConstants.getKeyboardHeight()
+        if (height == 0) {
+            height = AndroidUtilities.getScreenHeight() / 3
+        }
+        val tabBarHeightDp = 36
+        val contentHeightPx = height - AndroidUtilities.dp(tabBarHeightDp.toFloat())
+
+        val root = LinearLayout(activity).apply { orientation = LinearLayout.VERTICAL }
+        root.addView(
+            tabBar,
+            LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, tabBarHeightDp)
+        )
+        root.addView(
+            contentContainer,
+            LayoutHelper.createLinear(
+                LayoutHelper.MATCH_PARENT,
+                (contentHeightPx / AndroidUtilities.density).toInt()
+            )
+        )
+
+        selectTab(0)  // 默认 emoji tab
+        return root
+    }
+
+    private fun buildEmojiPanelTabButton(label: String): AppCompatTextView {
+        val activity = iConversationContext.chatActivity
+        return AppCompatTextView(activity).apply {
+            text = label
+            gravity = Gravity.CENTER
+            setTextColor(ContextCompat.getColor(activity, R.color.color999))
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
+            setPadding(0, AndroidUtilities.dp(6f), 0, AndroidUtilities.dp(6f))
+            Theme.setPressedBackground(this)
+        }
+    }
+
+    /**
+     * 抽取自旧 [getEmojiLayout]：emoji grid 视图，行为完全不变。
+     * onAttachedToWindow 在 tab 切换 / 面板重开时重新走"最近使用"排序。
+     */
+    private fun buildEmojiContentView(): View {
+        val activity = iConversationContext.chatActivity
         val width = AndroidUtilities.getScreenWidth() - AndroidUtilities.dp(30f) * 8
         val customList = EmojiManager.getInstance().getEmojiWithType("custom_")
         val normalList = EmojiManager.getInstance().getEmojiWithType("0_")
@@ -2314,38 +2407,27 @@ class ChatPanelManager(
             addAll(naturelList)
             addAll(symbolsList)
         }
-        // 初始就按"最近使用"排序——已点过的冒到前面，剩下按 custom→normal→natural→symbols 原顺序。
         val emojiAdapter = EmojiAdapter(buildOrderedEmojiList(baseList), width)
-        // 用匿名子类覆盖 onAttachedToWindow：每次面板被 ChatPanelManager.toolBarClick 通过
-        // moreLayout.removeAllViews() + addView() 重新挂上时，按最新 prefs 重排一次。
-        // 这样同一次面板期间顺序保持稳定（点击不当场跳位），下次打开才生效——对齐
+        // onAttachedToWindow：tab 切回来或面板重开时按最新 prefs 重排。
+        // 同一次面板期间顺序保持稳定（点击不当场跳位），下次打开才生效——对齐
         // WeChat / iOS 的体验（iOS WKEmojiContentView 也不在 didSelect 后 reloadData）。
-        val emojiLayout = object : LinearLayout(iConversationContext.chatActivity) {
+        val emojiLayout = object : LinearLayout(activity) {
             override fun onAttachedToWindow() {
                 super.onAttachedToWindow()
                 emojiAdapter.setList(buildOrderedEmojiList(baseList))
             }
         }
-        val recyclerView = RecyclerView(iConversationContext.chatActivity)
-        val emojiLayoutManager = GridLayoutManager(iConversationContext.chatActivity, 8)
-        recyclerView.layoutManager = emojiLayoutManager
+        val recyclerView = RecyclerView(activity)
+        recyclerView.layoutManager = GridLayoutManager(activity, 8)
         recyclerView.adapter = emojiAdapter
-        var height = WKConstants.getKeyboardHeight()
-        if (height == 0) {
-            height = AndroidUtilities.getScreenHeight() / 3
-        }
         emojiLayout.addView(
             recyclerView,
-            LayoutHelper.createLinear(
-                LayoutHelper.MATCH_PARENT,
-                (height / AndroidUtilities.density).toInt()
-            )
+            LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT)
         )
 
         emojiAdapter.setOnItemClickListener { adapter, _, position ->
             val emojiEntry = adapter.getItem(position) as EmojiEntry
             if (emojiEntry.tag.startsWith("custom_")) {
-                // 自定义表情直接作为独立消息发送
                 val textContent = WKTextContent(emojiEntry.text)
                 iConversationContext.sendMessage(textContent)
             } else {
@@ -2357,10 +2439,76 @@ class ChatPanelManager(
                 MoonUtil.addEmojiSpan(editText, emojiEntry.text, iConversationContext.chatActivity)
                 editText.setSelection(curPosition + emojiEntry.text.length)
             }
-            // 仅写 prefs，不当场 setList——本次面板顺序保持稳定，避免点完一个就跳位的割裂感。
             recordRecentEmoji(emojiEntry.text)
         }
         return emojiLayout
+    }
+
+    /**
+     * 我的贴图 tab：GridLayoutManager(4)，点击构造 [WKVectorStickerContent] 发送。
+     * 无收藏时显示引导文案。数据源 [WKStickerManager.stickersLiveData]。
+     */
+    private fun buildStickerContentView(): View {
+        val activity = iConversationContext.chatActivity
+        val container = FrameLayout(activity)
+
+        val recyclerView = RecyclerView(activity).apply {
+            layoutManager = GridLayoutManager(activity, 4)
+        }
+        val stickerAdapter = CollectStickerAdapter()
+        recyclerView.adapter = stickerAdapter
+        container.addView(
+            recyclerView,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        )
+
+        val emptyTv = AppCompatTextView(activity).apply {
+            text = activity.getString(R.string.str_no_collect_stickers)
+            gravity = Gravity.CENTER
+            setTextColor(ContextCompat.getColor(activity, R.color.color999))
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 13f)
+            visibility = View.GONE
+            setPadding(
+                AndroidUtilities.dp(24f), 0,
+                AndroidUtilities.dp(24f), 0
+            )
+        }
+        container.addView(
+            emptyTv,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        )
+
+        WKStickerManager.stickersLiveData.observe(activity) { list ->
+            val safeList = list ?: emptyList()
+            stickerAdapter.setList(safeList)
+            val empty = safeList.isEmpty()
+            emptyTv.visibility = if (empty) View.VISIBLE else View.GONE
+            recyclerView.visibility = if (empty) View.GONE else View.VISIBLE
+        }
+
+        stickerAdapter.setOnItemClickListener { adapter, _, position ->
+            val sticker = adapter.getItem(position) as? WKSticker ?: return@setOnItemClickListener
+            val content = WKVectorStickerContent().apply {
+                url = sticker.path
+                category = if (sticker.category.isNullOrEmpty()) "user" else sticker.category
+                placeholder = sticker.placeholder ?: ""
+                // format 优先用服务端字段，缺失则从 URL 后缀识别，再兜底 png。
+                // 避免 .gif URL 被硬贴上 format="png" 让对端渲染分支走错。
+                format = when {
+                    !sticker.format.isNullOrEmpty() -> sticker.format
+                    else -> StickerUrlUtils.extractExt(sticker.path) ?: "png"
+                }
+            }
+            iConversationContext.sendMessage(content)
+        }
+
+        return container
     }
 
     /**

--- a/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKIMUtils.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKIMUtils.java
@@ -75,6 +75,7 @@ import com.xinbida.wukongim.entity.WKChannel;
 import com.xinbida.wukongim.entity.WKChannelExtras;
 import com.xinbida.wukongim.entity.WKChannelMember;
 import com.xinbida.wukongim.entity.WKChannelStatus;
+import com.xinbida.wukongim.entity.WKSyncExtraMsg;
 import com.xinbida.wukongim.entity.WKChannelType;
 import com.xinbida.wukongim.entity.WKConversationMsg;
 import com.xinbida.wukongim.entity.WKMsg;
@@ -658,6 +659,14 @@ public class WKIMUtils {
                     if (revokeRemind == 1) {
                         if (BuildConfig.DEBUG) android.util.Log.d("RevokeDebug", "[revokeMsg] calling syncExtraMsg for channelID=" + channelID);
                         MsgModel.getInstance().syncExtraMsg(channelID, channelType);
+                        // 竞态修复：服务端撤回操作 + 写 extra 增量 + 推 CMD 三步不是严格原子的，
+                        // CMD 常常先于 extra 增量写入到达客户端。此时立即调 syncExtraMsg 会拿到
+                        // resultSize=0（服务端还没有增量可给），本地永远不知道消息已撤回 →
+                        // 表现为"撤回没反应 / 要撤好几次才成功"（碰运气：偶尔 extra 已就绪则成功）。
+                        // 分别在 500ms / 1500ms 再拉一次，每次先查本地 msg.remoteExtra.revoke
+                        // 是否已 = 1（前一次拉已生效），已生效则跳过（幂等，避免多余请求）。
+                        scheduleRevokeRetry(messageId, channelID, channelType, 1, 500);
+                        scheduleRevokeRetry(messageId, channelID, channelType, 2, 1500);
                     } else {
                         WKMsg wkMsg = WKIM.getInstance().getMsgManager().getWithMessageID(messageId);
                         if (wkMsg != null) {
@@ -679,6 +688,87 @@ public class WKIMUtils {
                 });
             }
         }
+    }
+
+    /**
+     * 撤回 CMD 时序竞态兜底：延迟 {@code delayMs} 后如果本地目标 msg 尚未 mark 撤回，
+     * 再调一次 {@link MsgModel#syncExtraMsg}。查本地状态确保幂等，避免无谓请求。
+     */
+    private void scheduleRevokeRetry(String messageId, String channelID, byte channelType, int attempt, long delayMs) {
+        new Handler(Looper.getMainLooper()).postDelayed(() -> {
+            com.chat.base.utils.WKDbScheduler.get().scheduleDirect(() -> {
+                WKMsg local = WKIM.getInstance().getMsgManager().getWithMessageID(messageId);
+                boolean alreadyRevoked = local != null && local.remoteExtra != null && local.remoteExtra.revoke == 1;
+                if (BuildConfig.DEBUG) android.util.Log.d("RevokeDebug",
+                        "[revokeMsg] retry attempt=" + attempt + " messageId=" + messageId
+                                + " alreadyRevoked=" + alreadyRevoked);
+                if (!alreadyRevoked) {
+                    MsgModel.getInstance().syncExtraMsg(channelID, channelType);
+                }
+            });
+        }, delayMs);
+    }
+
+    /**
+     * 对齐 iOS 自己撤回架构：{@code POST /message/revoke} HTTP 200 后立即本地 mark
+     * 目标消息 {@code remoteExtra.revoke=1, revoker=self.uid}，然后触发 UI 刷新。
+     *
+     * <p>为什么不"欺骗自己"：服务端 HTTP 200 已确认撤回成功，服务端也会推 CMD
+     * 给其它设备 / 其它用户，全局状态一致。本地 mark 只是**同步这个已知事实**到
+     * 当前设备 UI —— 对齐 iOS WKMessageManagerDelegateImp.m:137-138 的做法。
+     *
+     * <p>为什么必须做：服务端 syncMessageExtra 的 cache 逻辑（api.go:1258-1268）
+     * 可能返回 resultSize=0（用户实测 6 次撤回 4 次踩坑），只依赖 CMD → sync 路径
+     * 会永久卡住。iOS 通过"HTTP 200 立即本地 mark"绕过整个 sync 依赖。
+     *
+     * <p>用 clientMsgNo 查本地 msg（比传入 messageId 更稳，处理 messageID 尚未
+     * 从 IM ack 回填的场景）。若本地 msgID 仍为空则跳过（此消息扩展表按 messageID
+     * 索引，无法写入）—— 交给后续 IM ack + CMD 兜底。
+     *
+     * <p>他人撤回场景仍走 CMD → syncExtraMsg 路径（保留 [scheduleRevokeRetry] 兜底）。
+     */
+    public void markMsgRevokedLocallyByClientMsgNO(String clientMsgNo, String revoker) {
+        if (android.text.TextUtils.isEmpty(clientMsgNo)) return;
+        com.chat.base.utils.WKDbScheduler.get().scheduleDirect(() -> {
+            WKMsg wkMsg = WKIM.getInstance().getMsgManager().getWithClientMsgNO(clientMsgNo);
+            if (wkMsg == null) {
+                if (BuildConfig.DEBUG) android.util.Log.w("RevokeDebug",
+                        "[markLocal] msg not found for clientMsgNo=" + clientMsgNo);
+                return;
+            }
+            String messageId = wkMsg.messageID;
+            if (android.text.TextUtils.isEmpty(messageId) || "0".equals(messageId)) {
+                if (BuildConfig.DEBUG) android.util.Log.w("RevokeDebug",
+                        "[markLocal] messageID not yet filled (=" + messageId + ") for clientMsgNo=" + clientMsgNo
+                                + " — skip local mark, rely on CMD retry");
+                return;
+            }
+
+            WKSyncExtraMsg syncExtra = new WKSyncExtraMsg();
+            syncExtra.message_id = messageId;
+            syncExtra.revoke = 1;
+            syncExtra.revoker = revoker;
+            // 保留其它 remoteExtra 字段避免 insertOrReplace 覆盖丢失 (readed/pinned/editedAt 等)。
+            if (wkMsg.remoteExtra != null) {
+                syncExtra.readed = wkMsg.remoteExtra.readed;
+                syncExtra.readed_count = wkMsg.remoteExtra.readedCount;
+                syncExtra.unread_count = wkMsg.remoteExtra.unreadCount;
+                syncExtra.is_mutual_deleted = wkMsg.remoteExtra.isMutualDeleted;
+                syncExtra.is_pinned = wkMsg.remoteExtra.isPinned;
+                syncExtra.extra_version = wkMsg.remoteExtra.extraVersion;
+                syncExtra.edited_at = wkMsg.remoteExtra.editedAt;
+            }
+            List<WKSyncExtraMsg> list = new ArrayList<>();
+            list.add(syncExtra);
+            WKChannel channel = new WKChannel();
+            channel.channelID = wkMsg.channelID;
+            channel.channelType = wkMsg.channelType;
+            WKIM.getInstance().getMsgManager().saveRemoteExtraMsg(channel, list);
+
+            if (BuildConfig.DEBUG) android.util.Log.d("RevokeDebug",
+                    "[markLocal] revoke=1 marked messageID=" + messageId
+                            + " clientMsgNo=" + clientMsgNo + " revoker=" + revoker);
+        });
     }
 
 

--- a/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKIMUtils.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKIMUtils.java
@@ -738,6 +738,13 @@ public class WKIMUtils {
             }
             String messageId = wkMsg.messageID;
             if (android.text.TextUtils.isEmpty(messageId) || "0".equals(messageId)) {
+                // 已知边界（非主 66% miss 场景）：仅"消息刚发出、IM ack 还没回填 messageID"
+                // 的极小窗口才会命中。此分支跳过本地 mark（extra 表按 messageID 索引，
+                // 没有 messageID 就没法写），实际结果 = 只走服务端 CMD → syncExtraMsg
+                // 兜底。因为 HTTP revoke 本身已用 clientMsgNO 成功（服务端反查），全局
+                // 撤回一致；只是当前设备的 UI 会退回到"等 CMD"这条老路径。
+                // 需要覆盖到这个窗口，需要引入"按 clientMsgNO 索引的 pending revoke 表"，
+                // 待后续独立优化。
                 if (BuildConfig.DEBUG) android.util.Log.w("RevokeDebug",
                         "[markLocal] messageID not yet filled (=" + messageId + ") for clientMsgNo=" + clientMsgNo
                                 + " — skip local mark, rely on CMD retry");

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/PdfPreviewActivity.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/PdfPreviewActivity.kt
@@ -21,6 +21,8 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.pdf.PdfRenderer
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.os.ParcelFileDescriptor
 import android.util.DisplayMetrics
 import android.util.TypedValue
@@ -35,19 +37,30 @@ import androidx.recyclerview.widget.RecyclerView
 import com.chat.base.R
 import com.chat.base.utils.WKToastUtils
 import java.io.File
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import kotlin.math.sqrt
 
 /**
  * App 内 PDF 预览。用 [android.graphics.pdf.PdfRenderer]（API 21+ 内置），
  * 每页按屏幕宽度渲染成 Bitmap，RecyclerView 懒加载。
  *
- * 对齐 iOS `WKSafeFilePreviewVC.setupPDFViewInFrame:` 的行为：不走系统外部 App。
+ * 线程模型：`PdfRenderer` 文档要求"所有操作在同一线程"。此处所有 renderer 访问
+ * （open / openPage / render / close）都走 [renderExecutor]（单线程）序列化，
+ * 结果通过 [mainHandler] 回主线程 setImageBitmap。避免主线程解码超大页 → ANR/OOM。
+ *
+ * OOM 防护：大页按 [MAX_BITMAP_PIXELS] 等比缩放；`createBitmap`/`render` 失败
+ * （包括 [OutOfMemoryError]）单页跳过，不影响其它页。
  */
 class PdfPreviewActivity : AppCompatActivity() {
 
     private var filePath: String = ""
-    private var pdfRenderer: PdfRenderer? = null
-    private var fileDescriptor: ParcelFileDescriptor? = null
+    @Volatile private var pdfRenderer: PdfRenderer? = null
+    @Volatile private var fileDescriptor: ParcelFileDescriptor? = null
+    @Volatile private var pageCount: Int = 0
     private var pageWidthPx: Int = 0
+    private val renderExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -70,23 +83,32 @@ class PdfPreviewActivity : AppCompatActivity() {
         }
         setContentView(recyclerView)
 
-        val opened = openPdf()
-        if (!opened) {
-            WKToastUtils.getInstance().showToastNormal(getString(R.string.str_file_not_exist))
-            finish()
-            return
+        renderExecutor.execute {
+            val ok = openPdfOnExecutor()
+            mainHandler.post {
+                if (isFinishing || isDestroyed) return@post
+                if (!ok || pdfRenderer == null || pageCount <= 0) {
+                    WKToastUtils.getInstance().showToastNormal(getString(R.string.str_file_not_exist))
+                    finish()
+                    return@post
+                }
+                recyclerView.adapter = PdfPageAdapter(
+                    pdfRenderer!!, pageCount, pageWidthPx, renderExecutor, mainHandler
+                )
+            }
         }
-        val renderer = pdfRenderer ?: return
-        recyclerView.adapter = PdfPageAdapter(renderer, pageWidthPx)
     }
 
-    private fun openPdf(): Boolean {
+    /** 必须在 [renderExecutor] 上执行——PdfRenderer 线程绑定。 */
+    private fun openPdfOnExecutor(): Boolean {
         val file = File(filePath)
         if (!file.exists()) return false
         return try {
             val fd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
             fileDescriptor = fd
-            pdfRenderer = PdfRenderer(fd)
+            val renderer = PdfRenderer(fd)
+            pdfRenderer = renderer
+            pageCount = renderer.pageCount
             true
         } catch (_: Exception) {
             false
@@ -147,16 +169,30 @@ class PdfPreviewActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        try { pdfRenderer?.close() } catch (_: Exception) {}
-        try { fileDescriptor?.close() } catch (_: Exception) {}
+        // renderer/fd 必须在 renderExecutor 上关闭（线程绑定），提交后再 shutdown。
+        val r = pdfRenderer
+        val fd = fileDescriptor
+        pdfRenderer = null
+        fileDescriptor = null
+        renderExecutor.execute {
+            try { r?.close() } catch (_: Exception) {}
+            try { fd?.close() } catch (_: Exception) {}
+        }
+        renderExecutor.shutdown()
     }
 
     private class PdfPageAdapter(
         private val renderer: PdfRenderer,
+        private val pageCount: Int,
         private val pageWidthPx: Int,
+        private val renderExecutor: ExecutorService,
+        private val mainHandler: Handler,
     ) : RecyclerView.Adapter<PdfPageAdapter.VH>() {
 
-        class VH(val imageView: ImageView) : RecyclerView.ViewHolder(imageView)
+        class VH(val imageView: ImageView) : RecyclerView.ViewHolder(imageView) {
+            /** 当前请求的页码；异步 render 完成时用于比对是否已被回收/复用。 */
+            @Volatile var boundPage: Int = -1
+        }
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
             val marginPx = TypedValue.applyDimension(
@@ -174,29 +210,71 @@ class PdfPreviewActivity : AppCompatActivity() {
         }
 
         override fun onBindViewHolder(holder: VH, position: Int) {
-            val page = try { renderer.openPage(position) } catch (_: Exception) { return }
-            try {
-                val ratio = page.height.toFloat() / page.width.toFloat()
-                val h = (pageWidthPx * ratio).toInt().coerceAtLeast(1)
-                val bmp = Bitmap.createBitmap(pageWidthPx, h, Bitmap.Config.ARGB_8888)
-                bmp.eraseColor(Color.WHITE)
-                page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-                holder.imageView.setImageBitmap(bmp)
+            holder.boundPage = position
+            holder.imageView.setImageDrawable(null)
+            renderExecutor.execute {
+                val bmp = try {
+                    renderPage(position)
+                } catch (_: Exception) {
+                    null
+                }
+                mainHandler.post {
+                    if (holder.boundPage == position && bmp != null) {
+                        holder.imageView.setImageBitmap(bmp)
+                    }
+                    // 若 holder 已被复用/回收，丢弃这张 bitmap（不主动 recycle，让 GC 处理，
+                    // 避免"trying to use a recycled bitmap"在硬件加速 display list 里踩到）。
+                }
+            }
+        }
+
+        /** 在 [renderExecutor] 上执行——PdfRenderer 线程绑定。 */
+        private fun renderPage(position: Int): Bitmap? {
+            val page = try { renderer.openPage(position) } catch (_: Exception) { return null }
+            return try {
+                val ratio = page.height.toFloat() / page.width.toFloat().coerceAtLeast(1f)
+                val h0 = (pageWidthPx * ratio).toInt().coerceAtLeast(1)
+                val (w, h) = clampToMaxPixels(pageWidthPx, h0)
+                // Bitmap.createBitmap 在极端尺寸下会抛 OutOfMemoryError，单页失败不影响
+                // 其它页的渲染——所以 catch 掉返 null。
+                try {
+                    val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+                    bitmap.eraseColor(Color.WHITE)
+                    page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                    bitmap
+                } catch (_: OutOfMemoryError) {
+                    null
+                } catch (_: Exception) {
+                    null
+                }
             } finally {
                 try { page.close() } catch (_: Exception) {}
             }
         }
 
+        /** 按最大总像素数等比缩放，避免 `createBitmap` 分配几百 MB。 */
+        private fun clampToMaxPixels(w: Int, h: Int): Pair<Int, Int> {
+            val total = w.toLong() * h.toLong()
+            if (total <= MAX_BITMAP_PIXELS) return w to h
+            val scale = sqrt(MAX_BITMAP_PIXELS.toDouble() / total.toDouble())
+            return (w * scale).toInt().coerceAtLeast(1) to (h * scale).toInt().coerceAtLeast(1)
+        }
+
         override fun onViewRecycled(holder: VH) {
-            (holder.imageView.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap?.recycle()
+            holder.boundPage = -1
+            // 不主动 recycle bitmap：可能仍在 hardware display list 里被引用。
+            // 清除 drawable 引用后交给 GC 回收更安全。
             holder.imageView.setImageDrawable(null)
         }
 
-        override fun getItemCount(): Int = renderer.pageCount
+        override fun getItemCount(): Int = pageCount
     }
 
     companion object {
         private const val MENU_SAVE = 1001
         private const val MENU_SHARE = 1002
+
+        /** 单张 bitmap 允许的最大总像素数。8M px * 4B/px (ARGB_8888) = 32 MB。 */
+        private const val MAX_BITMAP_PIXELS: Long = 8_000_000L
     }
 }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/PdfPreviewActivity.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/PdfPreviewActivity.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.provider
+
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.pdf.PdfRenderer
+import android.os.Bundle
+import android.os.ParcelFileDescriptor
+import android.util.DisplayMetrics
+import android.util.TypedValue
+import android.view.Menu
+import android.view.MenuItem
+import android.view.ViewGroup
+import android.widget.ImageView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.FileProvider
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.chat.base.R
+import com.chat.base.utils.WKToastUtils
+import java.io.File
+
+/**
+ * App 内 PDF 预览。用 [android.graphics.pdf.PdfRenderer]（API 21+ 内置），
+ * 每页按屏幕宽度渲染成 Bitmap，RecyclerView 懒加载。
+ *
+ * 对齐 iOS `WKSafeFilePreviewVC.setupPDFViewInFrame:` 的行为：不走系统外部 App。
+ */
+class PdfPreviewActivity : AppCompatActivity() {
+
+    private var filePath: String = ""
+    private var pdfRenderer: PdfRenderer? = null
+    private var fileDescriptor: ParcelFileDescriptor? = null
+    private var pageWidthPx: Int = 0
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val title = intent.getStringExtra("title") ?: "PDF"
+        filePath = intent.getStringExtra("filePath") ?: ""
+
+        supportActionBar?.apply {
+            setDisplayHomeAsUpEnabled(true)
+            this.title = title
+        }
+
+        val metrics = DisplayMetrics()
+        @Suppress("DEPRECATION") windowManager.defaultDisplay.getMetrics(metrics)
+        pageWidthPx = metrics.widthPixels
+
+        val recyclerView = RecyclerView(this).apply {
+            layoutManager = LinearLayoutManager(this@PdfPreviewActivity)
+            setBackgroundColor(Color.parseColor("#EFEFEF"))
+        }
+        setContentView(recyclerView)
+
+        val opened = openPdf()
+        if (!opened) {
+            WKToastUtils.getInstance().showToastNormal(getString(R.string.str_file_not_exist))
+            finish()
+            return
+        }
+        val renderer = pdfRenderer ?: return
+        recyclerView.adapter = PdfPageAdapter(renderer, pageWidthPx)
+    }
+
+    private fun openPdf(): Boolean {
+        val file = File(filePath)
+        if (!file.exists()) return false
+        return try {
+            val fd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+            fileDescriptor = fd
+            pdfRenderer = PdfRenderer(fd)
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menu.add(0, MENU_SAVE, 0, R.string.str_file_save_to)
+            .setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER)
+        menu.add(0, MENU_SHARE, 1, R.string.str_file_share)
+            .setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                finish()
+                true
+            }
+            MENU_SAVE -> {
+                saveFile()
+                true
+            }
+            MENU_SHARE -> {
+                shareFile()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun saveFile() {
+        if (filePath.isEmpty()) return
+        val file = File(filePath)
+        if (!file.exists()) return
+        val intent = Intent(this, FileSaveActivity::class.java)
+        intent.putExtra("sourceFilePath", file.absolutePath)
+        intent.putExtra("fileName", file.name)
+        startActivity(intent)
+    }
+
+    private fun shareFile() {
+        if (filePath.isEmpty()) return
+        val file = File(filePath)
+        if (!file.exists()) return
+        try {
+            val uri = FileProvider.getUriForFile(this, "$packageName.fileProvider", file)
+            val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                type = WKFileProvider.getMimeType(file.name)
+                putExtra(Intent.EXTRA_STREAM, uri)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            startActivity(Intent.createChooser(shareIntent, file.name))
+        } catch (_: Exception) {
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        try { pdfRenderer?.close() } catch (_: Exception) {}
+        try { fileDescriptor?.close() } catch (_: Exception) {}
+    }
+
+    private class PdfPageAdapter(
+        private val renderer: PdfRenderer,
+        private val pageWidthPx: Int,
+    ) : RecyclerView.Adapter<PdfPageAdapter.VH>() {
+
+        class VH(val imageView: ImageView) : RecyclerView.ViewHolder(imageView)
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+            val marginPx = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP, 8f, parent.resources.displayMetrics
+            ).toInt()
+            val iv = ImageView(parent.context).apply {
+                layoutParams = RecyclerView.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                ).apply { setMargins(marginPx, marginPx, marginPx, marginPx) }
+                adjustViewBounds = true
+                setBackgroundColor(Color.WHITE)
+            }
+            return VH(iv)
+        }
+
+        override fun onBindViewHolder(holder: VH, position: Int) {
+            val page = try { renderer.openPage(position) } catch (_: Exception) { return }
+            try {
+                val ratio = page.height.toFloat() / page.width.toFloat()
+                val h = (pageWidthPx * ratio).toInt().coerceAtLeast(1)
+                val bmp = Bitmap.createBitmap(pageWidthPx, h, Bitmap.Config.ARGB_8888)
+                bmp.eraseColor(Color.WHITE)
+                page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                holder.imageView.setImageBitmap(bmp)
+            } finally {
+                try { page.close() } catch (_: Exception) {}
+            }
+        }
+
+        override fun onViewRecycled(holder: VH) {
+            (holder.imageView.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap?.recycle()
+            holder.imageView.setImageDrawable(null)
+        }
+
+        override fun getItemCount(): Int = renderer.pageCount
+    }
+
+    companion object {
+        private const val MENU_SAVE = 1001
+        private const val MENU_SHARE = 1002
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/TextPreviewActivity.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/TextPreviewActivity.kt
@@ -18,6 +18,8 @@ package com.chat.uikit.chat.provider
 
 import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.ScrollView
@@ -26,10 +28,14 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.FileProvider
 import com.chat.base.R
 import java.io.File
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 class TextPreviewActivity : AppCompatActivity() {
 
     private var filePath: String = ""
+    private val loadExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -40,7 +46,6 @@ class TextPreviewActivity : AppCompatActivity() {
         // 优先取 caller 预读的 content（避免重复 IO）；缺失则从 filePath 兜底读取，
         // 这样"预览"按钮不用重复实现"读文件 + 截断"逻辑就能复用本 Activity。
         val extraContent = intent.getStringExtra("content")
-        val content = extraContent ?: readFromFilePath(filePath)
 
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
@@ -52,7 +57,7 @@ class TextPreviewActivity : AppCompatActivity() {
             textSize = 13f
             setTextIsSelectable(true)
             typeface = android.graphics.Typeface.MONOSPACE
-            text = content
+            text = extraContent ?: ""
         }
 
         val scrollView = ScrollView(this).apply {
@@ -60,6 +65,22 @@ class TextPreviewActivity : AppCompatActivity() {
         }
 
         setContentView(scrollView)
+
+        // 没有预读 content 时后台线程 bounded read，避免 100MB 文件卡死主线程 (#92 review B5)。
+        if (extraContent == null && filePath.isNotEmpty()) {
+            loadExecutor.execute {
+                val content = TextPreviewLoader.readBounded(File(filePath), MAX_CHARS)
+                mainHandler.post {
+                    if (isFinishing || isDestroyed) return@post
+                    textView.text = content
+                }
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        loadExecutor.shutdownNow()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -124,17 +145,5 @@ class TextPreviewActivity : AppCompatActivity() {
 
         /** 与 WKFileProvider.TEXT_PREVIEW_EXTS 对齐的截断阈值（字符数）。 */
         private const val MAX_CHARS = 50_000
-
-        private fun readFromFilePath(filePath: String): String {
-            if (filePath.isEmpty()) return ""
-            return try {
-                val text = File(filePath).readText(Charsets.UTF_8)
-                if (text.length > MAX_CHARS) {
-                    text.substring(0, MAX_CHARS) + "\n\n... (文件过大，仅显示前${MAX_CHARS}字符)"
-                } else text
-            } catch (_: Exception) {
-                ""
-            }
-        }
     }
 }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/TextPreviewActivity.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/TextPreviewActivity.kt
@@ -35,8 +35,12 @@ class TextPreviewActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         val title = intent.getStringExtra("title") ?: "文件预览"
-        val content = intent.getStringExtra("content") ?: ""
         filePath = intent.getStringExtra("filePath") ?: ""
+
+        // 优先取 caller 预读的 content（避免重复 IO）；缺失则从 filePath 兜底读取，
+        // 这样"预览"按钮不用重复实现"读文件 + 截断"逻辑就能复用本 Activity。
+        val extraContent = intent.getStringExtra("content")
+        val content = extraContent ?: readFromFilePath(filePath)
 
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
@@ -117,5 +121,20 @@ class TextPreviewActivity : AppCompatActivity() {
     companion object {
         private const val MENU_SAVE = 1001
         private const val MENU_SHARE = 1002
+
+        /** 与 WKFileProvider.TEXT_PREVIEW_EXTS 对齐的截断阈值（字符数）。 */
+        private const val MAX_CHARS = 50_000
+
+        private fun readFromFilePath(filePath: String): String {
+            if (filePath.isEmpty()) return ""
+            return try {
+                val text = File(filePath).readText(Charsets.UTF_8)
+                if (text.length > MAX_CHARS) {
+                    text.substring(0, MAX_CHARS) + "\n\n... (文件过大，仅显示前${MAX_CHARS}字符)"
+                } else text
+            } catch (_: Exception) {
+                ""
+            }
+        }
     }
 }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/TextPreviewLoader.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/TextPreviewLoader.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.provider
+
+import java.io.File
+import java.io.FileInputStream
+import java.io.InputStreamReader
+
+/**
+ * Bounded 文本文件读取。避免 [File.readText] 全文加载后再截断带来的 OOM/ANR
+ * （聊天允许 100 MB 文件，直接 readText 一个 100 MB 的 .log 会 OOM/ANR）。
+ *
+ * 只读到 [maxChars] 字符就停止；若确实还有内容，末尾追加"文件过大"提示。
+ * 不做线程调度——呼叫方决定跑主线程还是后台。bounded 后 50k 字符 (≈200KB UTF-8)
+ * 磁盘 IO 通常在 10ms 以内，短文件场景主线程调用可接受。
+ */
+object TextPreviewLoader {
+
+    private const val BUF_SIZE = 4096
+
+    /** 追加在文本末尾提示被截断的模板。占位符是最终字符数（[maxChars]）。 */
+    private const val TRUNCATE_HINT_ZH = "\n\n... (文件过大，仅显示前%d字符)"
+
+    /**
+     * @param file 要读取的文件；不存在或读取抛异常时返回已累积的 [String]（可能为空）
+     * @param maxChars 上限字符数（Unicode code unit，即 Java `char`）
+     * @return 最多 [maxChars] 字符的内容，若被截断则末尾追加提示
+     */
+    fun readBounded(file: File, maxChars: Int): String {
+        if (!file.exists() || maxChars <= 0) return ""
+        val sb = StringBuilder()
+        val buf = CharArray(BUF_SIZE)
+        var truncated = false
+        try {
+            InputStreamReader(FileInputStream(file), Charsets.UTF_8).use { reader ->
+                while (sb.length < maxChars) {
+                    val toRead = minOf(buf.size, maxChars - sb.length)
+                    val n = reader.read(buf, 0, toRead)
+                    if (n <= 0) break
+                    sb.append(buf, 0, n)
+                }
+                // 探测后面是否还有内容——决定是否要追加"文件过大"提示。
+                if (sb.length >= maxChars && reader.read(buf, 0, 1) > 0) {
+                    truncated = true
+                }
+            }
+        } catch (_: Exception) {
+            // 静默失败：返回目前累积到的内容（呼叫方通常以空串处理）
+        }
+        if (truncated) sb.append(TRUNCATE_HINT_ZH.format(maxChars))
+        return sb.toString()
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKEmojiStickerProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKEmojiStickerProvider.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.provider
+
+import com.xinbida.wukongim.message.type.WKMsgContentType
+
+/**
+ * Emoji 贴图 (type=13) provider —— 结构与 vector sticker 一致，仅换 itemViewType。
+ *
+ * 独立子类的必要性：chad BaseProviderMultiAdapter.addItemProvider() 按
+ * provider.itemViewType 存 key，直接 new WKVectorStickerProvider() 复用会让
+ * mProviders 只留一份 type=12 映射，type=13 到达时 onCreateDefViewHolder 找不到崩。
+ */
+class WKEmojiStickerProvider : WKVectorStickerProvider() {
+    override val itemViewType: Int
+        get() = WKMsgContentType.WK_EMOJI_STICKER
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKFileProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKFileProvider.kt
@@ -254,6 +254,9 @@ class WKFileProvider : WKChatBaseProvider() {
         /** 文件名 UTF-8 字节长度上限（Linux NAME_MAX=255，留 55 字节余量给临时后缀/挂载点差异）。 */
         private const val MAX_FILENAME_BYTES = 200
 
+        /** 文本预览截断阈值（字符数），与 [TextPreviewActivity] 内部常量对齐。 */
+        private const val TEXT_PREVIEW_MAX_CHARS = 50_000
+
         /** App 内以纯文本形式展示（走 [TextPreviewActivity]）的扩展名白名单。
          *  同时驱动"打开"路径的 dispatch 与 BottomSheet "预览"按钮的显隐。 */
         private val TEXT_PREVIEW_EXTS = setOf(
@@ -336,19 +339,15 @@ class WKFileProvider : WKChatBaseProvider() {
         private fun openFileDirectlyStatic(context: Context, file: File) {
             val ext = file.extension.lowercase(Locale.getDefault())
             if (ext in TEXT_PREVIEW_EXTS) {
-                try {
-                    val content = file.readText(Charsets.UTF_8).let {
-                        if (it.length > 50000) it.substring(0, 50000) + "\n\n... (文件过大，仅显示前50000字符)" else it
-                    }
-                    val intent = Intent(context, TextPreviewActivity::class.java)
-                    intent.putExtra("title", file.name)
-                    intent.putExtra("content", content)
-                    intent.putExtra("filePath", file.absolutePath)
-                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    context.startActivity(intent)
-                } catch (_: Exception) {
-                    WKToastUtils.getInstance().showToastNormal(context.getString(R.string.str_file_not_exist))
-                }
+                // bounded 后主线程读上限 50k 字符 (≈200KB UTF-8) 通常 <10ms，避免旧
+                // `readText()` 全文加载导致 100MB `.log` OOM/ANR (#92 review B5)。
+                val content = TextPreviewLoader.readBounded(file, TEXT_PREVIEW_MAX_CHARS)
+                val intent = Intent(context, TextPreviewActivity::class.java)
+                intent.putExtra("title", file.name)
+                intent.putExtra("content", content)
+                intent.putExtra("filePath", file.absolutePath)
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                context.startActivity(intent)
                 return
             }
             try {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKFileProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKFileProvider.kt
@@ -152,7 +152,37 @@ class WKFileProvider : WKChatBaseProvider() {
         // Extract basename to prevent path traversal (../ or /)
         val basename = File(name).name
         // Remove any remaining dangerous characters
-        return basename.replace(Regex("[\\\\/:*?\"<>|]"), "_")
+        val cleaned = basename.replace(Regex("[\\\\/:*?\"<>|]"), "_")
+        // Linux 文件系统 NAME_MAX = 255 字节 (UTF-8, 不是字符)。
+        // 长中文/emoji 文件名（3~4 字节/字符）很容易越界，导致 FileOutputStream 抛
+        // ENAMETOOLONG 静默失败，用户观感是"点了没反应"。留 55 字节余量。
+        return truncateToByteLength(cleaned, MAX_FILENAME_BYTES)
+    }
+
+    /** 按 UTF-8 字节长度截断文件名，保留扩展名，按 code point 边界截取避免破坏字符。 */
+    private fun truncateToByteLength(name: String, maxBytes: Int): String {
+        if (name.toByteArray(Charsets.UTF_8).size <= maxBytes) return name
+        val dot = name.lastIndexOf('.')
+        val ext = if (dot > 0) name.substring(dot) else ""
+        val base = if (dot > 0) name.substring(0, dot) else name
+        val extBytes = ext.toByteArray(Charsets.UTF_8).size
+        val baseBudget = (maxBytes - extBytes).coerceAtLeast(1)
+
+        val sb = StringBuilder()
+        var used = 0
+        var i = 0
+        while (i < base.length) {
+            val cp = base.codePointAt(i)
+            val charCount = Character.charCount(cp)
+            val cpStr = base.substring(i, i + charCount)
+            val chBytes = cpStr.toByteArray(Charsets.UTF_8).size
+            if (used + chBytes > baseBudget) break
+            sb.append(cpStr)
+            used += chBytes
+            i += charCount
+        }
+        if (sb.isEmpty()) sb.append("file")
+        return sb.toString() + ext
     }
 
     private fun handleFileClick(
@@ -221,12 +251,50 @@ class WKFileProvider : WKChatBaseProvider() {
 
     companion object {
 
+        /** 文件名 UTF-8 字节长度上限（Linux NAME_MAX=255，留 55 字节余量给临时后缀/挂载点差异）。 */
+        private const val MAX_FILENAME_BYTES = 200
+
+        /** App 内以纯文本形式展示（走 [TextPreviewActivity]）的扩展名白名单。
+         *  同时驱动"打开"路径的 dispatch 与 BottomSheet "预览"按钮的显隐。 */
+        private val TEXT_PREVIEW_EXTS = setOf(
+            "txt", "md", "json", "yaml", "yml", "xml", "csv", "log",
+            "conf", "cfg", "ini", "properties", "toml",
+            "html", "htm", "css", "js", "ts", "py", "go", "java", "kt",
+            "sh", "bat", "sql", "gradle", "swift", "c", "cpp", "h",
+            "rb", "php", "rs", "lua", "r", "pl", "env", "gitignore",
+        )
+
         @JvmStatic
         fun openFileWithOptions(context: Context, file: File) {
             val activity = context as? Activity ?: return
             if (activity.isFinishing || activity.isDestroyed) return
             val dialog = BottomSheetDialog(activity)
             val sheetView = LayoutInflater.from(activity).inflate(R.layout.bottom_sheet_file_actions, null)
+
+            // 预览按钮：pdf / xlsx / 纯文本 显示，走 App 内预览；与"打开"（系统 Intent）分开走两条路
+            // 避免影响原有"打开"逻辑。对齐 iOS WKSafeFilePreviewVC。xls / doc / ppt 老格式暂不支持。
+            val ext = file.extension.lowercase(Locale.getDefault())
+            val previewClass: Class<*>? = when {
+                ext == "pdf" -> PdfPreviewActivity::class.java
+                ext == "xlsx" -> XlsxPreviewActivity::class.java
+                ext in TEXT_PREVIEW_EXTS -> TextPreviewActivity::class.java
+                else -> null
+            }
+            val previewView = sheetView.findViewById<View>(R.id.actionPreview)
+            if (previewClass != null) {
+                previewView.visibility = View.VISIBLE
+                previewView.setOnClickListener {
+                    dialog.dismiss()
+                    val intent = Intent(context, previewClass).apply {
+                        putExtra("title", file.name)
+                        putExtra("filePath", file.absolutePath)
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    context.startActivity(intent)
+                }
+            } else {
+                previewView.visibility = View.GONE
+            }
 
             sheetView.findViewById<View>(R.id.actionOpen).setOnClickListener {
                 dialog.dismiss()
@@ -267,13 +335,7 @@ class WKFileProvider : WKChatBaseProvider() {
 
         private fun openFileDirectlyStatic(context: Context, file: File) {
             val ext = file.extension.lowercase(Locale.getDefault())
-            if (ext in listOf(
-                    "txt", "md", "json", "yaml", "yml", "xml", "csv", "log",
-                    "conf", "cfg", "ini", "properties", "toml",
-                    "html", "htm", "css", "js", "ts", "py", "go", "java", "kt",
-                    "sh", "bat", "sql", "gradle", "swift", "c", "cpp", "h",
-                    "rb", "php", "rs", "lua", "r", "pl", "env", "gitignore"
-                )) {
+            if (ext in TEXT_PREVIEW_EXTS) {
                 try {
                     val content = file.readText(Charsets.UTF_8).let {
                         if (it.length > 50000) it.substring(0, 50000) + "\n\n... (文件过大，仅显示前50000字符)" else it

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKVectorStickerProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKVectorStickerProvider.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.provider
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.chat.base.config.WKApiConfig
+import com.chat.base.glide.GlideUtils
+import com.chat.base.msg.model.WKVectorStickerContent
+import com.chat.base.msgitem.WKChatBaseProvider
+import com.chat.base.msgitem.WKChatIteMsgFromType
+import com.chat.base.msgitem.WKUIChatMsgItemEntity
+import com.chat.base.ui.components.FilterImageView
+import com.chat.uikit.R
+import com.chat.uikit.chat.sticker.StickerUrlUtils
+import com.xinbida.wukongim.message.type.WKMsgContentType
+
+/**
+ * 矢量贴图 (contentType=12) provider —— 独立实现，不继承 WKImageProvider。
+ *
+ * 之所以不复用图片路径：贴图不能走大图预览 / "保存到相册" / 上传进度 / 焚阅气泡，
+ * URL 常是 CDN 全路径或 .lim/.json (Lottie) 无法 Glide 加载，
+ * 硬套 WKImageProvider 会崩或行为错乱。iOS `hiddenBubble=YES` 也强制无气泡。
+ *
+ * Emoji sticker (13) 走 [WKEmojiStickerProvider]（仅覆写 itemViewType）。
+ *
+ * 长按菜单复用基类 [addLongClick]：转发/撤回/删除/复制 由基类给；
+ * "添加到我的表情"通过 EndpointCategory.wkChatPopupItem 扩展点由
+ * AddToMyStickersMenuProvider 注入，按 msg.type 过滤。
+ *
+ * 无单击行为（对齐 iOS：贴图 cell 除长按/双击表情反应外无点击回响）。
+ */
+open class WKVectorStickerProvider : WKChatBaseProvider() {
+
+    override val itemViewType: Int
+        get() = WKMsgContentType.WK_VECTOR_STICKER
+
+    override fun getChatViewItem(parentView: ViewGroup, from: WKChatIteMsgFromType): View? {
+        return LayoutInflater.from(context).inflate(R.layout.chat_item_sticker, parentView, false)
+    }
+
+    override fun setData(
+        adapterPosition: Int,
+        parentView: View,
+        uiChatMsgItemEntity: WKUIChatMsgItemEntity,
+        from: WKChatIteMsgFromType
+    ) {
+        val imageView = parentView.findViewById<FilterImageView>(R.id.imageView)
+        imageView.setAllCorners(10)
+
+        val content = uiChatMsgItemEntity.wkMsg.baseContentMsgModel as? WKVectorStickerContent
+        if (content == null) {
+            imageView.setImageResource(R.drawable.default_view_bg)
+            addLongClick(imageView, uiChatMsgItemEntity)
+            return
+        }
+
+        val url = content.url
+        when {
+            url.isNullOrEmpty() -> imageView.setImageResource(R.drawable.default_view_bg)
+            StickerUrlUtils.isStaticImage(url) ->
+                GlideUtils.getInstance().showImg(context, WKApiConfig.getShowUrl(url), imageView)
+            StickerUrlUtils.isLottieFormat(url, content.format) ->
+                imageView.setImageResource(R.drawable.default_view_bg)
+            else ->
+                // 未知格式：先尝试当图片加载，失败降级到占位
+                GlideUtils.getInstance().showImg(context, WKApiConfig.getShowUrl(url), imageView)
+        }
+
+        addLongClick(imageView, uiChatMsgItemEntity)
+    }
+
+    override fun resetCellListener(
+        position: Int,
+        parentView: View,
+        uiChatMsgItemEntity: WKUIChatMsgItemEntity,
+        from: WKChatIteMsgFromType
+    ) {
+        super.resetCellListener(position, parentView, uiChatMsgItemEntity, from)
+        val imageView = parentView.findViewById<FilterImageView>(R.id.imageView) ?: return
+        addLongClick(imageView, uiChatMsgItemEntity)
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKVectorStickerProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKVectorStickerProvider.kt
@@ -21,6 +21,7 @@ import com.chat.base.msgitem.WKChatIteMsgFromType
 import com.chat.base.msgitem.WKUIChatMsgItemEntity
 import com.chat.base.ui.components.FilterImageView
 import com.chat.uikit.R
+import com.chat.uikit.chat.sticker.StickerDetailPopup
 import com.chat.uikit.chat.sticker.StickerUrlUtils
 import com.xinbida.wukongim.message.type.WKMsgContentType
 
@@ -37,7 +38,8 @@ import com.xinbida.wukongim.message.type.WKMsgContentType
  * "添加到我的表情"通过 EndpointCategory.wkChatPopupItem 扩展点由
  * AddToMyStickersMenuProvider 注入，按 msg.type 过滤。
  *
- * 无单击行为（对齐 iOS：贴图 cell 除长按/双击表情反应外无点击回响）。
+ * 单击行为：弹出 [StickerDetailPopup]（180dp 预览 + 发送 / 添加到我的表情）。
+ * 对齐 iOS `WKPOINT_TO_STICKER_INFO` 的最简版本。
  */
 open class WKVectorStickerProvider : WKChatBaseProvider() {
 
@@ -77,6 +79,9 @@ open class WKVectorStickerProvider : WKChatBaseProvider() {
         }
 
         addLongClick(imageView, uiChatMsgItemEntity)
+        imageView.setOnClickListener {
+            StickerDetailPopup.showForChatMessage(imageView.context, uiChatMsgItemEntity.wkMsg)
+        }
     }
 
     override fun resetCellListener(
@@ -88,5 +93,8 @@ open class WKVectorStickerProvider : WKChatBaseProvider() {
         super.resetCellListener(position, parentView, uiChatMsgItemEntity, from)
         val imageView = parentView.findViewById<FilterImageView>(R.id.imageView) ?: return
         addLongClick(imageView, uiChatMsgItemEntity)
+        imageView.setOnClickListener {
+            StickerDetailPopup.showForChatMessage(imageView.context, uiChatMsgItemEntity.wkMsg)
+        }
     }
 }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/XlsxParser.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/XlsxParser.kt
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.provider
+
+import android.util.Xml
+import org.xmlpull.v1.XmlPullParser
+import java.io.File
+import java.io.InputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+
+/**
+ * 极简 xlsx 解析器（零依赖）。只解析：sharedStrings + workbook.xml(.rels) + 每个 sheet 的 cell 值。
+ * 不还原样式/格式化/公式表达式，但公式的**缓存值**（`<v>`）会被读到。
+ *
+ * xlsx 布局：
+ *   [Content_Types].xml
+ *   _rels/.rels                          -> 找 workbook.xml
+ *   xl/workbook.xml                      -> sheet 列表 (name, r:id)
+ *   xl/_rels/workbook.xml.rels           -> rId -> target 路径
+ *   xl/sharedStrings.xml                 -> 字符串池（可选）
+ *   xl/worksheets/sheet1.xml             -> 单元格
+ *
+ * 内存保护：单 sheet 超过 [MAX_ROWS] 行截断，超过 [MAX_COLS] 列截断，[truncated] 标注。
+ */
+object XlsxParser {
+
+    const val MAX_ROWS = 500
+    const val MAX_COLS = 50
+
+    data class Sheet(
+        val name: String,
+        val rows: List<List<String>>,
+        val truncated: Boolean,
+    )
+
+    data class Workbook(val sheets: List<Sheet>)
+
+    /** 抛异常给上层展示"预览失败"，不吞。 */
+    fun parse(file: File): Workbook {
+        ZipFile(file).use { zip ->
+            val shared = zip.getEntry("xl/sharedStrings.xml")?.let { readSharedStrings(zip, it) } ?: emptyList()
+            val rels = zip.getEntry("xl/_rels/workbook.xml.rels")?.let { readRels(zip, it) } ?: emptyMap()
+            val workbookEntry = zip.getEntry("xl/workbook.xml")
+                ?: throw IllegalStateException("missing xl/workbook.xml")
+            val sheetRefs = readWorkbook(zip, workbookEntry)
+
+            val sheets = sheetRefs.mapNotNull { (name, rid) ->
+                val target = rels[rid] ?: return@mapNotNull null
+                // target 可能是 "worksheets/sheet1.xml"，相对于 xl/
+                val entryPath = if (target.startsWith("/")) target.trimStart('/') else "xl/$target"
+                val entry = zip.getEntry(entryPath) ?: return@mapNotNull null
+                readSheet(zip, entry, shared, name)
+            }
+            return Workbook(sheets)
+        }
+    }
+
+    // ---- sharedStrings.xml ----
+    private fun readSharedStrings(zip: ZipFile, entry: ZipEntry): List<String> {
+        val out = ArrayList<String>()
+        zip.getInputStream(entry).use { input ->
+            val parser = newParser(input)
+            var buf = StringBuilder()
+            var inSi = false
+            while (parser.next() != XmlPullParser.END_DOCUMENT) {
+                when (parser.eventType) {
+                    XmlPullParser.START_TAG -> when (parser.name) {
+                        "si" -> { inSi = true; buf = StringBuilder() }
+                        "t" -> if (inSi) buf.append(readText(parser))
+                    }
+                    XmlPullParser.END_TAG -> if (parser.name == "si" && inSi) {
+                        out.add(buf.toString()); inSi = false
+                    }
+                }
+            }
+        }
+        return out
+    }
+
+    // ---- _rels/workbook.xml.rels ----
+    private fun readRels(zip: ZipFile, entry: ZipEntry): Map<String, String> {
+        val out = HashMap<String, String>()
+        zip.getInputStream(entry).use { input ->
+            val parser = newParser(input)
+            while (parser.next() != XmlPullParser.END_DOCUMENT) {
+                if (parser.eventType == XmlPullParser.START_TAG && parser.name == "Relationship") {
+                    val id = parser.getAttributeValue(null, "Id")
+                    val target = parser.getAttributeValue(null, "Target")
+                    if (id != null && target != null) out[id] = target
+                }
+            }
+        }
+        return out
+    }
+
+    // ---- workbook.xml -> List<(name, rId)> ----
+    private fun readWorkbook(zip: ZipFile, entry: ZipEntry): List<Pair<String, String>> {
+        val out = ArrayList<Pair<String, String>>()
+        zip.getInputStream(entry).use { input ->
+            val parser = newParser(input)
+            while (parser.next() != XmlPullParser.END_DOCUMENT) {
+                if (parser.eventType == XmlPullParser.START_TAG && parser.name == "sheet") {
+                    val name = parser.getAttributeValue(null, "name") ?: "Sheet"
+                    // FEATURE_PROCESS_NAMESPACES=false 时 r:id 是字面属性名"r:id"，
+                    // getAttributeValue(null,"id") 拿不到；用 endsWith(":id") 兜任意前缀。
+                    val rid = (0 until parser.attributeCount)
+                        .firstOrNull {
+                            val n = parser.getAttributeName(it)
+                            n == "id" || n.endsWith(":id")
+                        }
+                        ?.let { parser.getAttributeValue(it) }
+                    if (rid != null) out.add(name to rid)
+                }
+            }
+        }
+        return out
+    }
+
+    // ---- worksheet ----
+    private fun readSheet(zip: ZipFile, entry: ZipEntry, shared: List<String>, name: String): Sheet {
+        val rows = ArrayList<List<String>>()
+        var truncated = false
+        zip.getInputStream(entry).use { input ->
+            val parser = newParser(input)
+            var currentRow: ArrayList<String>? = null
+            var cellType: String? = null
+            var cellRef: String? = null
+            var cellValue: String? = null
+            var inlineText: StringBuilder? = null
+            var inV = false
+            var inIsT = false // <c t="inlineStr"><is><t>...</t></is></c>
+
+            while (parser.next() != XmlPullParser.END_DOCUMENT) {
+                when (parser.eventType) {
+                    XmlPullParser.START_TAG -> when (parser.name) {
+                        "row" -> {
+                            if (rows.size >= MAX_ROWS) { truncated = true }
+                            currentRow = ArrayList()
+                        }
+                        "c" -> {
+                            cellRef = parser.getAttributeValue(null, "r")
+                            cellType = parser.getAttributeValue(null, "t")
+                            cellValue = null
+                            inlineText = if (cellType == "inlineStr") StringBuilder() else null
+                        }
+                        "v" -> inV = true
+                        "t" -> if (inlineText != null) inlineText!!.append(readText(parser)) else if (inV) {
+                            // <v><t> 不常见，忽略
+                        }
+                        "is" -> Unit
+                    }
+                    XmlPullParser.TEXT -> if (inV) {
+                        cellValue = (cellValue ?: "") + parser.text
+                    }
+                    XmlPullParser.END_TAG -> when (parser.name) {
+                        "v" -> inV = false
+                        "c" -> {
+                            if (currentRow != null && rows.size < MAX_ROWS) {
+                                val col = columnIndex(cellRef)
+                                val text = resolveCellText(cellType, cellValue, inlineText, shared)
+                                fillTo(currentRow!!, col)
+                                if (col < MAX_COLS) currentRow!![col] = text else truncated = true
+                            }
+                        }
+                        "row" -> {
+                            if (rows.size < MAX_ROWS && currentRow != null) rows.add(currentRow!!)
+                            currentRow = null
+                        }
+                    }
+                }
+            }
+        }
+        return Sheet(name = name, rows = rows, truncated = truncated)
+    }
+
+    private fun resolveCellText(
+        type: String?,
+        value: String?,
+        inlineBuf: StringBuilder?,
+        shared: List<String>,
+    ): String {
+        if (inlineBuf != null) return inlineBuf.toString()
+        val v = value ?: return ""
+        return when (type) {
+            "s" -> v.toIntOrNull()?.let { if (it in shared.indices) shared[it] else "" } ?: ""
+            "b" -> if (v == "1") "TRUE" else "FALSE"
+            "str", "e" -> v
+            else -> v // number / date（原始数值，不做 formatCode 还原）
+        }
+    }
+
+    /** "A1" -> 0, "B1" -> 1, "AA1" -> 26。ref 为空时用 -1（呼叫方需忽略）。 */
+    private fun columnIndex(ref: String?): Int {
+        if (ref.isNullOrEmpty()) return -1
+        var idx = 0
+        for (ch in ref) {
+            if (ch in 'A'..'Z') idx = idx * 26 + (ch - 'A' + 1) else break
+        }
+        return idx - 1
+    }
+
+    private fun fillTo(list: ArrayList<String>, index: Int) {
+        while (list.size <= index) list.add("")
+    }
+
+    private fun newParser(input: InputStream): XmlPullParser {
+        val parser = Xml.newPullParser()
+        parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false)
+        parser.setInput(input, null)
+        return parser
+    }
+
+    private fun readText(parser: XmlPullParser): String {
+        // t 里可能有嵌套（rich text run），把所有 TEXT 事件拼起来直到 </t>
+        val depth = parser.depth
+        val buf = StringBuilder()
+        while (true) {
+            val ev = parser.next()
+            if (ev == XmlPullParser.END_DOCUMENT) break
+            if (ev == XmlPullParser.END_TAG && parser.depth == depth) break
+            if (ev == XmlPullParser.TEXT) buf.append(parser.text)
+        }
+        return buf.toString()
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/XlsxParser.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/XlsxParser.kt
@@ -19,6 +19,7 @@ package com.chat.uikit.chat.provider
 import android.util.Xml
 import org.xmlpull.v1.XmlPullParser
 import java.io.File
+import java.io.IOException
 import java.io.InputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
@@ -35,12 +36,19 @@ import java.util.zip.ZipFile
  *   xl/sharedStrings.xml                 -> 字符串池（可选）
  *   xl/worksheets/sheet1.xml             -> 单元格
  *
- * 内存保护：单 sheet 超过 [MAX_ROWS] 行截断，超过 [MAX_COLS] 列截断，[truncated] 标注。
+ * 输入是不可信的聊天附件，因此对 zip entry 解压量、共享字符串条目数、单 sheet 行/列
+ * 都做硬上限，避免 zip-bomb / 恶意坐标 / 缺字段 触发 OOM 或 IOOBE。
  */
 object XlsxParser {
 
     const val MAX_ROWS = 500
     const val MAX_COLS = 50
+
+    /** 单个 zip entry 解压后允许的最大字节数（防 zip-bomb）。50 MB 足够任何常规办公文档。 */
+    private const val MAX_ENTRY_BYTES: Long = 50L * 1024L * 1024L
+
+    /** sharedStrings 表最大条目数（防 KB 级 xml 展开为百 MB 字符串数组）。10 万条覆盖常规文档。 */
+    private const val MAX_SHARED_STRINGS = 100_000
 
     data class Sheet(
         val name: String,
@@ -73,7 +81,7 @@ object XlsxParser {
     // ---- sharedStrings.xml ----
     private fun readSharedStrings(zip: ZipFile, entry: ZipEntry): List<String> {
         val out = ArrayList<String>()
-        zip.getInputStream(entry).use { input ->
+        boundedStream(zip, entry).use { input ->
             val parser = newParser(input)
             var buf = StringBuilder()
             var inSi = false
@@ -84,7 +92,10 @@ object XlsxParser {
                         "t" -> if (inSi) buf.append(readText(parser))
                     }
                     XmlPullParser.END_TAG -> if (parser.name == "si" && inSi) {
-                        out.add(buf.toString()); inSi = false
+                        // 达到条目上限后继续解析（避免 parser 状态不定），但丢弃后续字符串。
+                        // 索引超出的 shared[i] 读到会返回 ""（见 resolveCellText 的 in-bounds 判断）。
+                        if (out.size < MAX_SHARED_STRINGS) out.add(buf.toString())
+                        inSi = false
                     }
                 }
             }
@@ -95,7 +106,7 @@ object XlsxParser {
     // ---- _rels/workbook.xml.rels ----
     private fun readRels(zip: ZipFile, entry: ZipEntry): Map<String, String> {
         val out = HashMap<String, String>()
-        zip.getInputStream(entry).use { input ->
+        boundedStream(zip, entry).use { input ->
             val parser = newParser(input)
             while (parser.next() != XmlPullParser.END_DOCUMENT) {
                 if (parser.eventType == XmlPullParser.START_TAG && parser.name == "Relationship") {
@@ -111,7 +122,7 @@ object XlsxParser {
     // ---- workbook.xml -> List<(name, rId)> ----
     private fun readWorkbook(zip: ZipFile, entry: ZipEntry): List<Pair<String, String>> {
         val out = ArrayList<Pair<String, String>>()
-        zip.getInputStream(entry).use { input ->
+        boundedStream(zip, entry).use { input ->
             val parser = newParser(input)
             while (parser.next() != XmlPullParser.END_DOCUMENT) {
                 if (parser.eventType == XmlPullParser.START_TAG && parser.name == "sheet") {
@@ -135,7 +146,7 @@ object XlsxParser {
     private fun readSheet(zip: ZipFile, entry: ZipEntry, shared: List<String>, name: String): Sheet {
         val rows = ArrayList<List<String>>()
         var truncated = false
-        zip.getInputStream(entry).use { input ->
+        boundedStream(zip, entry).use { input ->
             val parser = newParser(input)
             var currentRow: ArrayList<String>? = null
             var cellType: String? = null
@@ -143,7 +154,6 @@ object XlsxParser {
             var cellValue: String? = null
             var inlineText: StringBuilder? = null
             var inV = false
-            var inIsT = false // <c t="inlineStr"><is><t>...</t></is></c>
 
             while (parser.next() != XmlPullParser.END_DOCUMENT) {
                 when (parser.eventType) {
@@ -170,15 +180,25 @@ object XlsxParser {
                     XmlPullParser.END_TAG -> when (parser.name) {
                         "v" -> inV = false
                         "c" -> {
-                            if (currentRow != null && rows.size < MAX_ROWS) {
+                            val row = currentRow
+                            if (row != null && rows.size < MAX_ROWS) {
                                 val col = columnIndex(cellRef)
-                                val text = resolveCellText(cellType, cellValue, inlineText, shared)
-                                fillTo(currentRow!!, col)
-                                if (col < MAX_COLS) currentRow!![col] = text else truncated = true
+                                // 三种情况：
+                                //  col in 0 until MAX_COLS → 正常写入（此时 fillTo 最多补 MAX_COLS-1 项，安全）
+                                //  col >= MAX_COLS         → 攻击性/超宽表，标 truncated 但不 fillTo（否则可 OOM）
+                                //  col < 0                 → 缺 `r` 属性或非法值，OOXML 允许省略 `r`，跳过该 cell
+                                if (col in 0 until MAX_COLS) {
+                                    val text = resolveCellText(cellType, cellValue, inlineText, shared)
+                                    fillTo(row, col)
+                                    row[col] = text
+                                } else if (col >= MAX_COLS) {
+                                    truncated = true
+                                }
                             }
                         }
                         "row" -> {
-                            if (rows.size < MAX_ROWS && currentRow != null) rows.add(currentRow!!)
+                            val row = currentRow
+                            if (rows.size < MAX_ROWS && row != null) rows.add(row)
                             currentRow = null
                         }
                     }
@@ -204,14 +224,15 @@ object XlsxParser {
         }
     }
 
-    /** "A1" -> 0, "B1" -> 1, "AA1" -> 26。ref 为空时用 -1（呼叫方需忽略）。 */
+    /** "A1" -> 0, "B1" -> 1, "AA1" -> 26。ref 为空或不含字母时返回 -1（呼叫方需忽略）。 */
     private fun columnIndex(ref: String?): Int {
         if (ref.isNullOrEmpty()) return -1
         var idx = 0
+        var seen = false
         for (ch in ref) {
-            if (ch in 'A'..'Z') idx = idx * 26 + (ch - 'A' + 1) else break
+            if (ch in 'A'..'Z') { idx = idx * 26 + (ch - 'A' + 1); seen = true } else break
         }
-        return idx - 1
+        return if (seen) idx - 1 else -1
     }
 
     private fun fillTo(list: ArrayList<String>, index: Int) {
@@ -236,5 +257,34 @@ object XlsxParser {
             if (ev == XmlPullParser.TEXT) buf.append(parser.text)
         }
         return buf.toString()
+    }
+
+    /** 给 [ZipFile.getInputStream] 套一层 [MAX_ENTRY_BYTES] 字节上限，防 zip-bomb。 */
+    private fun boundedStream(zip: ZipFile, entry: ZipEntry): InputStream =
+        BoundedInputStream(zip.getInputStream(entry), MAX_ENTRY_BYTES)
+
+    /** 只在超过上限时抛 [IOException]，让 parse() 整体失败上抛给 UI 展示"预览失败"。 */
+    private class BoundedInputStream(
+        private val delegate: InputStream,
+        private val maxBytes: Long,
+    ) : InputStream() {
+        private var consumed: Long = 0L
+        override fun read(): Int {
+            val b = delegate.read()
+            if (b >= 0) {
+                consumed++
+                if (consumed > maxBytes) throw IOException("xlsx entry exceeds $maxBytes bytes")
+            }
+            return b
+        }
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            val n = delegate.read(b, off, len)
+            if (n > 0) {
+                consumed += n
+                if (consumed > maxBytes) throw IOException("xlsx entry exceeds $maxBytes bytes")
+            }
+            return n
+        }
+        override fun close() = delegate.close()
     }
 }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/XlsxPreviewActivity.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/XlsxPreviewActivity.kt
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.provider
+
+import android.content.Intent
+import android.graphics.Color
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
+import android.widget.FrameLayout
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.FileProvider
+import com.chat.base.R
+import java.io.File
+import java.util.concurrent.Executors
+
+/**
+ * App 内 xlsx 预览。零依赖解析 → HTML table → WebView 渲染（JS 关闭）。
+ * 对齐 iOS `WKSafeFilePreviewVC` 走 WebKit 渲染 Office 的行为，但 Android WebView
+ * 不能直接吃 xlsx，所以在客户端做一层轻量解析。
+ *
+ * 局限：只显示单元格文本值（`<v>` 或共享字符串），不还原样式 / 数字格式 / 日期格式。
+ * 参考 [XlsxParser] 的 `resolveCellText`。
+ */
+class XlsxPreviewActivity : AppCompatActivity() {
+
+    private var filePath: String = ""
+    private lateinit var webView: WebView
+    private lateinit var progressBar: ProgressBar
+    private lateinit var errorTv: TextView
+    private val executor = Executors.newSingleThreadExecutor()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val title = intent.getStringExtra("title") ?: "Excel"
+        filePath = intent.getStringExtra("filePath") ?: ""
+
+        supportActionBar?.apply {
+            setDisplayHomeAsUpEnabled(true)
+            this.title = title
+        }
+
+        val root = FrameLayout(this).apply {
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            setBackgroundColor(Color.WHITE)
+        }
+        webView = WebView(this).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            // 只渲染受信 HTML 字符串，且解析产物无外链 → JS/文件访问全部关掉
+            settings.javaScriptEnabled = false
+            settings.allowFileAccess = false
+            settings.allowContentAccess = false
+            settings.builtInZoomControls = true
+            settings.displayZoomControls = false
+            settings.useWideViewPort = true
+            settings.loadWithOverviewMode = true
+        }
+        progressBar = ProgressBar(this).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT
+            ).apply { gravity = android.view.Gravity.CENTER }
+        }
+        errorTv = TextView(this).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT
+            ).apply { gravity = android.view.Gravity.CENTER }
+            textSize = 14f
+            visibility = View.GONE
+        }
+        root.addView(webView)
+        root.addView(progressBar)
+        root.addView(errorTv)
+        setContentView(root)
+
+        parseAsync()
+    }
+
+    private fun parseAsync() {
+        val file = File(filePath)
+        if (!file.exists()) {
+            showError(getString(R.string.str_file_not_exist))
+            return
+        }
+        executor.execute {
+            val result = runCatching { XlsxParser.parse(file) }
+            runOnUiThread {
+                if (isFinishing || isDestroyed) return@runOnUiThread
+                progressBar.visibility = View.GONE
+                result.onSuccess { renderWorkbook(it) }
+                    .onFailure { showError("无法预览此 Excel 文件") }
+            }
+        }
+    }
+
+    private fun renderWorkbook(wb: XlsxParser.Workbook) {
+        if (wb.sheets.isEmpty()) {
+            showError("空表格")
+            return
+        }
+        val html = buildHtml(wb)
+        webView.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
+    }
+
+    private fun showError(msg: String) {
+        webView.visibility = View.GONE
+        errorTv.text = msg
+        errorTv.visibility = View.VISIBLE
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menu.add(0, MENU_SAVE, 0, R.string.str_file_save_to)
+            .setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER)
+        menu.add(0, MENU_SHARE, 1, R.string.str_file_share)
+            .setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> { finish(); true }
+            MENU_SAVE -> { saveFile(); true }
+            MENU_SHARE -> { shareFile(); true }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun saveFile() {
+        if (filePath.isEmpty()) return
+        val file = File(filePath)
+        if (!file.exists()) return
+        val intent = Intent(this, FileSaveActivity::class.java)
+        intent.putExtra("sourceFilePath", file.absolutePath)
+        intent.putExtra("fileName", file.name)
+        startActivity(intent)
+    }
+
+    private fun shareFile() {
+        if (filePath.isEmpty()) return
+        val file = File(filePath)
+        if (!file.exists()) return
+        try {
+            val uri = FileProvider.getUriForFile(this, "$packageName.fileProvider", file)
+            val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                type = WKFileProvider.getMimeType(file.name)
+                putExtra(Intent.EXTRA_STREAM, uri)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            startActivity(Intent.createChooser(shareIntent, file.name))
+        } catch (_: Exception) {
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        executor.shutdownNow()
+        try { webView.destroy() } catch (_: Exception) {}
+    }
+
+    private fun buildHtml(wb: XlsxParser.Workbook): String {
+        val sb = StringBuilder(4096)
+        sb.append("<!DOCTYPE html><html><head><meta charset='utf-8'>")
+        sb.append("<meta name='viewport' content='width=device-width,initial-scale=1'>")
+        sb.append("<style>")
+        sb.append("body{margin:0;padding:0;font-family:-apple-system,sans-serif;font-size:12px;color:#222;}")
+        sb.append(".tabs{position:sticky;top:0;background:#F5F5F5;border-bottom:1px solid #DDD;padding:6px 8px;white-space:nowrap;overflow-x:auto;}")
+        sb.append(".tabs a{display:inline-block;padding:4px 10px;margin-right:4px;border:1px solid #CCC;border-radius:4px;color:#333;text-decoration:none;background:#FFF;}")
+        sb.append(".sheet{padding:8px;overflow-x:auto;}")
+        sb.append(".sheet h3{margin:12px 0 6px 0;font-size:13px;color:#666;}")
+        sb.append("table{border-collapse:collapse;}")
+        sb.append("td{border:1px solid #DDD;padding:4px 8px;white-space:nowrap;max-width:240px;overflow:hidden;text-overflow:ellipsis;}")
+        sb.append("tr:nth-child(even) td{background:#FAFAFA;}")
+        sb.append(".trunc{color:#999;font-size:11px;padding:6px 4px;}")
+        sb.append("</style></head><body>")
+
+        if (wb.sheets.size > 1) {
+            sb.append("<div class='tabs'>")
+            wb.sheets.forEachIndexed { i, s ->
+                sb.append("<a href='#s$i'>").append(escape(s.name)).append("</a>")
+            }
+            sb.append("</div>")
+        }
+
+        wb.sheets.forEachIndexed { i, s ->
+            sb.append("<div class='sheet' id='s").append(i).append("'>")
+            if (wb.sheets.size > 1) sb.append("<h3>").append(escape(s.name)).append("</h3>")
+            sb.append("<table>")
+            for (row in s.rows) {
+                sb.append("<tr>")
+                for (cell in row) {
+                    sb.append("<td>").append(escape(cell)).append("</td>")
+                }
+                sb.append("</tr>")
+            }
+            sb.append("</table>")
+            if (s.truncated) {
+                sb.append("<div class='trunc'>已截断显示（>")
+                sb.append(XlsxParser.MAX_ROWS).append("行 或 >")
+                sb.append(XlsxParser.MAX_COLS).append("列），完整内容请用其它应用打开</div>")
+            }
+            sb.append("</div>")
+        }
+
+        sb.append("</body></html>")
+        return sb.toString()
+    }
+
+    private fun escape(s: String): String {
+        if (s.isEmpty()) return ""
+        val sb = StringBuilder(s.length + 8)
+        for (ch in s) {
+            when (ch) {
+                '&' -> sb.append("&amp;")
+                '<' -> sb.append("&lt;")
+                '>' -> sb.append("&gt;")
+                '"' -> sb.append("&quot;")
+                '\'' -> sb.append("&#39;")
+                else -> sb.append(ch)
+            }
+        }
+        return sb.toString()
+    }
+
+    companion object {
+        private const val MENU_SAVE = 1001
+        private const val MENU_SHARE = 1002
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/AddToMyStickersMenuProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/AddToMyStickersMenuProvider.kt
@@ -10,9 +10,7 @@
 
 package com.chat.uikit.chat.sticker
 
-import android.text.TextUtils
 import com.chat.base.WKBaseApplication
-import com.chat.base.config.WKConfig
 import com.chat.base.endpoint.EndpointCategory
 import com.chat.base.endpoint.EndpointManager
 import com.chat.base.endpoint.entity.ChatItemPopupMenu
@@ -29,11 +27,14 @@ import com.xinbida.wukongim.message.type.WKMsgContentType
  * 通过 EndpointCategory.wkChatPopupItem 注册，与其他长按项（copy / create_thread /
  * forward / withdraw）平级 —— 不侵入 WKChatBaseProvider.getPopupList()。
  *
- * 过滤逻辑：
- *   msg.type 必须是 12 或 13 —— 其它消息返回 null，菜单不加。
- *   msg.fromUID == self.uid → 自己发的贴图不出菜单（iOS 未做此过滤，Android 主动优化：
- *     自己刚发出的贴图本就该在收藏里，或即将成为，再让用户"添加"逻辑上冗余）。
- *   URL 已在缓存里 → 视为已收藏，返回 null（对齐 iOS collectStickers 检查）。
+ * 过滤逻辑（对齐 iOS）：
+ *   - msg.type 必须是 12 或 13
+ *   - URL 已在缓存里视为已收藏，返回 null
+ *
+ * 早期版本还额外过滤 "msg.fromUID == self.uid"（自己发的贴图不弹菜单），
+ * 但这会误伤"用户删了自定义表情后想重新添加"的场景：删除后 isCollected=false，
+ * 本应弹菜单，但如果这条消息恰好是删除前自己用过发出去的，fromUID==self 直接被
+ * 拦掉。iOS 未做此过滤 —— 已移除，回归 iOS 行为。
  */
 object AddToMyStickersMenuProvider {
 
@@ -51,12 +52,6 @@ object AddToMyStickersMenuProvider {
             ) {
                 return@setMethod null
             }
-            // 自己发的贴图不弹菜单。selfUid 空（未登录 / 冷启动竞态）保守不过滤，
-            // 交给下面已收藏判断兜底。
-            val selfUid = WKConfig.getInstance().uid
-            if (!TextUtils.isEmpty(selfUid) && selfUid == msg.fromUID) {
-                return@setMethod null
-            }
             val content = msg.baseContentMsgModel as? WKVectorStickerContent ?: return@setMethod null
             val url = content.url
             if (url.isNullOrEmpty()) return@setMethod null
@@ -65,7 +60,10 @@ object AddToMyStickersMenuProvider {
             val label = WKBaseApplication.getInstance().context
                 .getString(BaseR.string.str_add_to_my_stickers)
             ChatItemPopupMenu(
-                R.mipmap.icon_chat_toolbar_emoji,
+                // 用矢量图 ic_menu_add_to_stickers（贴纸框 + "+" 徽章），与 msg_copy /
+                // msg_forward 同为 24dp 灰度线条风格。之前用 icon_chat_toolbar_emoji
+                // （输入面板的黄脸大图标）在长按菜单里颜色/尺寸都突兀。
+                R.drawable.ic_menu_add_to_stickers,
                 label,
                 object : ChatItemPopupMenu.IPopupItemClick {
                     override fun onClick(mMsg: WKMsg, iConversationContext: IConversationContext) {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/AddToMyStickersMenuProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/AddToMyStickersMenuProvider.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker
+
+import android.text.TextUtils
+import com.chat.base.WKBaseApplication
+import com.chat.base.config.WKConfig
+import com.chat.base.endpoint.EndpointCategory
+import com.chat.base.endpoint.EndpointManager
+import com.chat.base.endpoint.entity.ChatItemPopupMenu
+import com.chat.base.msg.IConversationContext
+import com.chat.base.msg.model.WKVectorStickerContent
+import com.chat.base.R as BaseR
+import com.chat.uikit.R
+import com.xinbida.wukongim.entity.WKMsg
+import com.xinbida.wukongim.message.type.WKMsgContentType
+
+/**
+ * 长按贴图消息 → 弹出"添加到我的表情"菜单，收藏后 WKStickerManager 缓存自更新。
+ *
+ * 通过 EndpointCategory.wkChatPopupItem 注册，与其他长按项（copy / create_thread /
+ * forward / withdraw）平级 —— 不侵入 WKChatBaseProvider.getPopupList()。
+ *
+ * 过滤逻辑：
+ *   msg.type 必须是 12 或 13 —— 其它消息返回 null，菜单不加。
+ *   msg.fromUID == self.uid → 自己发的贴图不出菜单（iOS 未做此过滤，Android 主动优化：
+ *     自己刚发出的贴图本就该在收藏里，或即将成为，再让用户"添加"逻辑上冗余）。
+ *   URL 已在缓存里 → 视为已收藏，返回 null（对齐 iOS collectStickers 检查）。
+ */
+object AddToMyStickersMenuProvider {
+
+    private const val SID = "add_to_my_stickers"
+
+    // sort 数值越小越靠前。iOS 长按面板里"添加表情"排在撤回/转发之后，用 20 即可
+    // （create_thread 用 10，copy 用 90）。
+    private const val SORT = 20
+
+    fun register() {
+        EndpointManager.getInstance().setMethod(SID, EndpointCategory.wkChatPopupItem, SORT) { obj ->
+            val msg = obj as? WKMsg ?: return@setMethod null
+            if (msg.type != WKMsgContentType.WK_VECTOR_STICKER &&
+                msg.type != WKMsgContentType.WK_EMOJI_STICKER
+            ) {
+                return@setMethod null
+            }
+            // 自己发的贴图不弹菜单。selfUid 空（未登录 / 冷启动竞态）保守不过滤，
+            // 交给下面已收藏判断兜底。
+            val selfUid = WKConfig.getInstance().uid
+            if (!TextUtils.isEmpty(selfUid) && selfUid == msg.fromUID) {
+                return@setMethod null
+            }
+            val content = msg.baseContentMsgModel as? WKVectorStickerContent ?: return@setMethod null
+            val url = content.url
+            if (url.isNullOrEmpty()) return@setMethod null
+            if (WKStickerManager.isCollected(url)) return@setMethod null
+
+            val label = WKBaseApplication.getInstance().context
+                .getString(BaseR.string.str_add_to_my_stickers)
+            ChatItemPopupMenu(
+                R.mipmap.icon_chat_toolbar_emoji,
+                label,
+                object : ChatItemPopupMenu.IPopupItemClick {
+                    override fun onClick(mMsg: WKMsg, iConversationContext: IConversationContext) {
+                        WKStickerManager.collect(mMsg)
+                    }
+                }
+            ).apply { tag = SID }
+        }
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/CollectStickerAdapter.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/CollectStickerAdapter.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker
+
+import com.chad.library.adapter.base.BaseQuickAdapter
+import com.chad.library.adapter.base.viewholder.BaseViewHolder
+import com.chat.base.config.WKApiConfig
+import com.chat.base.glide.GlideUtils
+import com.chat.base.ui.components.FilterImageView
+import com.chat.uikit.R
+
+/**
+ * "我的贴图" 表情面板 grid adapter。
+ * 复用 chat cell provider 的 URL 判定（[StickerUrlUtils]），静态图 Glide 加载，
+ * Lottie 走 default_view_bg 占位。点击回调由外层挂 setOnItemClickListener 处理
+ * （构造 WKVectorStickerContent 并 sendMessage）。
+ */
+class CollectStickerAdapter :
+    BaseQuickAdapter<WKSticker, BaseViewHolder>(R.layout.item_collect_sticker) {
+
+    override fun convert(holder: BaseViewHolder, item: WKSticker) {
+        val imageView = holder.getView<FilterImageView>(R.id.stickerImageView)
+        val url = item.path
+        when {
+            url.isNullOrEmpty() ->
+                imageView.setImageResource(com.chat.base.R.drawable.default_view_bg)
+            StickerUrlUtils.isStaticImage(url) ->
+                GlideUtils.getInstance().showImg(context, WKApiConfig.getShowUrl(url), imageView)
+            StickerUrlUtils.isLottieFormat(url, item.format) ->
+                imageView.setImageResource(com.chat.base.R.drawable.default_view_bg)
+            else ->
+                GlideUtils.getInstance().showImg(context, WKApiConfig.getShowUrl(url), imageView)
+        }
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/CollectStickerAdapter.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/CollectStickerAdapter.kt
@@ -10,34 +10,283 @@
 
 package com.chat.uikit.chat.sticker
 
-import com.chad.library.adapter.base.BaseQuickAdapter
-import com.chad.library.adapter.base.viewholder.BaseViewHolder
+import android.animation.ObjectAnimator
+import android.animation.ValueAnimator
+import android.os.Handler
+import android.os.Looper
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewConfiguration
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.ImageView
+import androidx.recyclerview.widget.RecyclerView
 import com.chat.base.config.WKApiConfig
 import com.chat.base.glide.GlideUtils
 import com.chat.base.ui.components.FilterImageView
 import com.chat.uikit.R
 
 /**
- * "我的贴图" 表情面板 grid adapter。
- * 复用 chat cell provider 的 URL 判定（[StickerUrlUtils]），静态图 Glide 加载，
- * Lottie 走 default_view_bg 占位。点击回调由外层挂 setOnItemClickListener 处理
- * （构造 WKVectorStickerContent 并 sendMessage）。
+ * "我的贴图" 表情面板 grid adapter，1:1 复刻 iOS `WKMyStickerContentView` 交互，
+ * 尤其是编辑态下"长按 hold-still 出预览 / 长按+移动 触发 drag"这条 iOS
+ * `UIContextMenuInteraction` 同时识别路径。
+ *
+ * <h3>viewType 布局</h3>
+ * - position 0 → 首格 "+" 按钮，永远存在
+ * - position 1..N → 用户收藏的 [WKSticker]
+ *
+ * <h3>非编辑态</h3>
+ * - tap sticker → [Callbacks.onStickerClick] 发送
+ * - long-press sticker → [Callbacks.onEnterEditMode]（外层触发 haptic + setEditMode(true)）
+ * - tap "+" → [Callbacks.onAddClick] 打开选图上传
+ *
+ * <h3>编辑态（cells 抖动 + × 徽章显示）</h3>
+ * - tap sticker → 退出编辑态（对齐 iOS "tap in edit exits"）
+ * - tap × 徽章 → [Callbacks.onDeleteSticker] 二次确认删除
+ * - long-press hold-still ≥500ms → [Callbacks.onPreviewSticker] 弹预览
+ * - long-press 立即移动（超 touchSlop）→ [Callbacks.startDrag] 触发拖拽
+ * - 空白 / 切 tab / "+" → 由外层 PanelManager 处理退出
+ *
+ * 编辑态下不用 `setOnLongClickListener`，改用 [View.OnTouchListener] 自己判定：
+ * 系统 long-press timer (~500ms) 和我们的预览 timer 一起就会打架，把预览和 drag
+ * 两个动作都塞进同一个 500ms 触发点里根本区分不开；OnTouchListener 里根据是否
+ * 移动过 slop 分流才是干净的方案。同时 [ItemTouchHelper.isLongPressDragEnabled]
+ * 必须置为 false，drag 由我们手动 [Callbacks.startDrag] 触发。
  */
-class CollectStickerAdapter :
-    BaseQuickAdapter<WKSticker, BaseViewHolder>(R.layout.item_collect_sticker) {
+class CollectStickerAdapter(
+    private val callbacks: Callbacks
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
-    override fun convert(holder: BaseViewHolder, item: WKSticker) {
-        val imageView = holder.getView<FilterImageView>(R.id.stickerImageView)
+    interface Callbacks {
+        fun onAddClick()
+        fun onStickerClick(sticker: WKSticker, position: Int)
+        fun onEnterEditMode()
+        fun onPreviewSticker(sticker: WKSticker, position: Int)
+        fun onDeleteSticker(sticker: WKSticker, position: Int)
+        fun startDrag(viewHolder: RecyclerView.ViewHolder)
+    }
+
+    private val stickers: MutableList<WKSticker> = mutableListOf()
+    private var editMode: Boolean = false
+
+    fun submitList(list: List<WKSticker>) {
+        stickers.clear()
+        stickers.addAll(list)
+        notifyDataSetChanged()
+    }
+
+    fun setEditMode(enabled: Boolean) {
+        if (editMode == enabled) return
+        editMode = enabled
+        notifyDataSetChanged()
+    }
+
+    fun isEditMode(): Boolean = editMode
+
+    /** 拖拽重排：交换 adapter 位置 [from] 和 [to]（均为 adapter position，含首格 +）。 */
+    fun moveItem(from: Int, to: Int): Boolean {
+        if (from == 0 || to == 0) return false // "+" 首格不参与
+        val fromStickerIdx = from - 1
+        val toStickerIdx = to - 1
+        if (fromStickerIdx !in stickers.indices || toStickerIdx !in stickers.indices) return false
+        val moved = stickers.removeAt(fromStickerIdx)
+        stickers.add(toStickerIdx, moved)
+        notifyItemMoved(from, to)
+        return true
+    }
+
+    /** 拖拽结束后取当前顺序（sticker_id 列表，不含首格 +）用于 [WKStickerManager.reorder]。 */
+    fun currentOrderIds(): List<String> = stickers.map { it.sticker_id }
+
+    fun getStickerAt(position: Int): WKSticker? {
+        if (position <= 0 || position > stickers.size) return null
+        return stickers[position - 1]
+    }
+
+    override fun getItemCount(): Int = stickers.size + 1
+
+    override fun getItemViewType(position: Int): Int =
+        if (position == 0) VIEW_ADD else VIEW_STICKER
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return if (viewType == VIEW_ADD) {
+            AddVH(inflater.inflate(R.layout.item_collect_sticker_add, parent, false))
+        } else {
+            StickerVH(inflater.inflate(R.layout.item_collect_sticker, parent, false))
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder) {
+            is AddVH -> {
+                holder.itemView.setOnClickListener { callbacks.onAddClick() }
+            }
+            is StickerVH -> {
+                val sticker = stickers[position - 1]
+                bindStickerImage(holder.imageView, sticker)
+                holder.deleteBadge.visibility = if (editMode) View.VISIBLE else View.GONE
+                if (editMode) holder.startShake() else holder.stopShake()
+                bindStickerListeners(holder, sticker)
+            }
+        }
+    }
+
+    private fun bindStickerListeners(holder: StickerVH, sticker: WKSticker) {
+        if (editMode) {
+            // 编辑态：tap = 退出编辑；长按 hold-still = 预览；长按 + 移动 = drag
+            holder.itemView.setOnLongClickListener(null)
+            holder.itemView.setOnClickListener {
+                setEditMode(false)
+            }
+            holder.itemView.setOnTouchListener(
+                EditModeTouchListener(holder, sticker, callbacks)
+            )
+        } else {
+            // 非编辑态：tap = 发送；长按 = 进编辑态
+            holder.itemView.setOnTouchListener(null)
+            holder.itemView.setOnClickListener {
+                callbacks.onStickerClick(sticker, holder.bindingAdapterPosition)
+            }
+            holder.itemView.setOnLongClickListener {
+                callbacks.onEnterEditMode()
+                true
+            }
+        }
+        holder.deleteBadge.setOnClickListener {
+            callbacks.onDeleteSticker(sticker, holder.bindingAdapterPosition)
+        }
+    }
+
+    override fun onViewRecycled(holder: RecyclerView.ViewHolder) {
+        if (holder is StickerVH) {
+            holder.stopShake()
+            holder.itemView.setOnTouchListener(null)
+        }
+        super.onViewRecycled(holder)
+    }
+
+    private fun bindStickerImage(imageView: FilterImageView, item: WKSticker) {
         val url = item.path
+        val ctx = imageView.context
         when {
             url.isNullOrEmpty() ->
                 imageView.setImageResource(com.chat.base.R.drawable.default_view_bg)
             StickerUrlUtils.isStaticImage(url) ->
-                GlideUtils.getInstance().showImg(context, WKApiConfig.getShowUrl(url), imageView)
+                GlideUtils.getInstance().showImg(ctx, WKApiConfig.getShowUrl(url), imageView)
             StickerUrlUtils.isLottieFormat(url, item.format) ->
                 imageView.setImageResource(com.chat.base.R.drawable.default_view_bg)
             else ->
-                GlideUtils.getInstance().showImg(context, WKApiConfig.getShowUrl(url), imageView)
+                GlideUtils.getInstance().showImg(ctx, WKApiConfig.getShowUrl(url), imageView)
         }
+    }
+
+    /**
+     * 编辑态下 sticker cell 的 touch dispatcher：模拟 iOS UIContextMenuInteraction
+     * 的"按住 hold-still → context menu / 按住立即 move → drag"分流。
+     *
+     * 流程：
+     * - ACTION_DOWN：记录起点，post 500ms 后的 preview Runnable
+     * - ACTION_MOVE：位移超 touchSlop → 取消 preview，改为 drag，标记 [dragStarted]
+     * - ACTION_UP / CANCEL：撤 preview 定时器；若已 fire 过 preview / drag → 消费 UP
+     *   阻断后续 click（不然预览完抬手会走到 [setOnClickListener] 触发 exit edit）
+     *
+     * 返回值：DOWN 一律 false 让 click 通道保留（真 tap 场景下 UP 时才决定是否消费）。
+     */
+    private class EditModeTouchListener(
+        private val holder: RecyclerView.ViewHolder,
+        private val sticker: WKSticker,
+        private val callbacks: Callbacks,
+    ) : View.OnTouchListener {
+
+        private val handler = Handler(Looper.getMainLooper())
+        private val previewDelayMs = 500L
+        private var downX = 0f
+        private var downY = 0f
+        private var slop = 0
+        private var previewFired = false
+        private var dragStarted = false
+        private var previewRunnable: Runnable? = null
+
+        @Suppress("ClickableViewAccessibility")
+        override fun onTouch(v: View, e: MotionEvent): Boolean {
+            when (e.actionMasked) {
+                MotionEvent.ACTION_DOWN -> {
+                    downX = e.x
+                    downY = e.y
+                    previewFired = false
+                    dragStarted = false
+                    slop = ViewConfiguration.get(v.context).scaledTouchSlop
+                    val r = Runnable {
+                        if (!dragStarted) {
+                            previewFired = true
+                            callbacks.onPreviewSticker(sticker, holder.bindingAdapterPosition)
+                        }
+                    }
+                    previewRunnable = r
+                    handler.postDelayed(r, previewDelayMs)
+                    return false
+                }
+                MotionEvent.ACTION_MOVE -> {
+                    if (dragStarted || previewFired) return true
+                    val dx = e.x - downX
+                    val dy = e.y - downY
+                    if (dx * dx + dy * dy > slop * slop) {
+                        // 用户移动 → 取消 preview 计时器，让 ItemTouchHelper 接管 drag
+                        previewRunnable?.let { handler.removeCallbacks(it) }
+                        dragStarted = true
+                        callbacks.startDrag(holder)
+                        return true
+                    }
+                    return false
+                }
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                    previewRunnable?.let { handler.removeCallbacks(it) }
+                    previewRunnable = null
+                    val consumed = previewFired || dragStarted
+                    // 重置 previewFired 前先读取；下次 DOWN 会重新清零
+                    return consumed
+                }
+            }
+            return false
+        }
+    }
+
+    private class AddVH(view: View) : RecyclerView.ViewHolder(view) {
+        val root: FrameLayout = view.findViewById(R.id.stickerAddRoot)
+    }
+
+    private class StickerVH(view: View) : RecyclerView.ViewHolder(view) {
+        val root: FrameLayout = view.findViewById(R.id.stickerRoot)
+        val imageView: FilterImageView = view.findViewById(R.id.stickerImageView)
+        val deleteBadge: ImageView = view.findViewById(R.id.stickerDeleteBadge)
+
+        private var shakeAnimator: ObjectAnimator? = null
+
+        fun startShake() {
+            if (shakeAnimator?.isRunning == true) return
+            val animator = ObjectAnimator.ofFloat(root, View.ROTATION, -2.2f, 2.2f).apply {
+                duration = 160L
+                repeatMode = ValueAnimator.REVERSE
+                repeatCount = ValueAnimator.INFINITE
+                // 各 cell 用 startDelay 打散，避免整齐同步（对齐 iOS
+                // WKStickerGIFCell 的 arc4random_uniform(160)/1000 相位偏移）
+                startDelay = ((bindingAdapterPosition * 37L) + 13L) % 160L
+            }
+            animator.start()
+            shakeAnimator = animator
+        }
+
+        fun stopShake() {
+            shakeAnimator?.cancel()
+            shakeAnimator = null
+            root.rotation = 0f
+        }
+    }
+
+    companion object {
+        private const val VIEW_ADD = 0
+        private const val VIEW_STICKER = 1
     }
 }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/ListStickerResp.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/ListStickerResp.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker;
+
+import java.util.List;
+
+/**
+ * GET /sticker/user 响应包装。
+ *
+ * 服务端刻意让空集合返回 {"list":[]} 而非 404（issue #26），
+ * 因此外层必须 wrap 一层 list 字段，不能直接反序列化成 List<WKSticker>。
+ */
+public class ListStickerResp {
+    public List<WKSticker> list;
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/LocalOrderStore.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/LocalOrderStore.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker
+
+import android.content.Context
+import com.chat.base.WKBaseApplication
+import com.chat.base.config.WKConfig
+import org.json.JSONArray
+
+/**
+ * 自定义贴纸的本地顺序表。
+ *
+ * 服务端 stickerResp.sort 字段由后端维护，但服务端不暴露"批量重排"接口
+ * （iOS 用的 /sticker/user/front 服务端未实现，见 memory 记录）。为了让用户
+ * 拖拽调整的顺序在本地稳定复现（对齐 iOS 行为），Android 侧把重排结果落在
+ * 本地 SharedPreferences 里。
+ *
+ * <h3>数据格式</h3>
+ * JSON 数组 `["stickerId1", "stickerId2", ...]`，先出现的排在前面。列表加载后：
+ * - 在本表登记过的 id 按此顺序前置
+ * - 未登记的（如后台其他端新增）按服务端返回顺序追加尾部
+ *
+ * <h3>多用户</h3>
+ * SP 文件按 uid 命名：`sticker_order_{uid}`，切换账号自动隔离。
+ * 未登录 (uid == null) 时读写空操作。
+ *
+ * <h3>并发</h3>
+ * 单例、SP 操作走系统内置线程安全；本类不额外加锁。所有 mutator 走 apply()
+ * 异步落盘（同 [com.chat.base.config.WKSharedPreferencesUtil] 的选型理由）。
+ */
+object StickerLocalOrderStore {
+
+    private const val PREF_PREFIX = "sticker_order_"
+    private const val KEY_ORDER = "order"
+
+    private fun prefsOrNull(): android.content.SharedPreferences? {
+        val uid = WKConfig.getInstance().uid
+        if (uid.isNullOrEmpty()) return null
+        val ctx = WKBaseApplication.getInstance().context ?: return null
+        return ctx.getSharedPreferences(PREF_PREFIX + uid, Context.MODE_PRIVATE)
+    }
+
+    /** 读取当前用户的本地顺序。列表为空 = 从未登记过 = 完全按服务端顺序。 */
+    fun read(): List<String> {
+        val raw = prefsOrNull()?.getString(KEY_ORDER, null) ?: return emptyList()
+        return runCatching {
+            val arr = JSONArray(raw)
+            List(arr.length()) { arr.getString(it) }
+        }.getOrElse { emptyList() }
+    }
+
+    /** 全量覆盖当前用户的本地顺序（拖拽结束时调）。 */
+    fun write(ids: List<String>) {
+        val prefs = prefsOrNull() ?: return
+        val arr = JSONArray()
+        ids.forEach { arr.put(it) }
+        prefs.edit().putString(KEY_ORDER, arr.toString()).apply()
+    }
+
+    /** 追加一个 id 到本地顺序末尾（收藏成功时调）。已存在则不动。 */
+    fun append(id: String) {
+        if (id.isEmpty()) return
+        val current = read()
+        if (current.contains(id)) return
+        write(current + id)
+    }
+
+    /** 从本地顺序移除一个 id（删除成功时调）。 */
+    fun remove(id: String) {
+        if (id.isEmpty()) return
+        val current = read()
+        if (!current.contains(id)) return
+        write(current.filterNot { it == id })
+    }
+
+    /** 与服务端返回的 id 集合求交集，剔除本地存在但服务端已删的 id。
+     *  在 [WKStickerManager.load] 成功后调用，防止本地表越涨越大。 */
+    fun prune(validIds: Set<String>) {
+        val current = read()
+        val pruned = current.filter { it in validIds }
+        if (pruned.size != current.size) write(pruned)
+    }
+
+    /**
+     * 按本地顺序对服务端返回列表排序：登记过的 id 按本地顺序前置，
+     * 未登记的按 [serverList] 原顺序追加尾部（这是"其他端刚加的"或"从未拖过的"）。
+     */
+    fun applyOrder(serverList: List<WKSticker>): List<WKSticker> {
+        return applyOrder(read(), serverList)
+    }
+
+    /** 纯函数版本（测试用）：给定顺序表和服务端列表，返回排序后列表。 */
+    @JvmStatic
+    fun applyOrder(orderedIds: List<String>, serverList: List<WKSticker>): List<WKSticker> {
+        if (orderedIds.isEmpty()) return serverList
+
+        val byId = serverList.associateBy { it.sticker_id }
+        val registered = orderedIds.mapNotNull { byId[it] }
+        val registeredIds = registered.mapTo(mutableSetOf()) { it.sticker_id }
+        val tail = serverList.filterNot { it.sticker_id in registeredIds }
+        return registered + tail
+    }
+
+    /** 纯函数版本（测试用）：给定原顺序表与合法 id 集，返回修剪后顺序表。 */
+    @JvmStatic
+    fun pruneOrder(orderedIds: List<String>, validIds: Set<String>): List<String> =
+        orderedIds.filter { it in validIds }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/StickerDetailPopup.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/StickerDetailPopup.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker
+
+import android.app.Dialog
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.view.LayoutInflater
+import android.view.View
+import android.view.Window
+import androidx.appcompat.widget.AppCompatTextView
+import com.chat.base.R as BaseR
+import com.chat.base.config.WKApiConfig
+import com.chat.base.glide.GlideUtils
+import com.chat.base.msg.model.WKVectorStickerContent
+import com.chat.base.ui.components.FilterImageView
+import com.chat.base.utils.WKDialogUtils
+import com.chat.uikit.R
+import com.chat.uikit.chat.manager.WKSendMsgUtils
+import com.xinbida.wukongim.entity.WKMsg
+import com.xinbida.wukongim.entity.WKMsgSetting
+
+/**
+ * 贴纸详情/预览弹窗。中央 180dp 预览 + 底部两个动作。
+ *
+ * 两个入口：
+ *   - [showForChatMessage] —— 点击聊天里贴图消息触发。动作 [发送 / 添加到我的表情]。
+ *     若已收藏，隐藏"添加"按钮，"发送"占满整行。
+ *   - [showForPanel] —— 长按"我的表情"面板里的自定义贴图触发（对齐 iOS 长按放大预览）。
+ *     动作 [发送 / 删除]。删除走二次确认。
+ *
+ * 两种模式共用同一份 `dialog_sticker_detail.xml` 布局，仅底部动作行的文案/回调不同。
+ * 对齐 iOS `WKPOINT_TO_STICKER_INFO` 与 `UIContextMenuInteraction` 的合并简化版。
+ */
+object StickerDetailPopup {
+
+    /** 消息内点击贴图 → 预览 + [发送 / 添加到我的表情]。 */
+    fun showForChatMessage(context: Context, msg: WKMsg) {
+        val content = msg.baseContentMsgModel as? WKVectorStickerContent ?: return
+        val url = content.url ?: return
+
+        showInternal(
+            context = context,
+            url = url,
+            format = content.format,
+            primaryText = context.getString(BaseR.string.str_sticker_send),
+            primaryAction = { resendSticker(msg, content) },
+            secondaryText = if (WKStickerManager.isCollected(url)) null
+                else context.getString(BaseR.string.str_add_to_my_stickers),
+            secondaryAction = if (WKStickerManager.isCollected(url)) null
+                else { { WKStickerManager.collect(msg) } }
+        )
+    }
+
+    /** 长按面板里已收藏的贴图 → 预览 + [发送 / 删除]。 */
+    fun showForPanel(context: Context, sticker: WKSticker, onSend: (WKSticker) -> Unit) {
+        val url = sticker.path ?: return
+        showInternal(
+            context = context,
+            url = url,
+            format = sticker.format,
+            primaryText = context.getString(BaseR.string.str_sticker_send),
+            primaryAction = { onSend(sticker) },
+            secondaryText = context.getString(BaseR.string.str_delete),
+            secondaryAction = {
+                // 二次确认后走 API 删除
+                WKDialogUtils.getInstance().showDialog(
+                    context,
+                    null,
+                    context.getString(BaseR.string.str_sticker_delete_confirm),
+                    true,
+                    context.getString(BaseR.string.cancel),
+                    context.getString(BaseR.string.sure),
+                    0, 0
+                ) { which ->
+                    if (which == 1) WKStickerManager.delete(sticker.sticker_id, null)
+                }
+            }
+        )
+    }
+
+    private fun showInternal(
+        context: Context,
+        url: String,
+        format: String?,
+        primaryText: String,
+        primaryAction: () -> Unit,
+        secondaryText: String?,
+        secondaryAction: (() -> Unit)?,
+    ) {
+        val view = LayoutInflater.from(context).inflate(R.layout.dialog_sticker_detail, null)
+        val image = view.findViewById<FilterImageView>(R.id.stickerDetailImage)
+        val primaryBtn = view.findViewById<AppCompatTextView>(R.id.stickerDetailSend)
+        val secondaryBtn = view.findViewById<AppCompatTextView>(R.id.stickerDetailAdd)
+        val divider = view.findViewById<View>(R.id.stickerDetailDivider)
+
+        // 静态图走 Glide，Lottie / 未知走占位（复用 provider 的判定）
+        when {
+            StickerUrlUtils.isStaticImage(url) ->
+                GlideUtils.getInstance().showImg(context, WKApiConfig.getShowUrl(url), image)
+            StickerUrlUtils.isLottieFormat(url, format) ->
+                image.setImageResource(BaseR.drawable.default_view_bg)
+            else ->
+                GlideUtils.getInstance().showImg(context, WKApiConfig.getShowUrl(url), image)
+        }
+
+        val dialog = Dialog(context).apply {
+            requestWindowFeature(Window.FEATURE_NO_TITLE)
+            setContentView(view)
+            setCanceledOnTouchOutside(true)
+            window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        }
+
+        primaryBtn.text = primaryText
+        primaryBtn.setOnClickListener {
+            primaryAction()
+            dialog.dismiss()
+        }
+
+        if (secondaryText != null && secondaryAction != null) {
+            secondaryBtn.text = secondaryText
+            secondaryBtn.setOnClickListener {
+                secondaryAction()
+                dialog.dismiss()
+            }
+        } else {
+            // 无第二动作 → 隐藏"添加"按钮 + 分隔线，主动作按钮占满整行
+            secondaryBtn.visibility = View.GONE
+            divider.visibility = View.GONE
+        }
+
+        dialog.show()
+    }
+
+    /** 快速转发：构造一条新 WKMsg 用相同 content 发送到当前频道。 */
+    private fun resendSticker(origin: WKMsg, content: WKVectorStickerContent) {
+        val copy = WKVectorStickerContent().apply {
+            url = content.url
+            width = content.width
+            height = content.height
+            category = content.category
+            placeholder = content.placeholder
+            format = content.format
+        }
+        val newMsg = WKMsg().apply {
+            channelID = origin.channelID
+            channelType = origin.channelType
+            baseContentMsgModel = copy
+            setting = WKMsgSetting()
+        }
+        WKSendMsgUtils.getInstance().sendMessage(newMsg)
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/StickerService.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/StickerService.java
@@ -11,25 +11,36 @@
 package com.chat.uikit.chat.sticker;
 
 import com.alibaba.fastjson.JSONObject;
+import com.chat.base.net.entity.CommonResponse;
 
 import io.reactivex.rxjava3.core.Observable;
 import retrofit2.http.Body;
+import retrofit2.http.DELETE;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
+import retrofit2.http.Path;
 
 /**
- * 用户收藏贴纸接口（Octo server /modules/sticker/api.go）。
+ * 用户收藏 / 上传贴纸接口（Octo server /modules/sticker/api.go）。
  *
  * Retrofit baseUrl 已包含 /v1/ 前缀（见 RetrofitUtils），此处路径不带 /v1。
  *
- * 关键差异：iOS 用 `POST /sticker/user` 收藏消息里的贴图 —— 那是"上传自己
- * 贴纸"接口，服务端会做 `path 必须以 sticker/{loginUID}/ 开头` 校验 → 收藏
- * 他人贴纸时永远 400。Android 走 `POST /sticker/user/collect` —— 服务端专门
- * 为"从消息收藏他人贴图"设计的入口：不需要 handle 签名、允许他人 uid 前缀、
- * 天然幂等（SHA256(source_path) 唯一键）。
+ * <h3>接口分工</h3>
+ * <ul>
+ *   <li>{@link #getMyStickers()} —— GET /sticker/user，列当前用户全部收藏</li>
+ *   <li>{@link #collectSticker(JSONObject)} —— POST /sticker/user/collect，
+ *       "从他人消息里收藏贴图"专用入口。允许他人 uid 前缀、不需要 handle 签名、
+ *       天然幂等（SHA256(source_path) 唯一键）</li>
+ *   <li>{@link #uploadSticker(JSONObject)} —— POST /sticker/user，
+ *       "上传自己的贴纸"入口。path 必须以 sticker/{loginUID}/ 开头，
+ *       服务端可能要求 handle 字段（HMAC 签名，视配置 sticker.handle_required）</li>
+ *   <li>{@link #deleteSticker(String)} —— DELETE /sticker/user/{sticker_id}，
+ *       单条软删</li>
+ * </ul>
  *
- * 未包含：`DELETE /sticker/user/{stickerId}` —— Android 当前无"取消收藏" UI，
- * 按需再加即可（服务端接口存在）。
+ * <h3>为什么 collect 走单独入口</h3>
+ * iOS 端历史上错用 POST /sticker/user 收藏他人贴图 —— 服务端 uid 前缀校验直接
+ * 400 → iOS "添加表情"无反应。Android 从一开始就走 /collect 这条正确路径。
  */
 public interface StickerService {
 
@@ -39,4 +50,13 @@ public interface StickerService {
     // 收藏他人消息里的贴纸。body: {path, placeholder?, sort?, shortcode?, keywords?}
     @POST("sticker/user/collect")
     Observable<WKSticker> collectSticker(@Body JSONObject body);
+
+    // 上传自己的贴纸（需先走 /file/upload 拿到 path）。
+    // body: {path, width, height, format, handle?}
+    @POST("sticker/user")
+    Observable<WKSticker> uploadSticker(@Body JSONObject body);
+
+    // 删除单条收藏（服务端软删）。204/200 都视为成功。
+    @DELETE("sticker/user/{sticker_id}")
+    Observable<CommonResponse> deleteSticker(@Path("sticker_id") String stickerId);
 }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/StickerService.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/StickerService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker;
+
+import com.alibaba.fastjson.JSONObject;
+
+import io.reactivex.rxjava3.core.Observable;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+
+/**
+ * 用户收藏贴纸接口（Octo server /modules/sticker/api.go）。
+ *
+ * Retrofit baseUrl 已包含 /v1/ 前缀（见 RetrofitUtils），此处路径不带 /v1。
+ *
+ * 关键差异：iOS 用 `POST /sticker/user` 收藏消息里的贴图 —— 那是"上传自己
+ * 贴纸"接口，服务端会做 `path 必须以 sticker/{loginUID}/ 开头` 校验 → 收藏
+ * 他人贴纸时永远 400。Android 走 `POST /sticker/user/collect` —— 服务端专门
+ * 为"从消息收藏他人贴图"设计的入口：不需要 handle 签名、允许他人 uid 前缀、
+ * 天然幂等（SHA256(source_path) 唯一键）。
+ *
+ * 未包含：`DELETE /sticker/user/{stickerId}` —— Android 当前无"取消收藏" UI，
+ * 按需再加即可（服务端接口存在）。
+ */
+public interface StickerService {
+
+    @GET("sticker/user")
+    Observable<ListStickerResp> getMyStickers();
+
+    // 收藏他人消息里的贴纸。body: {path, placeholder?, sort?, shortcode?, keywords?}
+    @POST("sticker/user/collect")
+    Observable<WKSticker> collectSticker(@Body JSONObject body);
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/StickerUploadValidator.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/StickerUploadValidator.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker
+
+import android.graphics.BitmapFactory
+import com.chat.base.R as BaseR
+import java.io.File
+import java.io.FileInputStream
+import java.io.IOException
+
+/**
+ * 上传自己贴纸的客户端校验。与 iOS `WKStickerUploadService` 校验规则 1:1 对齐：
+ *
+ * - 格式白名单：gif / png / jpg / jpeg / webp（读文件头 magic bytes，不能只信后缀）
+ * - 文件大小 ≤ [MAX_FILE_BYTES] (1 MB)
+ * - 图片长边 ≤ [MAX_DIMENSION_PX] (512 px)
+ *
+ * 使用方式：[validate] 返回 [Result.success] 或带 stringResId 的 [Result.failure]，
+ * 呼叫方 toast 对应字符串即可。BitmapFactory 用 inJustDecodeBounds 只读元数据不解码
+ * 完整图像，走磁盘一次 IO 即可完成尺寸校验。
+ */
+object StickerUploadValidator {
+
+    const val MAX_FILE_BYTES: Long = 1024 * 1024
+    const val MAX_DIMENSION_PX: Int = 512
+
+    enum class Format(val ext: String) {
+        GIF("gif"), PNG("png"), JPEG("jpg"), WEBP("webp");
+    }
+
+    /** 校验结果：成功带 [Meta] 数据（宽/高/格式）；失败带 UI 层直接可用的 stringResId。 */
+    data class Meta(val width: Int, val height: Int, val format: Format)
+
+    sealed class Failure(val stringResId: Int) {
+        object UnsupportedFormat : Failure(BaseR.string.str_sticker_format_unsupported)
+        object TooLarge : Failure(BaseR.string.str_sticker_too_large)
+        object DimensionTooLarge : Failure(BaseR.string.str_sticker_dim_too_large)
+        object IoError : Failure(BaseR.string.str_sticker_upload_failed)
+    }
+
+    fun validate(file: File): Result<Meta> {
+        if (!file.exists() || !file.isFile) return Result.failure(FailureException(Failure.IoError))
+        if (file.length() > MAX_FILE_BYTES) return Result.failure(FailureException(Failure.TooLarge))
+
+        val format = detectFormat(file) ?: return Result.failure(FailureException(Failure.UnsupportedFormat))
+
+        val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(file.absolutePath, opts)
+        val width = opts.outWidth
+        val height = opts.outHeight
+        if (width <= 0 || height <= 0) {
+            // WebP animated 或损坏的图 → BitmapFactory 可能拿不到尺寸；宽容处理，让服务端兜底
+            return Result.success(Meta(0, 0, format))
+        }
+        if (maxOf(width, height) > MAX_DIMENSION_PX) {
+            return Result.failure(FailureException(Failure.DimensionTooLarge))
+        }
+        return Result.success(Meta(width, height, format))
+    }
+
+    /** 呼叫方拿 stringResId 用：`(result.exceptionOrNull() as? FailureException)?.failure?.stringResId` */
+    class FailureException(val failure: Failure) : RuntimeException()
+
+    /**
+     * 读前 12 字节判 magic：
+     *  GIF: "GIF87a" / "GIF89a"
+     *  PNG: 89 50 4E 47 0D 0A 1A 0A
+     *  JPEG: FF D8 FF
+     *  WEBP: "RIFF" ???? "WEBP"（第 8-11 字节）
+     */
+    internal fun detectFormat(file: File): Format? {
+        val buf = ByteArray(12)
+        try {
+            FileInputStream(file).use { it.read(buf) }
+        } catch (e: IOException) {
+            return null
+        }
+        return detectFormatFromBytes(buf)
+    }
+
+    /** 纯函数版本（测试用）：直接从字节数组识别。 */
+    internal fun detectFormatFromBytes(buf: ByteArray): Format? {
+        return when {
+            startsWithAscii(buf, "GIF87a") || startsWithAscii(buf, "GIF89a") -> Format.GIF
+            buf.size >= 8 && buf[0] == 0x89.toByte() && buf[1] == 0x50.toByte() &&
+                buf[2] == 0x4E.toByte() && buf[3] == 0x47.toByte() -> Format.PNG
+            buf.size >= 3 && buf[0] == 0xFF.toByte() && buf[1] == 0xD8.toByte() &&
+                buf[2] == 0xFF.toByte() -> Format.JPEG
+            buf.size >= 12 && startsWithAscii(buf, "RIFF") &&
+                buf[8] == 'W'.code.toByte() && buf[9] == 'E'.code.toByte() &&
+                buf[10] == 'B'.code.toByte() && buf[11] == 'P'.code.toByte() -> Format.WEBP
+            else -> null
+        }
+    }
+
+    private fun startsWithAscii(buf: ByteArray, prefix: String): Boolean {
+        if (buf.size < prefix.length) return false
+        for (i in prefix.indices) {
+            if (buf[i] != prefix[i].code.toByte()) return false
+        }
+        return true
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/StickerUrlUtils.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/StickerUrlUtils.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker
+
+/**
+ * 贴图 URL 后缀识别 —— 决定 provider / 面板 adapter 用哪种加载策略。
+ *
+ * 服务端 sticker 表的 format 白名单只含静态图（gif/png/jpg/jpeg/webp），
+ * 但历史消息 / iOS 侧 lottie 贴图 URL 是 .lim（Lottie JSON），Android 未引入
+ * lottie 播放能力，`.lim / .json` 归为 lottie 走占位图降级。
+ */
+object StickerUrlUtils {
+
+    private val STATIC_EXTS = setOf("png", "jpg", "jpeg", "webp", "gif")
+    private val LOTTIE_EXTS = setOf("lim", "json")
+
+    /** 是否是 Glide 能直接渲染的静态/动图（含 gif）。 */
+    fun isStaticImage(url: String?): Boolean {
+        val ext = extractExt(url) ?: return false
+        return ext in STATIC_EXTS
+    }
+
+    /** 是否是 lottie 格式（Android 侧走占位）。 */
+    fun isLottieFormat(url: String?, format: String?): Boolean {
+        if (!format.isNullOrEmpty() && format.equals("lim", ignoreCase = true)) return true
+        val ext = extractExt(url) ?: return false
+        return ext in LOTTIE_EXTS
+    }
+
+    /** 从 URL 抽取小写扩展名（不含点），去掉 query/fragment。null 表示无法识别。 */
+    fun extractExt(url: String?): String? {
+        if (url.isNullOrEmpty()) return null
+        val cleanEnd = url.indexOfAny(charArrayOf('?', '#')).let {
+            if (it < 0) url.length else it
+        }
+        val path = url.substring(0, cleanEnd)
+        val dot = path.lastIndexOf('.')
+        val slash = path.lastIndexOf('/')
+        if (dot <= slash || dot == path.length - 1) return null
+        return path.substring(dot + 1).lowercase()
+    }
+
+    /**
+     * 归一化到"可对比"的 URL 形式：剥离 scheme+host+query/fragment，只留路径部分。
+     *
+     * 服务端可能返回绝对 `https://cdn/xxx/abc.png` 或相对 `/xxx/abc.png`
+     * （见 [com.chat.base.config.WKApiConfig.getShowUrl] 兼容逻辑）。消息 wire
+     * 和 `GET /v1/sticker/user` 缓存返回的 URL 格式并不保证一致，直接 `==` 比会漏判：
+     * 已收藏的贴图仍误显示"添加到我的表情"菜单，点后服务端 SHA256 去重返回已存在记录，
+     * 用户看到成功提示但列表没变化——很怪。用归一化的路径部分比较即可稳。
+     *
+     * 空串 / null 返回 null。
+     */
+    fun normalizePath(url: String?): String? {
+        if (url.isNullOrEmpty()) return null
+        val cleanEnd = url.indexOfAny(charArrayOf('?', '#')).let {
+            if (it < 0) url.length else it
+        }
+        val cleaned = url.substring(0, cleanEnd)
+        val lower = cleaned.lowercase()
+        val schemeIdx = lower.indexOf("://")
+        if (schemeIdx < 0) return cleaned.ifEmpty { null }
+        val afterScheme = cleaned.substring(schemeIdx + 3)
+        val slashIdx = afterScheme.indexOf('/')
+        return if (slashIdx < 0) "" else afterScheme.substring(slashIdx)
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/WKSticker.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/WKSticker.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker;
+
+import java.util.List;
+
+/**
+ * 用户收藏贴纸 —— 对齐服务端 stickerResp (modules/sticker/model.go)。
+ *
+ * 字段严格与服务端返回一致：sticker_id / path / category / placeholder /
+ * format / sort / shortcode / keywords。width/height 服务端不返回（表结构里
+ * 也没这两列），Android 侧渲染用固定 160dp。
+ */
+public class WKSticker {
+    public String sticker_id;
+    public String path;          // 可渲染 URL（服务端已规范化 CDN URL）
+    public String category;      // 固定 "user"
+    public String placeholder;   // 摘要占位文案，默认 "[表情]"
+    public String format;        // gif/png/jpg/jpeg/webp
+    public int sort;
+    public String shortcode;     // 客户端联想 shortcode
+    public List<String> keywords;
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/WKStickerManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/WKStickerManager.kt
@@ -166,13 +166,26 @@ object WKStickerManager : WKBaseModel() {
      * ⚠️ [StickerLocalOrderStore.write] 走 `apply()` 异步落盘，同一 tick 立刻 `read()`
      * 可能拿到旧值 → applyOrder 用旧顺序重排 → LiveData 发出旧顺序 →
      * 观察者 submitList(旧序) → notifyDataSetChanged → 视觉反弹回旧序。
-     * 所以这里必须用参数 [orderedIds] 直接排序，不走 SP 读回路径。
+     * 所以这里必须用参数 [orderedIds] 直接排序，不走 SP 读回路径——契约测试见
+     * `WKStickerManagerReorderTest`。
      */
     fun reorder(orderedIds: List<String>) {
         StickerLocalOrderStore.write(orderedIds)
-        cache = StickerLocalOrderStore.applyOrder(orderedIds, cache)
+        cache = reorderCache(orderedIds, cache)
         stickersLiveData.value = cache
     }
+
+    /**
+     * 纯函数版本：拿参数 [orderedIds] 直接排 [current]，不读任何持久化状态。
+     *
+     * 抽出成 `internal` 可见的原因：`reorder()` 会写 SP、发 LiveData——JVM 单测
+     * 测不到；但"结果只由参数决定，不从 SP 回读"这个 race-free 契约必须锁死，
+     * 否则回退成 `applyOrder(read(), cache)` 会让所有现有 [StickerLocalOrderStoreTest]
+     * 依然通过。见 `WKStickerManagerReorderTest.reorderCache_uses_only_params_no_persisted_read`。
+     */
+    @JvmStatic
+    internal fun reorderCache(orderedIds: List<String>, current: List<WKSticker>): List<WKSticker> =
+        StickerLocalOrderStore.applyOrder(orderedIds, current)
 
     /** 长按菜单判断：已收藏则不出 "添加到我的表情"（对齐 iOS 的行为）。
      *

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/WKStickerManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/WKStickerManager.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker
+
+import android.os.SystemClock
+import androidx.lifecycle.MutableLiveData
+import com.alibaba.fastjson.JSONObject
+import com.chat.base.base.WKBaseModel
+import com.chat.base.msg.model.WKVectorStickerContent
+import com.chat.base.net.IRequestResultListener
+import com.chat.base.utils.WKToastUtils
+import com.chat.base.R as BaseR
+import com.xinbida.wukongim.entity.WKMsg
+
+/**
+ * 用户收藏贴纸的内存缓存 + API 网关。全局单例。
+ *
+ * 数据流：
+ *   App 启动 / 登录成功 → [load] 从服务端拉取当前用户全部收藏
+ *   收到贴图消息长按 "添加到我的表情" → [collect] POST /sticker/user/collect
+ *   表情面板 "我的贴图" tab → 观察 [stickersLiveData] 展示 grid
+ *   长按菜单展示前 → [isCollected] 判断是否已收藏（已收藏则不出菜单）
+ *
+ * 幂等：服务端 collect 用 SHA256(source_path) 唯一键去重，重复收藏返回已存在
+ * 记录，不重复消耗配额（默认 100 张 / 用户），Android 侧不做前置去重，交给
+ * 服务端兜底。
+ *
+ * 未实现：上传自己的贴纸（需要 /v1/file/upload?type=sticker 流程 + handle 签名，
+ * 当前 Android 只做"从消息收藏"链路，如需上传后续再加）。
+ */
+object WKStickerManager : WKBaseModel() {
+
+    private val service by lazy { createService(StickerService::class.java) }
+
+    /** 两次成功 [load] 之间的最小间隔。UI 层可以随手在 tab 切换 / 面板打开时调 load()，
+     *  短时间内的重复调用会被 short-circuit（快速切 tab / 反复打开面板不会打网络）。 */
+    private const val LOAD_MIN_INTERVAL_MS = 30_000L
+
+    @Volatile
+    private var cache: List<WKSticker> = emptyList()
+
+    @Volatile
+    private var lastLoadedAtMs: Long = 0L
+
+    /** 主线程可观察的收藏列表。UI 层通过 observe / value 读。 */
+    val stickersLiveData: MutableLiveData<List<WKSticker>> = MutableLiveData(emptyList())
+
+    /**
+     * 拉取服务端最新收藏列表并刷新缓存。空集合返回 {"list":[]} 而非 404，视为成功。
+     * 距上次成功 <30s 的调用会跳过网络；[force]=true 用于用户主动下拉刷新等场景绕过。
+     */
+    @JvmOverloads
+    fun load(force: Boolean = false) {
+        if (!force && SystemClock.uptimeMillis() - lastLoadedAtMs < LOAD_MIN_INTERVAL_MS) {
+            return
+        }
+        request(service.getMyStickers(), object : IRequestResultListener<ListStickerResp> {
+            override fun onSuccess(result: ListStickerResp?) {
+                val list = result?.list ?: emptyList()
+                cache = list
+                lastLoadedAtMs = SystemClock.uptimeMillis()
+                stickersLiveData.value = list
+            }
+
+            override fun onFail(code: Int, msg: String?) {
+                // 静默失败：面板 tab 仍能显示已缓存的（可能是空），下次 load 重试。
+                // 失败不更新 lastLoadedAtMs，下次调用不会被节流吞掉。
+            }
+        })
+    }
+
+    /** 长按 chat 里的贴图消息 → 收藏到"我的表情"。 */
+    fun collect(msg: WKMsg) {
+        val content = msg.baseContentMsgModel as? WKVectorStickerContent ?: return
+        val path = content.url
+        if (path.isNullOrEmpty()) return
+
+        val body = JSONObject()
+        body["path"] = path
+        // placeholder 服务端会自动补默认值 "[表情]"，Android 不做前置指定；
+        // width/height/category/format/handle 服务端不接（会被忽略或校验失败）。
+
+        request(service.collectSticker(body), object : IRequestResultListener<WKSticker> {
+            override fun onSuccess(result: WKSticker?) {
+                if (result == null) return
+                // 幂等：如果服务端返回的是已存在记录，避免重复追加。
+                val updated = cache.filterNot { it.sticker_id == result.sticker_id } + result
+                cache = updated
+                stickersLiveData.value = updated
+                WKToastUtils.getInstance().showToastNormal(
+                    getString(BaseR.string.str_sticker_add_success)
+                )
+            }
+
+            override fun onFail(code: Int, msg: String?) {
+                // 服务端 400 body 里可能含 `quota_exceeded` 等 code，简化处理直接用 msg
+                val fallback = getString(BaseR.string.str_sticker_add_failed)
+                WKToastUtils.getInstance().showToastNormal(
+                    if (msg.isNullOrEmpty()) fallback else msg
+                )
+            }
+        })
+    }
+
+    /** 长按菜单判断：已收藏则不出 "添加到我的表情"（对齐 iOS 的行为）。
+     *
+     * 使用 [StickerUrlUtils.normalizePath] 归一化再比：服务端可能对同一贴图返回
+     * 绝对/相对 URL 混用，直接 `==` 会漏判为"未收藏"，菜单误显示 → 用户点后拿到
+     * 服务端"已存在"记录，列表不更新看起来像"没生效"。
+     */
+    fun isCollected(url: String?): Boolean {
+        val target = StickerUrlUtils.normalizePath(url) ?: return false
+        return cache.any { StickerUrlUtils.normalizePath(it.path) == target }
+    }
+
+    private fun getString(resId: Int): String {
+        return com.chat.base.WKBaseApplication.getInstance().context.getString(resId)
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/WKStickerManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/WKStickerManager.kt
@@ -16,6 +16,7 @@ import com.alibaba.fastjson.JSONObject
 import com.chat.base.base.WKBaseModel
 import com.chat.base.msg.model.WKVectorStickerContent
 import com.chat.base.net.IRequestResultListener
+import com.chat.base.net.entity.CommonResponse
 import com.chat.base.utils.WKToastUtils
 import com.chat.base.R as BaseR
 import com.xinbida.wukongim.entity.WKMsg
@@ -26,15 +27,17 @@ import com.xinbida.wukongim.entity.WKMsg
  * 数据流：
  *   App 启动 / 登录成功 → [load] 从服务端拉取当前用户全部收藏
  *   收到贴图消息长按 "添加到我的表情" → [collect] POST /sticker/user/collect
+ *   编辑态点 × → [delete] DELETE /sticker/user/{id}
+ *   编辑态拖拽结束 → [reorder] 本地顺序持久化
+ *   上传自己贴纸 → [WKStickerUploader]（走 POST /sticker/user）
  *   表情面板 "我的贴图" tab → 观察 [stickersLiveData] 展示 grid
- *   长按菜单展示前 → [isCollected] 判断是否已收藏（已收藏则不出菜单）
  *
  * 幂等：服务端 collect 用 SHA256(source_path) 唯一键去重，重复收藏返回已存在
  * 记录，不重复消耗配额（默认 100 张 / 用户），Android 侧不做前置去重，交给
  * 服务端兜底。
  *
- * 未实现：上传自己的贴纸（需要 /v1/file/upload?type=sticker 流程 + handle 签名，
- * 当前 Android 只做"从消息收藏"链路，如需上传后续再加）。
+ * 本地顺序：服务端 sort 字段由后端维护但无重排接口，Android 侧用
+ * [StickerLocalOrderStore] 让用户拖拽调整的顺序本地稳定复现（对齐 iOS）。
  */
 object WKStickerManager : WKBaseModel() {
 
@@ -50,12 +53,16 @@ object WKStickerManager : WKBaseModel() {
     @Volatile
     private var lastLoadedAtMs: Long = 0L
 
-    /** 主线程可观察的收藏列表。UI 层通过 observe / value 读。 */
+    /** 主线程可观察的收藏列表（已按 [StickerLocalOrderStore] 排序）。UI 层通过 observe / value 读。 */
     val stickersLiveData: MutableLiveData<List<WKSticker>> = MutableLiveData(emptyList())
 
     /**
      * 拉取服务端最新收藏列表并刷新缓存。空集合返回 {"list":[]} 而非 404，视为成功。
      * 距上次成功 <30s 的调用会跳过网络；[force]=true 用于用户主动下拉刷新等场景绕过。
+     *
+     * 成功后：
+     * 1. 按本地顺序表重排（登记过的前置，其他追加）
+     * 2. 修剪本地顺序表中服务端已不存在的 id（防表越涨越大）
      */
     @JvmOverloads
     fun load(force: Boolean = false) {
@@ -64,10 +71,12 @@ object WKStickerManager : WKBaseModel() {
         }
         request(service.getMyStickers(), object : IRequestResultListener<ListStickerResp> {
             override fun onSuccess(result: ListStickerResp?) {
-                val list = result?.list ?: emptyList()
-                cache = list
+                val serverList = result?.list ?: emptyList()
+                StickerLocalOrderStore.prune(serverList.mapTo(mutableSetOf()) { it.sticker_id })
+                val ordered = StickerLocalOrderStore.applyOrder(serverList)
+                cache = ordered
                 lastLoadedAtMs = SystemClock.uptimeMillis()
-                stickersLiveData.value = list
+                stickersLiveData.value = ordered
             }
 
             override fun onFail(code: Int, msg: String?) {
@@ -91,10 +100,7 @@ object WKStickerManager : WKBaseModel() {
         request(service.collectSticker(body), object : IRequestResultListener<WKSticker> {
             override fun onSuccess(result: WKSticker?) {
                 if (result == null) return
-                // 幂等：如果服务端返回的是已存在记录，避免重复追加。
-                val updated = cache.filterNot { it.sticker_id == result.sticker_id } + result
-                cache = updated
-                stickersLiveData.value = updated
+                onStickerAdded(result)
                 WKToastUtils.getInstance().showToastNormal(
                     getString(BaseR.string.str_sticker_add_success)
                 )
@@ -108,6 +114,64 @@ object WKStickerManager : WKBaseModel() {
                 )
             }
         })
+    }
+
+    /**
+     * 收藏 / 上传成功后往缓存里追加一条。已存在的按 sticker_id 覆盖（更新元数据），
+     * 新增的追加到本地顺序末尾。呼叫方无须自己维护 LiveData。
+     */
+    fun onStickerAdded(sticker: WKSticker) {
+        val existed = cache.any { it.sticker_id == sticker.sticker_id }
+        val updated = cache.filterNot { it.sticker_id == sticker.sticker_id } + sticker
+        cache = updated
+        if (!existed) StickerLocalOrderStore.append(sticker.sticker_id)
+        stickersLiveData.value = StickerLocalOrderStore.applyOrder(updated)
+    }
+
+    /**
+     * 删除一条已收藏的贴纸。成功后从缓存 + 本地顺序表 + LiveData 移除。
+     * 失败：吐 [onFail] 里的服务端 msg（或默认 "删除失败"），不改缓存。
+     */
+    fun delete(stickerId: String, onDone: ((Boolean) -> Unit)? = null) {
+        if (stickerId.isEmpty()) {
+            onDone?.invoke(false)
+            return
+        }
+        request(service.deleteSticker(stickerId), object : IRequestResultListener<CommonResponse> {
+            override fun onSuccess(result: CommonResponse?) {
+                val updated = cache.filterNot { it.sticker_id == stickerId }
+                cache = updated
+                StickerLocalOrderStore.remove(stickerId)
+                stickersLiveData.value = updated
+                WKToastUtils.getInstance().showToastNormal(
+                    getString(BaseR.string.str_sticker_delete_success)
+                )
+                onDone?.invoke(true)
+            }
+
+            override fun onFail(code: Int, msg: String?) {
+                val fallback = getString(BaseR.string.str_sticker_delete_failed)
+                WKToastUtils.getInstance().showToastNormal(
+                    if (msg.isNullOrEmpty()) fallback else msg
+                )
+                onDone?.invoke(false)
+            }
+        })
+    }
+
+    /**
+     * 拖拽结束后写入新顺序。传入应为当前面板可视顺序的 sticker_id 列表。
+     * 不打网络（服务端无重排接口），只落本地 SP + LiveData 发新值。
+     *
+     * ⚠️ [StickerLocalOrderStore.write] 走 `apply()` 异步落盘，同一 tick 立刻 `read()`
+     * 可能拿到旧值 → applyOrder 用旧顺序重排 → LiveData 发出旧顺序 →
+     * 观察者 submitList(旧序) → notifyDataSetChanged → 视觉反弹回旧序。
+     * 所以这里必须用参数 [orderedIds] 直接排序，不走 SP 读回路径。
+     */
+    fun reorder(orderedIds: List<String>) {
+        StickerLocalOrderStore.write(orderedIds)
+        cache = StickerLocalOrderStore.applyOrder(orderedIds, cache)
+        stickersLiveData.value = cache
     }
 
     /** 长按菜单判断：已收藏则不出 "添加到我的表情"（对齐 iOS 的行为）。

--- a/wkuikit/src/main/java/com/chat/uikit/chat/sticker/WKStickerUploader.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/sticker/WKStickerUploader.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker
+
+import android.net.Uri
+import android.text.TextUtils
+import com.alibaba.fastjson.JSONObject
+import com.chat.base.R as BaseR
+import com.chat.base.base.WKBaseModel
+import com.chat.base.config.WKApiConfig
+import com.chat.base.config.WKConfig
+import com.chat.base.net.ApiService
+import com.chat.base.net.IRequestResultListener
+import com.chat.base.net.entity.UploadFileUrl
+import com.chat.base.net.ud.WKUploader
+import com.chat.base.utils.WKToastUtils
+import java.io.File
+import java.util.UUID
+
+/**
+ * 上传自己贴纸的三步链路，对齐 iOS `WKStickerUploadService`：
+ *
+ * 1. [StickerUploadValidator.validate] —— 客户端校验（magic bytes / size / dim），
+ *    失败直接吐 toast 不打网络
+ * 2. GET /v1/file/upload/credentials?path=/sticker/{uid}/{uuid}.{ext}&type=sticker
+ *    → 拿 uploadUrl / downloadUrl
+ * 3. PUT uploadUrl 文件二进制 → 存 CDN
+ * 4. POST /v1/sticker/user body {path, width, height, format} → 注册元数据
+ * 5. 成功 → [WKStickerManager.onStickerAdded] 更新缓存 + LiveData
+ *
+ * ⚠️ handle 字段：iOS 上传 STEP 3 响应会带 `sticker_handle`（HMAC 签名），
+ * POST /sticker/user 时带 `handle` 字段。Android 现有 `/file/upload/credentials`
+ * 响应结构无 handle 字段。本实现先不带 handle 试探：
+ * - 服务端 200 → 完成
+ * - 服务端 400 `handle_required` → 服务端配置了 `sticker.handle_required=true`，
+ *   需要与后端对齐把 handle 加入 credentials 响应，或改走 iOS server-proxied 上传
+ *
+ * 呼叫方：面板 UI 层拿到用户选中的图 → new File → uploader.upload(file, callback)。
+ * 选图（PickVisualMedia）由 Activity/Fragment 层负责，本类只做上传编排。
+ */
+object WKStickerUploader : WKBaseModel() {
+
+    private val apiService by lazy { createService(ApiService::class.java) }
+    private val stickerService by lazy { createService(StickerService::class.java) }
+
+    /** UI 层回调：上传状态。progress 0..100（Retrofit 层未提供细粒度进度时可能一直是 0/100）。 */
+    interface Callback {
+        fun onProgress(progress: Int) {}
+        fun onSuccess(sticker: WKSticker)
+        fun onError(messageResId: Int)
+    }
+
+    /**
+     * 触发上传。所有阶段的错误都通过 [callback.onError] 回调，UI 层直接 toast 对应
+     * 字符串即可。本方法必须在主线程调（内部会切 IO / 主线程）。
+     */
+    fun upload(file: File, callback: Callback) {
+        // 1. 校验
+        val meta = StickerUploadValidator.validate(file).getOrElse { throwable ->
+            val failure = (throwable as? StickerUploadValidator.FailureException)?.failure
+                ?: StickerUploadValidator.Failure.IoError
+            callback.onError(failure.stringResId)
+            return
+        }
+
+        val uid = WKConfig.getInstance().uid
+        if (uid.isNullOrEmpty()) {
+            callback.onError(BaseR.string.str_sticker_upload_failed)
+            return
+        }
+
+        // 2. 服务端签发上传凭证
+        val ext = ".${meta.format.ext}"
+        val contentType = mimeFor(meta.format)
+        val fileSize = file.length()
+        // path 前缀必须以 sticker/{uid}/ 开头（服务端 /sticker/user 上传校验）
+        val remotePath = "/sticker/$uid/${UUID.randomUUID().toString().replace("-", "")}$ext"
+
+        val url = Uri.parse(WKApiConfig.baseUrl + "file/upload/credentials").buildUpon().apply {
+            appendQueryParameter("path", remotePath)
+            appendQueryParameter("type", "sticker")
+            appendQueryParameter("filename", file.name)
+            appendQueryParameter("contentType", contentType)
+            appendQueryParameter("fileSize", fileSize.toString())
+        }.build().toString()
+
+        request(apiService.getUploadCredentials(url), object : IRequestResultListener<UploadFileUrl> {
+            override fun onSuccess(result: UploadFileUrl?) {
+                val uploadUrl = result?.uploadUrl
+                val downloadUrl = result?.downloadUrl
+                if (uploadUrl.isNullOrEmpty() || downloadUrl.isNullOrEmpty()) {
+                    callback.onError(BaseR.string.str_sticker_upload_failed)
+                    return
+                }
+                val ct = if (!TextUtils.isEmpty(result.contentType)) result.contentType else contentType
+                // 3. PUT 文件到 CDN
+                callback.onProgress(10)
+                WKUploader.getInstance().putUpload(
+                    uploadUrl,
+                    file.absolutePath,
+                    ct,
+                    result.contentDisposition,
+                    file.absolutePath, // tag: 用 path 作为唯一标记
+                    object : WKUploader.IUploadBack {
+                        override fun onSuccess(unusedUrl: String?) {
+                            callback.onProgress(90)
+                            registerSticker(remotePath, meta, callback)
+                        }
+
+                        override fun onError() {
+                            callback.onError(BaseR.string.str_sticker_upload_failed)
+                        }
+                    }
+                )
+            }
+
+            override fun onFail(code: Int, msg: String?) {
+                callback.onError(BaseR.string.str_sticker_upload_failed)
+            }
+        })
+    }
+
+    // 4. POST /sticker/user 注册元数据
+    private fun registerSticker(path: String, meta: StickerUploadValidator.Meta, callback: Callback) {
+        val body = JSONObject()
+        body["path"] = path
+        if (meta.width > 0) body["width"] = meta.width
+        if (meta.height > 0) body["height"] = meta.height
+        body["format"] = meta.format.ext
+        // handle 字段：先不带，若服务端拒绝再考虑加
+
+        request(stickerService.uploadSticker(body), object : IRequestResultListener<WKSticker> {
+            override fun onSuccess(result: WKSticker?) {
+                if (result == null) {
+                    callback.onError(BaseR.string.str_sticker_upload_failed)
+                    return
+                }
+                callback.onProgress(100)
+                WKStickerManager.onStickerAdded(result)
+                WKToastUtils.getInstance().showToastNormal(
+                    com.chat.base.WKBaseApplication.getInstance().context
+                        .getString(BaseR.string.str_sticker_upload_success)
+                )
+                callback.onSuccess(result)
+            }
+
+            override fun onFail(code: Int, msg: String?) {
+                // 服务端 message 优先（可能是 "配额已达上限"），退回默认 "上传失败"
+                if (!msg.isNullOrEmpty()) {
+                    WKToastUtils.getInstance().showToastNormal(msg)
+                    callback.onError(0) // 已经吐过 toast，UI 层不用再吐
+                } else {
+                    callback.onError(BaseR.string.str_sticker_upload_failed)
+                }
+            }
+        })
+    }
+
+    private fun mimeFor(format: StickerUploadValidator.Format): String = when (format) {
+        StickerUploadValidator.Format.GIF -> "image/gif"
+        StickerUploadValidator.Format.PNG -> "image/png"
+        StickerUploadValidator.Format.JPEG -> "image/jpeg"
+        StickerUploadValidator.Format.WEBP -> "image/webp"
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/group/UpdateGroupNameActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/group/UpdateGroupNameActivity.java
@@ -22,6 +22,7 @@ import android.widget.TextView;
 import com.chat.base.base.WKBaseActivity;
 import com.chat.base.net.HttpResponseCode;
 import com.chat.base.utils.SoftKeyboardUtils;
+import com.chat.base.utils.StringUtils;
 import com.chat.uikit.R;
 import com.chat.uikit.databinding.ActUpdateGroupNameLayoutBinding;
 import com.chat.uikit.group.service.GroupModel;
@@ -36,6 +37,8 @@ import java.util.Objects;
  * 修改群名称
  */
 public class UpdateGroupNameActivity extends WKBaseActivity<ActUpdateGroupNameLayoutBinding> {
+
+    private static final int GROUP_NAME_MAX_LEN = 50;
 
     String groupNo;
     WKChannel channel;
@@ -93,6 +96,7 @@ public class UpdateGroupNameActivity extends WKBaseActivity<ActUpdateGroupNameLa
             wkVBinding.nameEt.setText(channel.channelName);
             wkVBinding.nameEt.setSelection(channel.channelName.length());
         }
+        StringUtils.attachLengthLimit(wkVBinding.nameEt, GROUP_NAME_MAX_LEN);
         SoftKeyboardUtils.getInstance().showSoftKeyBoard(UpdateGroupNameActivity.this, wkVBinding.nameEt);
     }
 

--- a/wkuikit/src/main/java/com/chat/uikit/thread/CreateThreadActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/thread/CreateThreadActivity.java
@@ -27,6 +27,7 @@ import android.widget.TextView;
 
 import com.chat.base.base.WKBaseActivity;
 import com.chat.base.net.HttpResponseCode;
+import com.chat.base.utils.StringUtils;
 import com.chat.base.utils.WKToastUtils;
 import com.chat.uikit.R;
 import com.chat.uikit.chat.ChatActivity;
@@ -37,6 +38,8 @@ import com.xinbida.wukongim.entity.WKChannel;
 import com.xinbida.wukongim.entity.WKChannelType;
 
 public class CreateThreadActivity extends WKBaseActivity<ActCreateThreadLayoutBinding> {
+
+    private static final int THREAD_NAME_MAX_LEN = 100;
 
 
     private String groupNo;
@@ -76,6 +79,8 @@ public class CreateThreadActivity extends WKBaseActivity<ActCreateThreadLayoutBi
         sourceContentType = getIntent().getIntExtra("sourceContentType", 0);
         sourceFromName = getIntent().getStringExtra("sourceFromName");
         sourceFromUid = getIntent().getStringExtra("sourceFromUid");
+
+        StringUtils.attachLengthLimit(wkVBinding.threadNameEt, THREAD_NAME_MAX_LEN);
 
         if (!TextUtils.isEmpty(sourceMessageId) && !TextUtils.isEmpty(sourceContent)) {
             wkVBinding.divider.setVisibility(View.VISIBLE);
@@ -123,8 +128,8 @@ public class CreateThreadActivity extends WKBaseActivity<ActCreateThreadLayoutBi
         String name = wkVBinding.threadNameEt.getText().toString().trim();
         if (TextUtils.isEmpty(name)) {
             if (!TextUtils.isEmpty(sourceContent)) {
-                name = sourceContent.length() > 50
-                        ? sourceContent.substring(0, 50)
+                name = sourceContent.length() > THREAD_NAME_MAX_LEN
+                        ? sourceContent.substring(0, THREAD_NAME_MAX_LEN)
                         : sourceContent;
             } else {
                 name = getString(R.string.str_new_thread);

--- a/wkuikit/src/main/java/com/chat/uikit/thread/ThreadDetailActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/thread/ThreadDetailActivity.java
@@ -209,7 +209,7 @@ public class ThreadDetailActivity extends WKBaseActivity<ActThreadDetailLayoutBi
         WKDialogUtils.getInstance().showInputDialog(this,
                 getString(R.string.str_rename_thread),
                 getString(R.string.str_rename_thread_hint),
-                currentName, "", 50, text -> {
+                currentName, "", 100, text -> {
                     String trimmed = text.trim();
                     if (TextUtils.isEmpty(trimmed)) {
                         WKToastUtils.getInstance().showToastNormal(getString(R.string.str_thread_name_empty));

--- a/wkuikit/src/main/res/drawable/bg_sticker_add_cell.xml
+++ b/wkuikit/src/main/res/drawable/bg_sticker_add_cell.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <!-- 首格 + 的背景：浅灰圆角，与 sticker 视觉平衡（点击态 selector 由代码控制 alpha） -->
+    <solid android:color="#F5F5F5" />
+    <corners android:radius="8dp" />
+</shape>

--- a/wkuikit/src/main/res/drawable/ic_menu_add_to_stickers.xml
+++ b/wkuikit/src/main/res/drawable/ic_menu_add_to_stickers.xml
@@ -1,0 +1,28 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- 长按菜单"添加到我的表情"图标：贴纸边框（圆角矩形）+ 右下"+"徽章。
+         尺寸/线宽对齐 msg_copy / msg_forward 视觉重量，避免与前后菜单项割裂。 -->
+    <path
+        android:pathData="M3.5,4.5 L14.5,4.5 A2,2 0 0 1 16.5,6.5 L16.5,17.5 A2,2 0 0 1 14.5,19.5 L5.5,19.5 A2,2 0 0 1 3.5,17.5 L3.5,6.5 A2,2 0 0 1 5.5,4.5 Z"
+        android:strokeColor="#333333"
+        android:strokeWidth="1.4"
+        android:fillColor="#00000000" />
+    <!-- 右下角圆形背景（先画白色垫底避免和边框视觉粘连） -->
+    <path
+        android:pathData="M17,17 m-4,0 a4,4 0 1 0 8,0 a4,4 0 1 0 -8,0"
+        android:fillColor="#FFFFFF" />
+    <!-- + 徽章 -->
+    <path
+        android:pathData="M17,17 m-4,0 a4,4 0 1 0 8,0 a4,4 0 1 0 -8,0"
+        android:strokeColor="#333333"
+        android:strokeWidth="1.2"
+        android:fillColor="#00000000" />
+    <path
+        android:pathData="M17,14.5 L17,19.5 M14.5,17 L19.5,17"
+        android:strokeColor="#333333"
+        android:strokeWidth="1.2"
+        android:strokeLineCap="round" />
+</vector>

--- a/wkuikit/src/main/res/drawable/ic_sticker_add.xml
+++ b/wkuikit/src/main/res/drawable/ic_sticker_add.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+    <!-- "我的表情" 面板首格 + 按钮：细线 "+" 灰色 -->
+    <path
+        android:pathData="M16,8 L16,24 M8,16 L24,16"
+        android:strokeColor="#999999"
+        android:strokeWidth="1.8"
+        android:strokeLineCap="round" />
+</vector>

--- a/wkuikit/src/main/res/drawable/ic_sticker_delete_badge.xml
+++ b/wkuikit/src/main/res/drawable/ic_sticker_delete_badge.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="22dp"
+    android:height="22dp"
+    android:viewportWidth="22"
+    android:viewportHeight="22">
+    <!-- 编辑态删除徽章：红底白 ×，位于 sticker 左上角 -->
+    <path
+        android:pathData="M11,11m-11,0a11,11 0,1 1,22 0a11,11 0,1 1,-22 0"
+        android:fillColor="#F80303" />
+    <path
+        android:pathData="M7,7 L15,15 M15,7 L7,15"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.8"
+        android:strokeLineCap="round" />
+</vector>

--- a/wkuikit/src/main/res/layout/act_create_thread_layout.xml
+++ b/wkuikit/src/main/res/layout/act_create_thread_layout.xml
@@ -46,7 +46,7 @@
                 android:focusable="true"
                 android:focusableInTouchMode="true"
                 android:hint="@string/str_thread_name_hint"
-                android:maxLength="50"
+                android:maxLength="100"
                 android:maxLines="1"
                 android:minHeight="44dp"
                 android:paddingHorizontal="12dp"

--- a/wkuikit/src/main/res/layout/act_update_group_name_layout.xml
+++ b/wkuikit/src/main/res/layout/act_update_group_name_layout.xml
@@ -34,7 +34,7 @@
             android:paddingBottom="10dp"
             android:layout_marginBottom="10dp"
             android:hint="@string/group_name"
-            android:maxLength="30"
+            android:maxLength="50"
             android:textColor="@color/colorDark"
             android:textColorHint="@color/color999" />
     </LinearLayout>

--- a/wkuikit/src/main/res/layout/bottom_sheet_file_actions.xml
+++ b/wkuikit/src/main/res/layout/bottom_sheet_file_actions.xml
@@ -28,6 +28,17 @@
         android:background="@color/colorLine" />
 
     <TextView
+        android:id="@+id/actionPreview"
+        android:layout_width="match_parent"
+        android:layout_height="52dp"
+        android:gravity="center"
+        android:text="@string/str_file_preview"
+        android:textColor="@color/colorDark"
+        android:textSize="16sp"
+        android:visibility="gone"
+        android:background="?android:attr/selectableItemBackground" />
+
+    <TextView
         android:id="@+id/actionOpen"
         android:layout_width="match_parent"
         android:layout_height="52dp"

--- a/wkuikit/src/main/res/layout/chat_item_sticker.xml
+++ b/wkuikit/src/main/res/layout/chat_item_sticker.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  贴图消息 (contentType=12/13) 的 chat cell layout。
+  与 chat_item_img 的差异：
+    - 无 blurView / progressView / progressTv / otherLayout（贴图不需要焚阅/上传进度）
+    - imageView 固定 160dp x 160dp，纯透明容器（不带气泡背景，与 iOS hiddenBubble 对齐）
+    - 保留 msg_status（时间戳 + 已读态）与图片消息一致
+
+  贴图 URL 由 WKVectorStickerProvider 分类加载：
+    静态图后缀 → Glide 直接加载
+    .lim/.json (Lottie) → 显示 default_view_bg 占位
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/contentLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="end"
+    android:orientation="horizontal">
+
+    <FrameLayout
+        android:id="@+id/imageLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <com.chat.base.ui.components.FilterImageView
+            android:id="@+id/imageView"
+            android:layout_width="160dp"
+            android:layout_height="160dp"
+            android:scaleType="fitCenter"
+            android:src="@drawable/default_view_bg" />
+
+        <FrameLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_marginEnd="5dp"
+            android:layout_marginBottom="5dp"
+            android:background="@drawable/msg_time_status_bg">
+
+            <include layout="@layout/wk_msg_status_layout" />
+        </FrameLayout>
+
+    </FrameLayout>
+
+</LinearLayout>

--- a/wkuikit/src/main/res/layout/dialog_sticker_detail.xml
+++ b/wkuikit/src/main/res/layout/dialog_sticker_detail.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  贴纸详情弹窗（消息内点击贴图弹出）：中央预览 + 底部动作条。
+  尺寸：卡片 220dp 宽 × wrap_content 高，预览 180dp，按钮 44dp 高。
+-->
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    app:cardBackgroundColor="#FFFFFF"
+    app:cardCornerRadius="14dp"
+    app:cardElevation="4dp">
+
+    <LinearLayout
+        android:layout_width="220dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="20dp">
+
+            <com.chat.base.ui.components.FilterImageView
+                android:id="@+id/stickerDetailImage"
+                android:layout_width="180dp"
+                android:layout_height="180dp"
+                android:layout_gravity="center"
+                android:scaleType="fitCenter"
+                android:src="@drawable/default_view_bg" />
+
+        </FrameLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="0.5dp"
+            android:background="#F0F0F0" />
+
+        <LinearLayout
+            android:id="@+id/stickerDetailButtonRow"
+            android:layout_width="match_parent"
+            android:layout_height="44dp"
+            android:orientation="horizontal">
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/stickerDetailSend"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="?attr/selectableItemBackground"
+                android:gravity="center"
+                android:text="@string/str_sticker_send"
+                android:textColor="@color/colorAccent"
+                android:textSize="15sp" />
+
+            <View
+                android:id="@+id/stickerDetailDivider"
+                android:layout_width="0.5dp"
+                android:layout_height="match_parent"
+                android:background="#F0F0F0" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/stickerDetailAdd"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="?attr/selectableItemBackground"
+                android:gravity="center"
+                android:text="@string/str_add_to_my_stickers"
+                android:textColor="@color/colorAccent"
+                android:textSize="15sp" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>

--- a/wkuikit/src/main/res/layout/item_collect_sticker.xml
+++ b/wkuikit/src/main/res/layout/item_collect_sticker.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  表情面板 "我的贴图" tab 的单个 grid item。
+  纯 image 展示，点击由 CollectStickerAdapter setOnItemClickListener 发送贴图。
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="6dp">
+
+    <com.chat.base.ui.components.FilterImageView
+        android:id="@+id/stickerImageView"
+        android:layout_width="72dp"
+        android:layout_height="72dp"
+        android:layout_gravity="center"
+        android:scaleType="fitCenter"
+        android:src="@drawable/default_view_bg" />
+
+</FrameLayout>

--- a/wkuikit/src/main/res/layout/item_collect_sticker.xml
+++ b/wkuikit/src/main/res/layout/item_collect_sticker.xml
@@ -1,19 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  表情面板 "我的贴图" tab 的单个 grid item。
-  纯 image 展示，点击由 CollectStickerAdapter setOnItemClickListener 发送贴图。
+  表情面板 "我的贴图" tab 的 sticker 单元。
+  - 默认态：只显示 stickerImageView，点击发送
+  - 编辑态（stickerRoot 由 Adapter 播抖动、deleteBadge 显示）：点 badge 触发删除，
+    单指拖动触发 ItemTouchHelper 重排
 -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/stickerRoot"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="6dp">
 
     <com.chat.base.ui.components.FilterImageView
         android:id="@+id/stickerImageView"
-        android:layout_width="72dp"
-        android:layout_height="72dp"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
         android:layout_gravity="center"
         android:scaleType="fitCenter"
         android:src="@drawable/default_view_bg" />
 
+    <!-- 删除徽章：编辑态可见，位于 sticker 左上角外沿（-2dp offset 让 × 半盖在图上） -->
+    <ImageView
+        android:id="@+id/stickerDeleteBadge"
+        android:layout_width="22dp"
+        android:layout_height="22dp"
+        android:layout_gravity="start|top"
+        android:layout_marginStart="-2dp"
+        android:layout_marginTop="-2dp"
+        android:contentDescription="@string/str_sticker_delete_confirm"
+        android:src="@drawable/ic_sticker_delete_badge"
+        android:visibility="gone" />
+
 </FrameLayout>
+

--- a/wkuikit/src/main/res/layout/item_collect_sticker_add.xml
+++ b/wkuikit/src/main/res/layout/item_collect_sticker_add.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  表情面板 "我的贴图" tab 的首格 "+" 上传按钮。
+  尺寸与 item_collect_sticker.xml 保持一致（padding 6dp + 60dp inner），Adapter 侧点击
+  触发相册选图 → WKStickerUploader。编辑态下半透明表示禁用。
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/stickerAddRoot"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="6dp">
+
+    <FrameLayout
+        android:layout_width="60dp"
+        android:layout_height="60dp"
+        android:layout_gravity="center"
+        android:background="@drawable/bg_sticker_add_cell">
+
+        <ImageView
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_gravity="center"
+            android:contentDescription="@string/str_sticker_add_button"
+            android:src="@drawable/ic_sticker_add" />
+
+    </FrameLayout>
+
+</FrameLayout>

--- a/wkuikit/src/test/java/com/chat/uikit/chat/sticker/StickerLocalOrderStoreTest.kt
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/sticker/StickerLocalOrderStoreTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * 本地顺序表的纯函数逻辑回归。SP 写入路径依赖 Android runtime，此处只测排序 /
+ * 修剪算法（两个纯函数）；SP 层由 instrumented test 或 runtime 验证。
+ */
+class StickerLocalOrderStoreTest {
+
+    private fun mk(id: String): WKSticker = WKSticker().also { it.sticker_id = id }
+
+    @Test
+    fun `empty local order returns server list unchanged`() {
+        val server = listOf(mk("a"), mk("b"), mk("c"))
+        val out = StickerLocalOrderStore.applyOrder(emptyList(), server)
+        assertEquals(listOf("a", "b", "c"), out.map { it.sticker_id })
+    }
+
+    @Test
+    fun `full local order reorders server list`() {
+        val server = listOf(mk("a"), mk("b"), mk("c"))
+        val out = StickerLocalOrderStore.applyOrder(listOf("c", "a", "b"), server)
+        assertEquals(listOf("c", "a", "b"), out.map { it.sticker_id })
+    }
+
+    @Test
+    fun `partial local order puts registered first then server-fresh appended`() {
+        // 用户拖过 c,a；此后 b, d 是别端新增（服务端返回顺序里）
+        val server = listOf(mk("a"), mk("b"), mk("c"), mk("d"))
+        val out = StickerLocalOrderStore.applyOrder(listOf("c", "a"), server)
+        // c,a 按本地顺序前置；b,d 按服务端返回顺序追加
+        assertEquals(listOf("c", "a", "b", "d"), out.map { it.sticker_id })
+    }
+
+    @Test
+    fun `stale ids in local order are ignored`() {
+        // 本地顺序里的 x 服务端已删，applyOrder 会忽略它（不会 NPE 也不会占位）
+        val server = listOf(mk("a"), mk("b"))
+        val out = StickerLocalOrderStore.applyOrder(listOf("x", "a"), server)
+        assertEquals(listOf("a", "b"), out.map { it.sticker_id })
+    }
+
+    @Test
+    fun `empty server list returns empty`() {
+        val out = StickerLocalOrderStore.applyOrder(listOf("a", "b"), emptyList())
+        assertEquals(emptyList<String>(), out.map { it.sticker_id })
+    }
+
+    @Test
+    fun `prune removes stale ids and preserves order`() {
+        val out = StickerLocalOrderStore.pruneOrder(
+            listOf("a", "x", "b", "y", "c"),
+            setOf("a", "b", "c")
+        )
+        assertEquals(listOf("a", "b", "c"), out)
+    }
+
+    @Test
+    fun `prune with empty valid set returns empty`() {
+        val out = StickerLocalOrderStore.pruneOrder(listOf("a", "b"), emptySet())
+        assertEquals(emptyList<String>(), out)
+    }
+
+    @Test
+    fun `prune with all valid keeps everything`() {
+        val out = StickerLocalOrderStore.pruneOrder(
+            listOf("a", "b", "c"),
+            setOf("a", "b", "c", "d")
+        )
+        assertEquals(listOf("a", "b", "c"), out)
+    }
+}

--- a/wkuikit/src/test/java/com/chat/uikit/chat/sticker/StickerUploadValidatorTest.kt
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/sticker/StickerUploadValidatorTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * 上传贴纸文件的 magic bytes 识别回归。校验规则不依赖 Android BitmapFactory 的
+ * 部分（格式识别）走 JVM 单测；尺寸/大小校验依赖 BitmapFactory 需 instrumented。
+ */
+class StickerUploadValidatorTest {
+
+    @Test
+    fun `gif 87a magic bytes are recognized`() {
+        val buf = "GIF87a".toByteArray(Charsets.US_ASCII) + ByteArray(6)
+        assertEquals(
+            StickerUploadValidator.Format.GIF,
+            StickerUploadValidator.detectFormatFromBytes(buf)
+        )
+    }
+
+    @Test
+    fun `gif 89a magic bytes are recognized`() {
+        val buf = "GIF89a".toByteArray(Charsets.US_ASCII) + ByteArray(6)
+        assertEquals(
+            StickerUploadValidator.Format.GIF,
+            StickerUploadValidator.detectFormatFromBytes(buf)
+        )
+    }
+
+    @Test
+    fun `png magic bytes are recognized`() {
+        val buf = byteArrayOf(
+            0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0, 0, 0, 0
+        )
+        assertEquals(
+            StickerUploadValidator.Format.PNG,
+            StickerUploadValidator.detectFormatFromBytes(buf)
+        )
+    }
+
+    @Test
+    fun `jpeg magic bytes are recognized`() {
+        val buf = byteArrayOf(
+            0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(),
+            0xE0.toByte(), 0, 0x10, 'J'.code.toByte(), 'F'.code.toByte(),
+            'I'.code.toByte(), 'F'.code.toByte(), 0, 0
+        )
+        assertEquals(
+            StickerUploadValidator.Format.JPEG,
+            StickerUploadValidator.detectFormatFromBytes(buf)
+        )
+    }
+
+    @Test
+    fun `webp magic bytes are recognized`() {
+        val buf = byteArrayOf(
+            'R'.code.toByte(), 'I'.code.toByte(), 'F'.code.toByte(), 'F'.code.toByte(),
+            0, 0, 0, 0,
+            'W'.code.toByte(), 'E'.code.toByte(), 'B'.code.toByte(), 'P'.code.toByte()
+        )
+        assertEquals(
+            StickerUploadValidator.Format.WEBP,
+            StickerUploadValidator.detectFormatFromBytes(buf)
+        )
+    }
+
+    @Test
+    fun `bmp is rejected`() {
+        // BMP magic: 42 4D
+        val buf = byteArrayOf(0x42, 0x4D, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        assertNull(StickerUploadValidator.detectFormatFromBytes(buf))
+    }
+
+    @Test
+    fun `plain text is rejected`() {
+        val buf = "hello world\n".toByteArray(Charsets.US_ASCII)
+        assertNull(StickerUploadValidator.detectFormatFromBytes(buf))
+    }
+
+    @Test
+    fun `riff without webp signature is rejected`() {
+        // RIFF but not WEBP (e.g., .wav)
+        val buf = byteArrayOf(
+            'R'.code.toByte(), 'I'.code.toByte(), 'F'.code.toByte(), 'F'.code.toByte(),
+            0, 0, 0, 0,
+            'W'.code.toByte(), 'A'.code.toByte(), 'V'.code.toByte(), 'E'.code.toByte()
+        )
+        assertNull(StickerUploadValidator.detectFormatFromBytes(buf))
+    }
+
+    @Test
+    fun `empty buffer is rejected`() {
+        assertNull(StickerUploadValidator.detectFormatFromBytes(ByteArray(0)))
+    }
+
+    @Test
+    fun `short buffer with png prefix only is rejected`() {
+        // 少于 8 字节 → PNG magic 未完整判定失败
+        val buf = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47)
+        assertNull(StickerUploadValidator.detectFormatFromBytes(buf))
+    }
+}

--- a/wkuikit/src/test/java/com/chat/uikit/chat/sticker/StickerUrlUtilsTest.kt
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/sticker/StickerUrlUtilsTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 贴图 URL 后缀识别回归。渲染分支基于这里的判定，一旦回归贴图消息就会显示错。
+ */
+class StickerUrlUtilsTest {
+
+    @Test
+    fun `png jpg jpeg webp gif recognised as static image`() {
+        assertTrue(StickerUrlUtils.isStaticImage("https://cdn.example.com/a.png"))
+        assertTrue(StickerUrlUtils.isStaticImage("https://cdn.example.com/a.jpg"))
+        assertTrue(StickerUrlUtils.isStaticImage("https://cdn.example.com/a.jpeg"))
+        assertTrue(StickerUrlUtils.isStaticImage("https://cdn.example.com/a.webp"))
+        assertTrue(StickerUrlUtils.isStaticImage("https://cdn.example.com/a.gif"))
+    }
+
+    @Test
+    fun `uppercase extension recognised (case-insensitive)`() {
+        assertTrue(StickerUrlUtils.isStaticImage("https://cdn.example.com/a.PNG"))
+        assertTrue(StickerUrlUtils.isStaticImage("https://cdn.example.com/a.GIF"))
+    }
+
+    @Test
+    fun `url with query string still recognised`() {
+        assertTrue(StickerUrlUtils.isStaticImage("https://cdn.example.com/a.png?x=1&y=2"))
+        assertTrue(StickerUrlUtils.isStaticImage("https://cdn.example.com/a.gif#fragment"))
+    }
+
+    @Test
+    fun `lim and json not static image`() {
+        assertFalse(StickerUrlUtils.isStaticImage("https://cdn.example.com/a.lim"))
+        assertFalse(StickerUrlUtils.isStaticImage("https://cdn.example.com/a.json"))
+    }
+
+    @Test
+    fun `lim url is lottie format`() {
+        assertTrue(StickerUrlUtils.isLottieFormat("https://cdn.example.com/a.lim", null))
+        assertTrue(StickerUrlUtils.isLottieFormat("https://cdn.example.com/a.json", null))
+    }
+
+    @Test
+    fun `format field lim overrides url extension`() {
+        // 服务端可能返回 .png URL 但 format 是 "lim"（历史数据 / 上传标准化产物）
+        assertTrue(StickerUrlUtils.isLottieFormat("https://cdn.example.com/a.png", "lim"))
+        assertTrue(StickerUrlUtils.isLottieFormat("https://cdn.example.com/a.png", "LIM"))
+    }
+
+    @Test
+    fun `null or empty url handled safely`() {
+        assertFalse(StickerUrlUtils.isStaticImage(null))
+        assertFalse(StickerUrlUtils.isStaticImage(""))
+        assertFalse(StickerUrlUtils.isLottieFormat(null, null))
+        assertFalse(StickerUrlUtils.isLottieFormat("", ""))
+    }
+
+    @Test
+    fun `no extension url returns null ext`() {
+        assertNull(StickerUrlUtils.extractExt("https://cdn.example.com/nofile"))
+        assertNull(StickerUrlUtils.extractExt("https://cdn.example.com/a."))  // trailing dot
+        // 路径里没扩展名，query 里的 ".xxx" 不算
+        assertNull(StickerUrlUtils.extractExt("https://cdn.example.com/nofile?type=lim"))
+    }
+
+    @Test
+    fun `extract ext lowercased and no dot`() {
+        assertEquals("png", StickerUrlUtils.extractExt("a.PNG"))
+        assertEquals("gif", StickerUrlUtils.extractExt("/foo/bar/baz.gif"))
+        assertEquals("lim", StickerUrlUtils.extractExt("http://a.b/c.LIM?x=1"))
+    }
+
+    @Test
+    fun `normalizePath treats absolute and relative same-path as equal`() {
+        val absolute = StickerUrlUtils.normalizePath("https://cdn.example.com/sticker/uid/abc.png")
+        val relative = StickerUrlUtils.normalizePath("/sticker/uid/abc.png")
+        assertEquals(absolute, relative)
+    }
+
+    @Test
+    fun `normalizePath strips query and fragment`() {
+        assertEquals(
+            "/sticker/uid/a.png",
+            StickerUrlUtils.normalizePath("https://cdn.example.com/sticker/uid/a.png?v=2")
+        )
+        assertEquals(
+            "/sticker/uid/a.png",
+            StickerUrlUtils.normalizePath("https://cdn.example.com/sticker/uid/a.png#frag")
+        )
+    }
+
+    @Test
+    fun `normalizePath scheme case-insensitive`() {
+        assertEquals(
+            StickerUrlUtils.normalizePath("https://cdn/a.png"),
+            StickerUrlUtils.normalizePath("HTTPS://cdn/a.png")
+        )
+    }
+
+    @Test
+    fun `normalizePath null or empty returns null`() {
+        assertNull(StickerUrlUtils.normalizePath(null))
+        assertNull(StickerUrlUtils.normalizePath(""))
+    }
+
+    @Test
+    fun `normalizePath scheme with no path yields empty`() {
+        assertEquals("", StickerUrlUtils.normalizePath("https://cdn.example.com"))
+    }
+}

--- a/wkuikit/src/test/java/com/chat/uikit/chat/sticker/WKStickerManagerReorderTest.kt
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/sticker/WKStickerManagerReorderTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.uikit.chat.sticker
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * `WKStickerManager.reorderCache` 契约回归。
+ *
+ * 头图设计决策：`reorder(orderedIds)` 必须**只**用参数 `orderedIds` 排序，不能
+ * 走 `applyOrder(StickerLocalOrderStore.read(), cache)` 路径——因为
+ * `StickerLocalOrderStore.write()` 走 `apply()` 异步落盘，同 tick `read()` 会拿旧值，
+ * 用户实测表现为"拖动松手后视觉反弹回旧序"。
+ *
+ * 这个测试锁死"只由入参决定结果"的契约：如果有人回退 `reorder()` 内部实现改回
+ * `applyOrder(read(), cache)`，纯函数 `reorderCache` 的入参就变成了 SP 里的旧顺序，
+ * 用当前入参 orderedIds 断言就会挂。
+ */
+class WKStickerManagerReorderTest {
+
+    private fun mk(id: String): WKSticker = WKSticker().also { it.sticker_id = id }
+
+    @Test
+    fun `reorderCache uses only params, no persisted read`() {
+        // 模拟：当前 cache 顺序 = [a, b, c]（假设服务端返回顺序）
+        // 用户拖拽后传入 orderedIds = [c, a, b]
+        val cache = listOf(mk("a"), mk("b"), mk("c"))
+        val userDraggedOrder = listOf("c", "a", "b")
+
+        val result = WKStickerManager.reorderCache(userDraggedOrder, cache)
+
+        // 结果必须严格按 orderedIds 参数排——不能依赖任何持久化 read()。
+        assertEquals(userDraggedOrder, result.map { it.sticker_id })
+    }
+
+    @Test
+    fun `reorderCache preserves server-fresh ids by appending to tail`() {
+        // 用户只拖过 c、a；b、d 是别端刚同步来的新贴纸（用户还没拖过）。
+        val cache = listOf(mk("a"), mk("b"), mk("c"), mk("d"))
+        val partialUserOrder = listOf("c", "a")
+
+        val result = WKStickerManager.reorderCache(partialUserOrder, cache)
+
+        // 前置 c、a；未登记的 b、d 按 cache 顺序追加尾部。
+        assertEquals(listOf("c", "a", "b", "d"), result.map { it.sticker_id })
+    }
+
+    @Test
+    fun `reorderCache with empty params returns cache unchanged`() {
+        val cache = listOf(mk("a"), mk("b"))
+        val result = WKStickerManager.reorderCache(emptyList(), cache)
+        assertEquals(listOf("a", "b"), result.map { it.sticker_id })
+    }
+}


### PR DESCRIPTION
## Summary
本次批量合入 5 组独立可追溯的 chat 侧改动（10 笔 commit / 50 文件 / +3722 −50）：

| Issue | 主题 | 类型 |
|---|---|---|
| #87 | 消息撤回经常无反应 —— 修 messageID 参数 + 双路径 | bug |
| #88 | 群名 / 子区名超长静默截断 —— 节流 toast + 上限调整 | enhancement |
| #89 | release 包频道搜索 ClassCastException —— 补 proguard keep | bug |
| #90 | 聊天窗口内文件预览（PDF / xlsx / 文本）+ 修长文件名下载失败 | feature |
| #91 | 自定义贴纸功能（发送 / 接收 / 收藏 / 删除 / 排序 / 上传）| feature |

Closes #87
Closes #88
Closes #89
Closes #90
Closes #91

## 关键设计决策
- **撤回双路径**：HTTP 200 后立即本地 mark，不再单靠服务端 CMD → syncExtraMsg（后者有 cache bug，miss 率 ~66%）；messageID 空/`'0'` 时传空串让服务端反查
- **贴纸不引入 Lottie SDK**：静态图走 Glide，`.lim / .json` 走占位图降级；两种新 contentType 12/13 走独立 provider，不继承 `WKImageProvider`
- **贴纸编辑态自研 touch dispatch**：`ItemTouchHelper.isLongPressDragEnabled = false`，用 `EditModeTouchListener` 在同一次长按里区分 preview（hold-still ≥500ms 弹预览）和 drag（超 touchSlop 才 startDrag）
- **贴纸重排**：服务端无接口，本地 SP `sticker_order_{uid}` 存顺序；reorder 直接用参数排序不走 SP 读回路径，避免 apply() 异步落盘 race
- **文件预览零依赖**：PDF 走 Android 原生 `PdfRenderer`；xlsx 自写 `XlsxParser` 解析 sharedStrings/workbook/sheet → HTML → WebView（JS 已关闭）
- **名称长度节流**：`ThrottledRunnable` + `StringUtils.attachLengthLimit()` 一行 API，收敛 3 处 EditText + 10+ 弹窗调用方

## 影响 & 风险
- 未改任何消息收发 / 存储 / 同步 / 通知 / 子区 / 转发核心路径；贴纸走 Provider 注入模式与既有消息互不影响
- release proguard 已补两处 keep（`com.chat.uikit.chat.sticker.**` 和 `com.chat.base.search.channel.dto.**`），避免 R8 混淆导致 FastJson 反序列化崩溃
- 单测新增 4 个测试类共 38 个 case（`WKStickerContentTest / StickerUrlUtilsTest / StickerLocalOrderStoreTest / StickerUploadValidatorTest`）

## Test plan
- [ ] 撤回：单聊 / 群聊 / 子区自己发的消息撤回一次成功，不再需要重试
- [ ] 撤回：他人撤回消息 CMD 到达后本地能刷新为"已撤回"
- [ ] 名称长度：群名 / 子区名 / 加好友备注 / Space 名 / 群昵称 打字触顶弹 toast，2s 内粘贴超长不刷屏
- [ ] release 频道搜索：Message / All / Media / File 4 个 tab 不再崩溃
- [ ] 文件预览：pdf / xlsx / txt 消息底部"预览"按钮工作正常，其它扩展名隐藏"预览"
- [ ] 长文件名（100+ 中文/emoji）文件下载不再静默失败
- [ ] 贴纸发送：面板选贴图能正常发送，对端能收到并显示
- [ ] 贴纸收藏：长按他人贴图菜单出现"添加到我的表情"，收藏后重复长按菜单不再出现
- [ ] 贴纸编辑：长按进编辑态，tap × 二次确认删除，长按 hold ≥500ms 弹预览，长按拖动排序，切 tab / tap 空白退出
- [ ] 贴纸上传：+ 号选图，超 1024KB / 长边 >512px / 非 gif/png/jpg/webp 会被客户端校验拦截
- [ ] 贴纸详情弹窗：消息内 tap 贴图 "发送 + 添加"；面板编辑态外长按 "发送 + 删除"
- [ ] **release 包全量回归**：贴纸收藏 / 频道搜索这两个 R8 敏感路径重点验证