### PR TITLE
feat(emoji): 服务端 manifest 拉取（内置表情元数据同步）

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -204,6 +204,12 @@
 # 导致 collect / list 反序列化失败 → release 包"添加到我的表情"回调走 onFail
 -keep class com.chat.uikit.chat.sticker.** { *; }
 -keep interface com.chat.uikit.chat.sticker.StickerService { *; }
+# 内置表情 manifest DTO (wkbase)：EmojiManifestResp / EmojiManifestItem
+# GET /v1/common/emojis 走 FastJson 反射按字段名映射 {version, list:[{key,name,url}]}，
+# 不 keep 会被 R8 重命名字段 → 反序列化出空对象 → refreshFromServer 静默失败
+# → 无法应用服务端新增 emoji（同 sticker/search 类型问题的第 3 次踩坑）
+-keep class com.chat.base.emoji.EmojiManifestResp { *; }
+-keep class com.chat.base.emoji.EmojiManifestItem { *; }
 #----------客服------------------
 -keep class com.chat.customerservice.entity.** { *; }
 #----------隐私安全------------------

--- a/wkbase/src/main/java/com/chat/base/WKBaseApplication.java
+++ b/wkbase/src/main/java/com/chat/base/WKBaseApplication.java
@@ -182,7 +182,13 @@ public class WKBaseApplication {
         //   EmojiManager 现在是 idempotent 的：文本 hot path（WKTextProvider / MoonUtil /
         //   SelectTextHelper / WKUIChatMsgItemEntity）里 getPattern() 等入口都会
         //   ensureInitialized()，真撞上 Phase-C 之前的访问也能同步补齐。
-        AppStartup.postPhaseC("emoji", () -> EmojiManager.getInstance().init());
+        AppStartup.postPhaseC("emoji", () -> {
+            EmojiManager.getInstance().init();
+            // 冷启动后同一 Phase-C 里追加一次服务端 manifest 拉取（fire-and-forget）：
+            // 成功后合并进 text2entry + 重建 pattern，未来服务端新增内置表情 Android 无需发版即可显示。
+            // 失败保留 xml + 上次 SP 缓存，静默 log。
+            EmojiManager.getInstance().refreshFromServer();
+        });
 
         // Glide + cacheDir 不依赖 SP，先执行，给 EncryptedSP 后台线程更多时间
         Glide.get(context).getRegistry().replace(GlideUrl.class, InputStream.class, new OkHttpUrlLoader.Factory());

--- a/wkbase/src/main/java/com/chat/base/common/WKCommonModel.java
+++ b/wkbase/src/main/java/com/chat/base/common/WKCommonModel.java
@@ -25,6 +25,7 @@ import com.chat.base.base.WKBaseModel;
 import com.chat.base.config.WKConfig;
 import com.chat.base.config.WKConstants;
 import com.chat.base.config.WKSharedPreferencesUtil;
+import com.chat.base.emoji.EmojiManifestResp;
 import com.chat.base.endpoint.EndpointManager;
 import com.chat.base.entity.AppModule;
 import com.chat.base.entity.AppVersion;
@@ -309,5 +310,28 @@ public class WKCommonModel extends WKBaseModel {
 
     public interface IAppModule {
         void onResult(int code, String msg, List<AppModule> list);
+    }
+
+    /**
+     * 拉取服务端内置自定义表情清单 {@code GET /v1/common/emojis}（公开无鉴权）。
+     * 失败时 callback 收到 null，呼叫方保留本地 fallback（内置 xml + 上次缓存）。
+     */
+    public void getEmojis(final IEmojiManifest callback) {
+        request(createService(WKCommonService.class).getEmojis(), new IRequestResultListener<EmojiManifestResp>() {
+            @Override
+            public void onSuccess(EmojiManifestResp result) {
+                if (callback != null) callback.onResult(result);
+            }
+
+            @Override
+            public void onFail(int code, String msg) {
+                if (callback != null) callback.onResult(null);
+            }
+        });
+    }
+
+    public interface IEmojiManifest {
+        /** @param manifest 拉取成功给非 null；网络失败或反序列化失败给 null，呼叫方走本地兜底 */
+        void onResult(EmojiManifestResp manifest);
     }
 }

--- a/wkbase/src/main/java/com/chat/base/common/WKCommonService.java
+++ b/wkbase/src/main/java/com/chat/base/common/WKCommonService.java
@@ -16,6 +16,7 @@
 
 package com.chat.base.common;
 
+import com.chat.base.emoji.EmojiManifestResp;
 import com.chat.base.entity.AppModule;
 import com.chat.base.entity.ChannelInfoEntity;
 import com.chat.base.entity.WKAPPConfig;
@@ -47,4 +48,9 @@ interface WKCommonService {
 
     @GET("common/appmodule")
     Observable<List<AppModule>> getAppModule();
+
+    /** 服务端 GET /v1/common/emojis：公开无鉴权，返回内置自定义表情清单。响应体
+     *  是顶层 {version, list}，无 {status, data, msg} 信封，故 T 直接是 {@link EmojiManifestResp}。 */
+    @GET("common/emojis")
+    Observable<EmojiManifestResp> getEmojis();
 }

--- a/wkbase/src/main/java/com/chat/base/emoji/EmojiManager.java
+++ b/wkbase/src/main/java/com/chat/base/emoji/EmojiManager.java
@@ -28,13 +28,14 @@ import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.text.TextUtils;
-import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.Xml;
 
 import androidx.collection.LruCache;
 
+import com.chat.base.BuildConfig;
 import com.chat.base.WKBaseApplication;
+import com.chat.base.common.WKCommonModel;
 import com.chat.base.utils.WKLogUtils;
 
 import org.jetbrains.annotations.NotNull;
@@ -45,31 +46,42 @@ import org.xml.sax.helpers.DefaultHandler;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public class EmojiManager {
 
+    private static final String TAG = "EmojiManager";
     private final String EMOT_DIR = "emoji/";
 
     // max cache size
     private final int CACHE_MAX_SIZE = 1024;
 
-    private Pattern pattern;
+    // Hot-path 字段全部 volatile：applyManifest 通过 copy-on-write 构建新引用后原子 swap，
+    // 消费端（MoonUtil / WKTextProvider / SelectTextHelper / WKUIChatMsgItemEntity）
+    // 无锁读安全。原 field 直接 mutate 的模式在只 init 一次时安全，但 refreshFromServer
+    // 引入后会与读者并发，必须改成不可变引用替换。
+    private volatile Pattern pattern;
+    private volatile Map<String, Entry> text2entry = Collections.emptyMap();
+    private volatile List<Entry> defaultEntries = Collections.emptyList();
+    private volatile String currentSig = "";
+
     //  (P-04) — init() 幂等标记，供 ensureInitialized() 使用。
     private volatile boolean initialized = false;
 
-    // default entries
-    private final List<Entry> defaultEntries = new ArrayList<>();
-    // text to entry
-    private final Map<String, Entry> text2entry = new HashMap<>();
+    // 内置 xml 加载的一份原始副本（applyManifest 的 base），init 后不再改。
+    private Map<String, Entry> xmlText2entry = Collections.emptyMap();
+    private List<Entry> xmlDefaultEntries = Collections.emptyList();
+
     // asset bitmap cache, key: asset path
     private LruCache<String, Bitmap> drawableCache;
-
-    private String patternStr = "";
 
     private EmojiManager() {
 
@@ -109,8 +121,22 @@ public class EmojiManager {
             return;
         }
 
-        load(context, EMOT_DIR + "emoji.xml");
-        pattern = makePattern();
+        // 1) 从 xml 加载出内置真源（保留一份不可变副本，applyManifest 时以此为 base）
+        List<Entry> xmlEntries = new ArrayList<>();
+        Map<String, Entry> xmlMap = new LinkedHashMap<>();
+        new EntryLoader(xmlMap, xmlEntries).load(context, EMOT_DIR + "emoji.xml");
+        xmlDefaultEntries = Collections.unmodifiableList(xmlEntries);
+        xmlText2entry = Collections.unmodifiableMap(xmlMap);
+
+        // 2) 首屏立即可用：先按 xml 状态跑一次 applyManifest（无 manifest = 纯 xml）
+        applyManifestInternal(Collections.<EmojiManifestItem>emptyList());
+
+        // 3) SP 里若有上次缓存的 manifest，立刻 apply 一次（避免"首屏没有服务端新增表情"）
+        EmojiManifestResp cached = EmojiManifestCache.load();
+        if (cached != null && cached.list != null) {
+            applyManifestInternal(EmojiManifestSanitizer.sanitize(cached.list));
+        }
+
         drawableCache = new LruCache<String, Bitmap>(CACHE_MAX_SIZE) {
             @Override
             protected void entryRemoved(boolean evicted, @NotNull String key, @NotNull Bitmap oldValue, Bitmap newValue) {
@@ -131,15 +157,169 @@ public class EmojiManager {
         }
     }
 
-    private static class Entry {
-        String text;
-        String assetPath;
-        String id;
+    /**
+     * 拉取服务端最新 emoji 清单，成功后合并进 text2entry + defaultEntries 并重建 pattern。
+     * fire-and-forget 语义——失败保留当前状态（xml + 上次缓存），静默 log。
+     *
+     * <p>调用时机：{@link com.chat.base.WKBaseApplication} 的 {@code AppStartup.postPhaseC}
+     * 里 {@link #init()} 后紧跟一次。运行时其它场景不主动重刷（服务端 clean install 稀有事件，
+     * 冷启动一次覆盖足够；后续用户看到的表情池自然是"当前 session 起点 + 未来的合并"）。
+     */
+    public void refreshFromServer() {
+        ensureInitialized();
+        WKCommonModel.getInstance().getEmojis(new WKCommonModel.IEmojiManifest() {
+            @Override
+            public void onResult(EmojiManifestResp manifest) {
+                if (manifest == null || manifest.list == null) {
+                    // 网络失败 / 反序列化失败——保留当前状态。呼叫方无 UI 需要通知。
+                    return;
+                }
+                List<EmojiManifestItem> clean = EmojiManifestSanitizer.sanitize(manifest.list);
+                if (clean.isEmpty()) {
+                    // 服务端理论上不会下发空 list（parseEmojiManifest 会 reject），
+                    // 走到这里意味着 sanitize 把所有条目都 drop 了——保留当前状态更安全。
+                    return;
+                }
+                boolean changed = applyManifestInternal(clean);
+                if (changed) {
+                    EmojiManifestCache.save(manifest);
+                }
+            }
+        });
+    }
+
+    /**
+     * 合并 manifest 到内部数据结构（copy-on-write），返回是否发生实际变化。
+     * 变化用 sig（内容签名）判断——服务端下发跟本地 sig 一致时短路，避免无谓重建 pattern。
+     *
+     * <p>合并策略（merge, 不删）：
+     * <ol>
+     *   <li>base = 内置 xml 全部条目</li>
+     *   <li>manifest 中的 key：若 xml 里已有同 key，用 xml 的 id + assetPath；若无（未来新增），
+     *       id 走 {@link #deriveIdFromKey(String)}，assetPath = null，remoteUrl = item.url</li>
+     *   <li>defaultEntries 排序：manifest customs 按 manifest 顺序在前 → xml customs 未在
+     *       manifest 的（保留兜底）→ 全部非 custom（Unicode）按 xml 顺序在后</li>
+     * </ol>
+     */
+    synchronized boolean applyManifestInternal(List<EmojiManifestItem> sanitizedItems) {
+        String newSig = signatureOf(sanitizedItems);
+        if (newSig.equals(currentSig) && !text2entry.isEmpty()) {
+            return false;
+        }
+
+        // 1) 起点是 xml 的完整副本（可变）
+        Map<String, Entry> newMap = new LinkedHashMap<>(xmlText2entry);
+
+        // 2) manifest 覆盖同 key（url 空则退化成 xml 已有 asset；url 非空则记 remoteUrl）
+        //    manifest 新 key 直接加进 map（xml 里没有）
+        List<Entry> manifestCustoms = new ArrayList<>(sanitizedItems.size());
+        Set<String> seenManifestKeys = new HashSet<>();
+        for (EmojiManifestItem item : sanitizedItems) {
+            Entry existing = xmlText2entry.get(item.key);
+            String id = existing != null ? existing.id : deriveIdFromKey(item.key);
+            String assetPath = existing != null ? existing.assetPath : null;
+            String remoteUrl = item.url == null ? "" : item.url;
+            String name = item.name;
+            Entry merged = new Entry(id, item.key, assetPath, remoteUrl, name);
+            newMap.put(item.key, merged);
+            manifestCustoms.add(merged);
+            seenManifestKeys.add(item.key);
+        }
+
+        // 3) defaultEntries 排序：manifest customs 在前 → xml-only customs → Unicode
+        List<Entry> newDefaults = new ArrayList<>(manifestCustoms.size() + xmlDefaultEntries.size());
+        newDefaults.addAll(manifestCustoms);
+        for (Entry e : xmlDefaultEntries) {
+            boolean isCustom = e.id != null && e.id.startsWith("custom_");
+            if (isCustom && !seenManifestKeys.contains(e.text)) {
+                // xml 里有但 manifest 没下发——保留（"merge 不删"语义）
+                newDefaults.add(e);
+            }
+        }
+        for (Entry e : xmlDefaultEntries) {
+            boolean isCustom = e.id != null && e.id.startsWith("custom_");
+            if (!isCustom) {
+                newDefaults.add(e);
+            }
+        }
+
+        // 4) 重建 pattern（用新的 defaults）
+        Pattern newPattern = buildPattern(newDefaults);
+
+        // 5) volatile swap（唯一"发布"点，happens-before 保证消费端看到一致状态）
+        this.text2entry = Collections.unmodifiableMap(newMap);
+        this.defaultEntries = Collections.unmodifiableList(newDefaults);
+        this.pattern = newPattern;
+        this.currentSig = newSig;
+
+        Log.i(TAG, "applyManifest: manifestItems=" + sanitizedItems.size()
+                + " panelEntries=" + newDefaults.size() + " sig=" + newSig);
+        // 每 item 逐行 log 只在 debug 打——release 场景没必要每次冷启动灌 N 行；
+        // 顶层那条汇总日志（manifestItems + panelEntries）保留 release 也有，
+        // 出问题时能立刻看出 manifest 拉没拉到、数量对不对。
+        if (BuildConfig.DEBUG) {
+            for (EmojiManifestItem item : sanitizedItems) {
+                Log.d(TAG, "  item key=" + item.key + " name=" + item.name
+                        + " url=" + (item.url == null || item.url.isEmpty() ? "(none)" : item.url));
+            }
+        }
+        return true;
+    }
+
+    /** manifest 里新增的 key（xml 无兜底）派生一个稳定 id：{@code custom_<hex>}。
+     *  必须以 {@code custom_} 开头以满足 {@link #isCustomEmoji(String)} 的判定。 */
+    private static String deriveIdFromKey(String key) {
+        // 简单稳定哈希——冲突概率极低（几个新增 emoji），无需 MD5 复杂度
+        long h = 1125899906842597L;
+        for (int i = 0; i < key.length(); i++) h = 31 * h + key.charAt(i);
+        return "custom_" + Long.toHexString(h & 0x7fffffffffffffffL);
+    }
+
+    /** 内容签名：manifest items 完全一致 → 相同 sig，短路 apply。 */
+    private static String signatureOf(List<EmojiManifestItem> items) {
+        StringBuilder sb = new StringBuilder(64 + items.size() * 24);
+        sb.append("n=").append(items.size());
+        for (EmojiManifestItem it : items) {
+            sb.append('').append(it.key).append('').append(it.name).append('').append(it.url);
+        }
+        return sb.toString();
+    }
+
+    private static Pattern buildPattern(List<Entry> entries) {
+        StringBuilder sb = new StringBuilder(entries.size() * 8);
+        sb.append("(");
+        boolean first = true;
+        for (Entry e : entries) {
+            if (e.text == null || e.text.isEmpty()) continue;
+            if (!first) sb.append("|");
+            sb.append(Pattern.quote(e.text));
+            first = false;
+        }
+        sb.append(")");
+        return Pattern.compile(sb.toString());
+    }
+
+    static final class Entry {
+        final String text;
+        final String assetPath;
+        final String id;
+        /** 服务端 manifest 下发的图片 URL。空 = 用 {@link #assetPath} 本地兜底；
+         *  非空 = 未来 Layer 3 走 Glide 加载（当前 MVP 期不消费此字段，仅存储）。 */
+        final String remoteUrl;
+        /** 服务端 manifest 下发的人类可读名；xml 加载时留空，仅 manifest 派生的条目有值。
+         *  选择器 title / 无障碍文本可以用（当前消费方主要用 text/id，为未来预留）。 */
+        final String name;
 
         Entry(String id, String text, String assetPath) {
+            this(id, text, assetPath, "", "");
+        }
+
+        Entry(String id, String text, String assetPath, String remoteUrl, String name) {
             this.text = text;
             this.id = id;
             this.assetPath = assetPath;
+            this.remoteUrl = remoteUrl == null ? "" : remoteUrl;
+            this.name = name == null ? "" : name;
         }
     }
 
@@ -150,15 +330,15 @@ public class EmojiManager {
 
     public Drawable getDisplayDrawable(Context context, int index) {
         ensureInitialized();
-        String text = (index >= 0 && index < defaultEntries.size() ?
-                defaultEntries.get(index).text : null);
+        List<Entry> list = defaultEntries;
+        String text = (index >= 0 && index < list.size() ? list.get(index).text : null);
         return text == null ? null : getDrawable(context, text);
     }
 
     public String getDisplayText(int index) {
         ensureInitialized();
-        return index >= 0 && index < defaultEntries.size() ? defaultEntries
-                .get(index).text : null;
+        List<Entry> list = defaultEntries;
+        return index >= 0 && index < list.size() ? list.get(index).text : null;
     }
 
     public Pattern getPattern() {
@@ -168,26 +348,26 @@ public class EmojiManager {
 
     public Drawable getDrawableWithTag(Context context, String tag) {
         ensureInitialized();
-        Drawable drawable = null;
-        for (int i = 0; i < defaultEntries.size(); i++) {
-            if (defaultEntries.get(i).id.equals(tag)) {
-                drawable = getDrawable(context, defaultEntries.get(i).text);
-                break;
+        List<Entry> list = defaultEntries;
+        for (int i = 0; i < list.size(); i++) {
+            if (list.get(i).id.equals(tag)) {
+                return getDrawable(context, list.get(i).text);
             }
         }
-        return drawable;
+        return null;
     }
-    public EmojiEntry getEmojiWithTag(String tag){
+
+    public EmojiEntry getEmojiWithTag(String tag) {
         ensureInitialized();
-        EmojiEntry entry = null;
-        for (int i = 0; i < defaultEntries.size(); i++) {
-            if (defaultEntries.get(i).id.equals(tag)) {
-                entry = new EmojiEntry(defaultEntries.get(i).id, defaultEntries.get(i).text, safeAssetPath(defaultEntries.get(i).assetPath));
-                break;
+        List<Entry> list = defaultEntries;
+        for (int i = 0; i < list.size(); i++) {
+            if (list.get(i).id.equals(tag)) {
+                return new EmojiEntry(list.get(i).id, list.get(i).text, safeAssetPath(list.get(i).assetPath));
             }
         }
-        return entry;
+        return null;
     }
+
     public EmojiEntry getEmojiEntry(String text) {
         ensureInitialized();
         Entry entry = text2entry.get(text);
@@ -207,6 +387,13 @@ public class EmojiManager {
         ensureInitialized();
         Entry entry = text2entry.get(text);
         if (entry == null) {
+            return null;
+        }
+
+        // 服务端 manifest 下发但客户端未打包 asset 的情况（remoteUrl 非空且 assetPath 为 null）：
+        // 当前 MVP 不支持远程 URL 加载（web PR #492 的 Layer 3 能力），直接返 null 让消息渲染成
+        // [xxx] 文本降级。Glide 预下载 + ImageSpan 异步刷新是独立 PR 的工作量。
+        if (entry.assetPath == null && !TextUtils.isEmpty(entry.remoteUrl)) {
             return null;
         }
 
@@ -242,7 +429,7 @@ public class EmojiManager {
      */
     private Bitmap renderUnicodeBitmap(Context context, String text) {
         try {
-            DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+            android.util.DisplayMetrics metrics = context.getResources().getDisplayMetrics();
             int sizePx = Math.round(60f * metrics.density);
             if (sizePx <= 0) sizePx = 60;
 
@@ -267,38 +454,12 @@ public class EmojiManager {
         }
     }
 
-    //
-    // internal
-    //
-
-    private Pattern makePattern() {
-        return Pattern.compile(patternOfDefault());
-    }
-
-    private String patternOfDefault() {
-//        return "\\[[^\\[]{1,10}\\]";
-        if (TextUtils.isEmpty(patternStr)) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("(");
-            for (int i = 0, size = defaultEntries.size(); i < size; i++) {
-                if (!sb.toString().endsWith("(")) {
-                    sb.append("|");
-                }
-                sb.append(Pattern.quote(defaultEntries.get(i).text));
-            }
-            sb.append(")");
-            patternStr = sb.toString();
-        }
-        return patternStr;
-        // return "[^\\u0000-\\uFFFF]";
-    }
-
     private Bitmap loadAssetBitmap(Context context, String assetPath) {
         InputStream is = null;
         try {
             Resources resources = context.getResources();
             Options options = new Options();
-            options.inDensity = DisplayMetrics.DENSITY_HIGH;
+            options.inDensity = android.util.DisplayMetrics.DENSITY_HIGH;
             options.inScreenDensity = resources.getDisplayMetrics().densityDpi;
             options.inTargetDensity = resources.getDisplayMetrics().densityDpi;
             is = context.getAssets().open(assetPath);
@@ -321,15 +482,18 @@ public class EmojiManager {
         return null;
     }
 
-    private void load(Context context, String xmlPath) {
-        new EntryLoader().load(context, xmlPath);
-    }
-
     //
     // load emoticons from asset
     //
     private class EntryLoader extends DefaultHandler {
         private String catalog = "";
+        private final Map<String, Entry> outMap;
+        private final List<Entry> outDefaults;
+
+        EntryLoader(Map<String, Entry> outMap, List<Entry> outDefaults) {
+            this.outMap = outMap;
+            this.outDefaults = outDefaults;
+        }
 
         void load(Context context, String assetPath) {
             InputStream is = null;
@@ -362,9 +526,9 @@ public class EmojiManager {
                         ? null
                         : EMOT_DIR + catalog + "/" + fileName;
                 Entry entry = new Entry(id, tag, assetPath);
-                text2entry.put(entry.text, entry);
+                outMap.put(entry.text, entry);
                 if (catalog.equals("default")) {
-                    defaultEntries.add(entry);
+                    outDefaults.add(entry);
                 }
             }
         }
@@ -380,36 +544,38 @@ public class EmojiManager {
     }
 
     public boolean isHeart(String tag) {
-        if (!text2entry.containsKey(tag)) return false;
-        return Objects.requireNonNull(text2entry.get(tag)).id.equals("2_0")
-                || Objects.requireNonNull(text2entry.get(tag)).id.equals("2_1")
-                || Objects.requireNonNull(text2entry.get(tag)).id.equals("2_2")
-                || Objects.requireNonNull(text2entry.get(tag)).id.equals("2_3")
-                || Objects.requireNonNull(text2entry.get(tag)).id.equals("2_4")
-                || Objects.requireNonNull(text2entry.get(tag)).id.equals("2_5")
-                || Objects.requireNonNull(text2entry.get(tag)).id.equals("2_6")
-                || Objects.requireNonNull(text2entry.get(tag)).id.equals("2_7")
-                || Objects.requireNonNull(text2entry.get(tag)).id.equals("2_8");
+        Map<String, Entry> map = text2entry;
+        if (!map.containsKey(tag)) return false;
+        return Objects.requireNonNull(map.get(tag)).id.equals("2_0")
+                || Objects.requireNonNull(map.get(tag)).id.equals("2_1")
+                || Objects.requireNonNull(map.get(tag)).id.equals("2_2")
+                || Objects.requireNonNull(map.get(tag)).id.equals("2_3")
+                || Objects.requireNonNull(map.get(tag)).id.equals("2_4")
+                || Objects.requireNonNull(map.get(tag)).id.equals("2_5")
+                || Objects.requireNonNull(map.get(tag)).id.equals("2_6")
+                || Objects.requireNonNull(map.get(tag)).id.equals("2_7")
+                || Objects.requireNonNull(map.get(tag)).id.equals("2_8");
     }
 
 
     public List<EmojiEntry> getEmojiWithType(String type) {
         ensureInitialized();
+        List<Entry> source = defaultEntries;
         List<EmojiEntry> list = new ArrayList<>();
-        for (int i = 0, size = defaultEntries.size(); i < size; i++) {
-            if (defaultEntries.get(i).id.contains("color")) {
+        for (int i = 0, size = source.size(); i < size; i++) {
+            if (source.get(i).id.contains("color")) {
                 continue;
             }
             boolean isAdd = true;
             for (EmojiEntry entry : list) {
-                if (entry.getText().equals(defaultEntries.get(i).text)) {
+                if (entry.getText().equals(source.get(i).text)) {
                     isAdd = false;
                     break;
                 }
             }
             if (isAdd) {
-                if (defaultEntries.get(i).id.startsWith(type)) {
-                    EmojiEntry entry = new EmojiEntry(defaultEntries.get(i).id, defaultEntries.get(i).text, safeAssetPath(defaultEntries.get(i).assetPath));
+                if (source.get(i).id.startsWith(type)) {
+                    EmojiEntry entry = new EmojiEntry(source.get(i).id, source.get(i).text, safeAssetPath(source.get(i).assetPath));
                     list.add(entry);
                 }
             }

--- a/wkbase/src/main/java/com/chat/base/emoji/EmojiManager.java
+++ b/wkbase/src/main/java/com/chat/base/emoji/EmojiManager.java
@@ -338,7 +338,8 @@ public class EmojiManager {
         return sb.toString();
     }
 
-    private static Pattern buildPattern(List<Entry> entries) {
+    /** package-private 便于单测 buildPattern 空 list 兜底行为。 */
+    static Pattern buildPattern(List<Entry> entries) {
         StringBuilder sb = new StringBuilder(entries.size() * 8);
         sb.append("(");
         boolean first = true;
@@ -349,6 +350,10 @@ public class EmojiManager {
             first = false;
         }
         sb.append(")");
+        // Defensive：空 entry 会得到 "()" 一直零宽匹配——理论上不可达（xml + manifest 至少一层），
+        // 但 asset 缺失 + 无缓存时可能命中。返回**永不匹配**的 (?!) 而不是零宽 ()，
+        // 避免消费端在渲染循环里遇到零宽 span 的边界情况。
+        if (first) return Pattern.compile("(?!)");
         return Pattern.compile(sb.toString());
     }
 

--- a/wkbase/src/main/java/com/chat/base/emoji/EmojiManager.java
+++ b/wkbase/src/main/java/com/chat/base/emoji/EmojiManager.java
@@ -47,13 +47,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.regex.Pattern;
 
 public class EmojiManager {
@@ -77,11 +78,23 @@ public class EmojiManager {
     private volatile boolean initialized = false;
 
     // 内置 xml 加载的一份原始副本（applyManifest 的 base），init 后不再改。
-    private Map<String, Entry> xmlText2entry = Collections.emptyMap();
-    private List<Entry> xmlDefaultEntries = Collections.emptyList();
+    // 用 volatile 引用替换保证可见性——虽然当前实现下 initialized 屏障+同步 init() 已经足够，
+    // 但 volatile 让这个不变量在代码上强制表达（避免未来加新入口时忘了走 ensureInitialized）。
+    private volatile Map<String, Entry> xmlText2entry = Collections.emptyMap();
+    private volatile List<Entry> xmlDefaultEntries = Collections.emptyList();
 
     // asset bitmap cache, key: asset path
-    private LruCache<String, Bitmap> drawableCache;
+    // volatile 保证 init() 里赋值对其它线程 read 可见（同上）。
+    private volatile LruCache<String, Bitmap> drawableCache;
+
+    // 后台单线程执行 applyManifest + cache.save——避免在 UI 线程做正则编译 + SP 同步序列化。
+    // WKBaseModel.request 用的是 observeOn(mainThread())，回调本身在主线程，所以要显式 hop 出去。
+    // 静态 lazy——只有真正拉到 manifest 时才启动线程，冷启动无网络场景零开销。
+    private static final ExecutorService applyExecutor = Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread(r, "emoji-apply");
+        t.setPriority(Thread.NORM_PRIORITY - 1);
+        return t;
+    });
 
     private EmojiManager() {
 
@@ -174,16 +187,20 @@ public class EmojiManager {
                     // 网络失败 / 反序列化失败——保留当前状态。呼叫方无 UI 需要通知。
                     return;
                 }
-                List<EmojiManifestItem> clean = EmojiManifestSanitizer.sanitize(manifest.list);
-                if (clean.isEmpty()) {
-                    // 服务端理论上不会下发空 list（parseEmojiManifest 会 reject），
-                    // 走到这里意味着 sanitize 把所有条目都 drop 了——保留当前状态更安全。
-                    return;
-                }
-                boolean changed = applyManifestInternal(clean);
-                if (changed) {
-                    EmojiManifestCache.save(manifest);
-                }
+                // WKBaseModel.request 用 observeOn(mainThread())，回调本身在主线程。
+                // sanitize + build maps + Pattern.compile + SP.save 都不轻——hop 到后台线程
+                // 避免冷启动 Phase-C 期间的主线程 jank（Phase-C 存在的意义就是 off main）。
+                // volatile swap 从任何线程 publish 都对读者可见，安全。
+                applyExecutor.execute(() -> {
+                    List<EmojiManifestItem> clean = EmojiManifestSanitizer.sanitize(manifest.list);
+                    if (clean.isEmpty()) {
+                        return;
+                    }
+                    boolean changed = applyManifestInternal(clean);
+                    if (changed) {
+                        EmojiManifestCache.save(manifest);
+                    }
+                });
             }
         });
     }
@@ -195,11 +212,17 @@ public class EmojiManager {
      * <p>合并策略（merge, 不删）：
      * <ol>
      *   <li>base = 内置 xml 全部条目</li>
-     *   <li>manifest 中的 key：若 xml 里已有同 key，用 xml 的 id + assetPath；若无（未来新增），
-     *       id 走 {@link #deriveIdFromKey(String)}，assetPath = null，remoteUrl = item.url</li>
+     *   <li>manifest item 若 xml 里已有同 key：用 xml 的 id + assetPath，同时刷新 name/url
+     *       (name 只做元数据；url 存进 remoteUrl 供未来 Layer 3 使用)</li>
+     *   <li>manifest item 若 xml 里没有（即"服务端新增未打包"）：<b>整个跳过</b>——
+     *       当前 MVP 不支持远程加载（Layer 3 独立 PR），加进 defaultEntries 会显示为**空白格子**
+     *       （PR #94 review B1 明确要求排除）；进入 text2entry 也会让消息 pattern 匹配到但
+     *       getDrawable 返 null，无用</li>
      *   <li>defaultEntries 排序：manifest customs 按 manifest 顺序在前 → xml customs 未在
      *       manifest 的（保留兜底）→ 全部非 custom（Unicode）按 xml 顺序在后</li>
      * </ol>
+     *
+     * <p><b>可能被后台 executor 或 init() 主线程调用</b>——{@code synchronized} 保证互斥。
      */
     synchronized boolean applyManifestInternal(List<EmojiManifestItem> sanitizedItems) {
         String newSig = signatureOf(sanitizedItems);
@@ -207,56 +230,24 @@ public class EmojiManager {
             return false;
         }
 
-        // 1) 起点是 xml 的完整副本（可变）
-        Map<String, Entry> newMap = new LinkedHashMap<>(xmlText2entry);
+        // core 合并逻辑抽到纯函数——JVM 单测覆盖"manifest-only key 是否会污染 panel"契约
+        MergeResult merged = mergeXmlAndManifest(xmlText2entry, xmlDefaultEntries, sanitizedItems);
 
-        // 2) manifest 覆盖同 key（url 空则退化成 xml 已有 asset；url 非空则记 remoteUrl）
-        //    manifest 新 key 直接加进 map（xml 里没有）
-        List<Entry> manifestCustoms = new ArrayList<>(sanitizedItems.size());
-        Set<String> seenManifestKeys = new HashSet<>();
-        for (EmojiManifestItem item : sanitizedItems) {
-            Entry existing = xmlText2entry.get(item.key);
-            String id = existing != null ? existing.id : deriveIdFromKey(item.key);
-            String assetPath = existing != null ? existing.assetPath : null;
-            String remoteUrl = item.url == null ? "" : item.url;
-            String name = item.name;
-            Entry merged = new Entry(id, item.key, assetPath, remoteUrl, name);
-            newMap.put(item.key, merged);
-            manifestCustoms.add(merged);
-            seenManifestKeys.add(item.key);
-        }
+        // 重建 pattern（用新的 defaults）
+        Pattern newPattern = buildPattern(merged.defaultEntries);
 
-        // 3) defaultEntries 排序：manifest customs 在前 → xml-only customs → Unicode
-        List<Entry> newDefaults = new ArrayList<>(manifestCustoms.size() + xmlDefaultEntries.size());
-        newDefaults.addAll(manifestCustoms);
-        for (Entry e : xmlDefaultEntries) {
-            boolean isCustom = e.id != null && e.id.startsWith("custom_");
-            if (isCustom && !seenManifestKeys.contains(e.text)) {
-                // xml 里有但 manifest 没下发——保留（"merge 不删"语义）
-                newDefaults.add(e);
-            }
-        }
-        for (Entry e : xmlDefaultEntries) {
-            boolean isCustom = e.id != null && e.id.startsWith("custom_");
-            if (!isCustom) {
-                newDefaults.add(e);
-            }
-        }
-
-        // 4) 重建 pattern（用新的 defaults）
-        Pattern newPattern = buildPattern(newDefaults);
-
-        // 5) volatile swap（唯一"发布"点，happens-before 保证消费端看到一致状态）
-        this.text2entry = Collections.unmodifiableMap(newMap);
-        this.defaultEntries = Collections.unmodifiableList(newDefaults);
+        // volatile swap（唯一"发布"点，happens-before 保证消费端看到一致状态）
+        this.text2entry = merged.text2entry;
+        this.defaultEntries = merged.defaultEntries;
         this.pattern = newPattern;
         this.currentSig = newSig;
 
+        // B6：full sig 可能很长（500 items × 2KB URL 可达 MB 级），release 日志不适合直接打。
+        // hash + count 足以做冷启动排查（"服务端返 4 item 匹配上次 hash"）；full 内容 debug 才打。
         Log.i(TAG, "applyManifest: manifestItems=" + sanitizedItems.size()
-                + " panelEntries=" + newDefaults.size() + " sig=" + newSig);
-        // 每 item 逐行 log 只在 debug 打——release 场景没必要每次冷启动灌 N 行；
-        // 顶层那条汇总日志（manifestItems + panelEntries）保留 release 也有，
-        // 出问题时能立刻看出 manifest 拉没拉到、数量对不对。
+                + " panelEntries=" + merged.defaultEntries.size()
+                + " skippedNoAsset=" + merged.skippedNoAsset
+                + " sigHash=" + Integer.toHexString(newSig.hashCode()));
         if (BuildConfig.DEBUG) {
             for (EmojiManifestItem item : sanitizedItems) {
                 Log.d(TAG, "  item key=" + item.key + " name=" + item.name
@@ -266,13 +257,75 @@ public class EmojiManager {
         return true;
     }
 
-    /** manifest 里新增的 key（xml 无兜底）派生一个稳定 id：{@code custom_<hex>}。
-     *  必须以 {@code custom_} 开头以满足 {@link #isCustomEmoji(String)} 的判定。 */
-    private static String deriveIdFromKey(String key) {
-        // 简单稳定哈希——冲突概率极低（几个新增 emoji），无需 MD5 复杂度
-        long h = 1125899906842597L;
-        for (int i = 0; i < key.length(); i++) h = 31 * h + key.charAt(i);
-        return "custom_" + Long.toHexString(h & 0x7fffffffffffffffL);
+    /** {@link #mergeXmlAndManifest} 的产物三元组：新 text2entry + 新 defaultEntries + skip 计数。
+     *  package-private 便于同包单测断言。 */
+    static final class MergeResult {
+        final Map<String, Entry> text2entry;
+        final List<Entry> defaultEntries;
+        final int skippedNoAsset;
+
+        MergeResult(Map<String, Entry> text2entry, List<Entry> defaultEntries, int skippedNoAsset) {
+            this.text2entry = text2entry;
+            this.defaultEntries = defaultEntries;
+            this.skippedNoAsset = skippedNoAsset;
+        }
+    }
+
+    /**
+     * 纯函数版合并——无 Android 依赖，供 JVM 单测覆盖"manifest-only key 不污染 panel"契约。
+     *
+     * <p>规则：
+     * <ul>
+     *   <li>manifest 中 xml 已有的 key：合并（id/assetPath 沿用 xml，name/url 用 manifest）</li>
+     *   <li>manifest 中 xml 未打包的 key：<b>整条跳过</b>——MVP 阶段无远程加载，
+     *       进面板会显示空白格子（PR #94 review B1）；进 text2entry 也只会让消息 pattern 匹配但 render 为空</li>
+     *   <li>defaultEntries 排序：manifest customs → xml-only customs → Unicode</li>
+     * </ul>
+     */
+    static MergeResult mergeXmlAndManifest(
+            Map<String, Entry> xmlText2entry,
+            List<Entry> xmlDefaultEntries,
+            List<EmojiManifestItem> sanitizedItems) {
+        Map<String, Entry> newMap = new LinkedHashMap<>(xmlText2entry);
+        List<Entry> manifestCustoms = new ArrayList<>(sanitizedItems.size());
+        Set<String> seenManifestKeys = new HashSet<>();
+        int skippedNoAsset = 0;
+        for (EmojiManifestItem item : sanitizedItems) {
+            Entry existing = xmlText2entry.get(item.key);
+            if (existing == null) {
+                // manifest 有但 xml 无——MVP 阶段跳过（Layer 3 上线后再解锁）
+                skippedNoAsset++;
+                continue;
+            }
+            String remoteUrl = item.url == null ? "" : item.url;
+            Entry mergedEntry = new Entry(existing.id, item.key, existing.assetPath, remoteUrl, item.name);
+            newMap.put(item.key, mergedEntry);
+            manifestCustoms.add(mergedEntry);
+            seenManifestKeys.add(item.key);
+        }
+
+        // defaultEntries 排序：manifest customs 在前 → xml-only customs → 其它
+        // B5 defensive：Unicode 分支也加 seenManifestKeys 判断，防未来 xml catalog 混入
+        // [xxx]-shape 非 custom entry 与 manifest key collision 造成重复
+        List<Entry> newDefaults = new ArrayList<>(manifestCustoms.size() + xmlDefaultEntries.size());
+        newDefaults.addAll(manifestCustoms);
+        for (Entry e : xmlDefaultEntries) {
+            boolean isCustom = e.id != null && e.id.startsWith("custom_");
+            if (isCustom && !seenManifestKeys.contains(e.text)) {
+                newDefaults.add(e);
+            }
+        }
+        for (Entry e : xmlDefaultEntries) {
+            boolean isCustom = e.id != null && e.id.startsWith("custom_");
+            if (!isCustom && !seenManifestKeys.contains(e.text)) {
+                newDefaults.add(e);
+            }
+        }
+
+        return new MergeResult(
+                Collections.unmodifiableMap(newMap),
+                Collections.unmodifiableList(newDefaults),
+                skippedNoAsset);
     }
 
     /** 内容签名：manifest items 完全一致 → 相同 sig，短路 apply。 */

--- a/wkbase/src/main/java/com/chat/base/emoji/EmojiManifestBodyLimitInterceptor.java
+++ b/wkbase/src/main/java/com/chat/base/emoji/EmojiManifestBodyLimitInterceptor.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.emoji;
+
+import androidx.annotation.NonNull;
+
+import java.io.IOException;
+import java.util.List;
+
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * 对 {@code GET /v1/common/emojis} 的 HTTP 响应做 raw-body 字节上限检查，防止 hostile
+ * 或误配的服务端（此端点<b>公开无鉴权</b>）推巨大 body → Retrofit + FastJson buffer
+ * 全内容后 parse 时 OOM。
+ *
+ * <p>Sanitizer 的 {@code MAX_ITEMS} / {@code MAX_URL_LEN} 都是**对象已解出后**才生效，
+ * 挡不住 parse-time OOM。此拦截器补齐这个前置边界（PR #94 Jerry-Xin C / yujiawei P1）。
+ *
+ * <p><b>作用范围严格限定</b>：只对 URL 路径末尾是 {@code common/emojis} 的请求生效，
+ * 不影响其它接口的 body 大小行为（避免"全局 body 上限"式误伤，如文件下载/大分页列表）。
+ *
+ * <p>双保险策略：
+ * <ol>
+ *   <li>先读 {@code Content-Length} header（cheap 检查，直接判断上限）；</li>
+ *   <li>无 Content-Length 或 chunked 编码下再用 {@link ResponseBody#peekBody(long)}
+ *       peek 到上限 + 1 字节，长度超过上限则拒绝。</li>
+ * </ol>
+ *
+ * <p>命中上限：关闭响应体、抛 {@link IOException}——Retrofit 收到后由
+ * {@code WKCommonModel.getEmojis} 的 {@code onFail} 兜底，本地保留 xml + 上次缓存。
+ */
+public final class EmojiManifestBodyLimitInterceptor implements Interceptor {
+
+    /** 1 MB。当前服务端 manifest 4 项 url="" 全部约 200 字节；这是 5000× 余量的合理上限。
+     *  即使未来加带 CDN URL 的表情，单条 URL 2KB × 500 项理论上限也才 1MB。 */
+    static final long MAX_MANIFEST_BODY_BYTES = 1024L * 1024L;
+
+    @NonNull
+    @Override
+    public Response intercept(@NonNull Chain chain) throws IOException {
+        Request request = chain.request();
+        if (!isEmojiManifestUrl(request)) {
+            return chain.proceed(request);
+        }
+        Response response = chain.proceed(request);
+        ResponseBody body = response.body();
+        if (body == null) {
+            return response;
+        }
+
+        // 快路径：Content-Length 已知且超上限直接拒
+        long contentLength = body.contentLength();
+        if (contentLength > MAX_MANIFEST_BODY_BYTES) {
+            response.close();
+            throw new IOException("emoji manifest body too large: Content-Length="
+                    + contentLength + " > " + MAX_MANIFEST_BODY_BYTES);
+        }
+
+        // 慢路径：Content-Length 缺失 / chunked / 服务端说谎——peek 上限+1 字节
+        // peekBody 在 body 更大时会返回**至多** byteCount 字节，所以 byteCount = MAX+1 时
+        // 拿到的字节数 > MAX 说明真实 body 至少有 MAX+1 → 超限。
+        ResponseBody peeked = response.peekBody(MAX_MANIFEST_BODY_BYTES + 1);
+        byte[] bytes = peeked.bytes();
+        if (bytes.length > MAX_MANIFEST_BODY_BYTES) {
+            response.close();
+            throw new IOException("emoji manifest body exceeds " + MAX_MANIFEST_BODY_BYTES + " bytes");
+        }
+
+        // 用已 peek 到的字节重建 response body（原 body 已随 peek 处于可再消费但等价的状态；
+        // 但严谨起见我们把 peek 到的字节直接作为新 body，让下游 Retrofit 消费）。
+        MediaType contentType = body.contentType();
+        response.close();
+        return response.newBuilder()
+                .body(ResponseBody.create(bytes, contentType))
+                .build();
+    }
+
+    /** 匹配 URL 路径末尾为 {@code common/emojis}——严格路径匹配，防子路径误命中。 */
+    private static boolean isEmojiManifestUrl(Request request) {
+        List<String> segments = request.url().pathSegments();
+        int n = segments.size();
+        return n >= 2
+                && "emojis".equals(segments.get(n - 1))
+                && "common".equals(segments.get(n - 2));
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/emoji/EmojiManifestCache.java
+++ b/wkbase/src/main/java/com/chat/base/emoji/EmojiManifestCache.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.emoji;
+
+import android.text.TextUtils;
+
+import com.alibaba.fastjson.JSON;
+import com.chat.base.config.WKSharedPreferencesUtil;
+
+/**
+ * emoji 清单本地持久化。写 SP、读 SP、序列化都做浅封装，让下次冷启动能"首屏立即可用"
+ * ——manifest 网络请求在 {@code AppStartup.postPhaseC} 后 fire-and-forget，
+ * 但用户可能在网络返回前就打开表情面板或读消息。
+ *
+ * <p>非 UID 隔离：清单是全局公共数据（服务端公开端点也无鉴权），账号切换不需要清空。
+ *
+ * <p>{@link #serialize(EmojiManifestResp)} / {@link #deserialize(String)} 是无 Android
+ * 依赖的纯函数，JVM 单测直接覆盖。{@link #save(EmojiManifestResp)} / {@link #load()}
+ * 是薄壳，包装 SP IO——SP 层线程安全由 {@link WKSharedPreferencesUtil} 承担。
+ *
+ * <p>Key 后缀 {@code _v1}：DTO shape 一旦改变（比如加了 category 字段），bump 到 {@code _v2}
+ * 让老缓存自然失效，避免 FastJson 解出畸形对象。
+ */
+public final class EmojiManifestCache {
+
+    static final String CACHE_KEY = "emoji_manifest_v1";
+
+    private EmojiManifestCache() {}
+
+    /**
+     * 把 manifest 序列化为可持久化的 JSON 字符串。
+     *
+     * @return JSON 字符串；null/list null 时返回空串（呼叫方判断跳过写盘）
+     */
+    public static String serialize(EmojiManifestResp resp) {
+        if (resp == null || resp.list == null) return "";
+        return JSON.toJSONString(resp);
+    }
+
+    /**
+     * 反序列化持久化字符串。空串 / null / 损坏 JSON 都返回 null，呼叫方走内置兜底。
+     */
+    public static EmojiManifestResp deserialize(String raw) {
+        if (TextUtils.isEmpty(raw)) return null;
+        try {
+            return JSON.parseObject(raw, EmojiManifestResp.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** 写入 SP。async apply——延迟落盘对本用途足够，且不阻塞主线程。 */
+    public static void save(EmojiManifestResp resp) {
+        String json = serialize(resp);
+        if (TextUtils.isEmpty(json)) return;
+        WKSharedPreferencesUtil.getInstance().putSP(CACHE_KEY, json);
+    }
+
+    /** 从 SP 读取。返回 null 表示无缓存或解析失败——呼叫方走内置兜底。 */
+    public static EmojiManifestResp load() {
+        return deserialize(WKSharedPreferencesUtil.getInstance().getSP(CACHE_KEY));
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/emoji/EmojiManifestItem.java
+++ b/wkbase/src/main/java/com/chat/base/emoji/EmojiManifestItem.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.emoji;
+
+/**
+ * 服务端 {@code GET /v1/common/emojis} 响应中的单个自定义表情条目。
+ *
+ * <p>字段与服务端 {@code modules/common/emoji.go} 的 {@code emojiItem} 严格对齐：
+ * <ul>
+ *   <li>{@code key}：消息正文里的字面 token，如 {@code "[使命必达]"}——wire 契约，各端逐字节一致，
+ *       服务端保证形如 {@code [xxx]}（{@code [} 开头 {@code ]} 结尾、中间非空且不含 {@code ]}）</li>
+ *   <li>{@code name}：人类可读标签（如 {@code "使命必达"}），供选择器 title / 无障碍文本用；服务端保证非空</li>
+ *   <li>{@code url}：图片地址——内置表情留空（{@code ""}）由客户端复用打包 asset；未来后台新增的表情
+ *       会带非空 URL，客户端据此渲染</li>
+ * </ul>
+ *
+ * <p>用 public 字段满足 FastJson 反序列化——release 包必须 proguard keep（见
+ * {@code app/proguard-rules.pro}），否则 R8 混淆字段名会让 JSON 解析出空对象。
+ */
+public class EmojiManifestItem {
+    public String key;
+    public String name;
+    public String url;
+}

--- a/wkbase/src/main/java/com/chat/base/emoji/EmojiManifestResp.java
+++ b/wkbase/src/main/java/com/chat/base/emoji/EmojiManifestResp.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.emoji;
+
+import java.util.List;
+
+/**
+ * 服务端 {@code GET /v1/common/emojis} 的顶层响应体。
+ *
+ * <p>wire 契约（来自 {@code octo-server modules/common/emoji.go} {@code emojiManifestResp}）：
+ * 顶层直接是 {@code {version, list}}，<b>无</b> {@code {status, data, msg}} 信封（服务端测试专门
+ * 断言了这一点）。故 FastJson 直接反序列化到本类，不走通用 {@code CommonResponse<T>} 包装。
+ *
+ * <ul>
+ *   <li>{@code version}：清单版本号，manifest 任一改动服务端会自增；供本地缓存判断是否需要刷新</li>
+ *   <li>{@code list}：条目按服务端真源顺序排列；服务端保证非空且每条目 key 唯一</li>
+ * </ul>
+ *
+ * <p>用 public 字段满足 FastJson 反序列化——release 包必须 proguard keep（见
+ * {@code app/proguard-rules.pro}）。
+ */
+public class EmojiManifestResp {
+    public int version;
+    public List<EmojiManifestItem> list;
+}

--- a/wkbase/src/main/java/com/chat/base/emoji/EmojiManifestSanitizer.java
+++ b/wkbase/src/main/java/com/chat/base/emoji/EmojiManifestSanitizer.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.emoji;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 服务端 emoji 清单的**客户端 sanitize 防线**——纯函数、无 IO、无 Android 依赖，便于 JVM 单测。
+ *
+ * <p>虽然服务端已经在 {@code parseEmojiManifest}（{@code modules/common/emoji.go}）
+ * 做了强校验（{@code [xxx]} token、name 非空、key 唯一），客户端仍守这一层，是为了防：
+ * <ul>
+ *   <li>不同版本服务端的契约不一致（本地是 vN，服务端已 vN+1 加了新校验松紧变化）</li>
+ *   <li>中间人 / 代理注入非法数据</li>
+ *   <li>本地缓存的 JSON 被外部工具改坏</li>
+ * </ul>
+ *
+ * <p><b>核心防护目标：Pattern.quote 空 branch 零宽死循环</b>——
+ * {@link com.chat.base.emoji.EmojiManager} 的 {@code getPattern()} 会把所有 token
+ * {@code Pattern.quote()} 后用 {@code |} 拼成 alternation。如果 token 为空或纯空白，
+ * 就会产生 {@code (a|b|)} 这种带空 branch 的正则——消费端 {@code Matcher} 在
+ * {@code find() + slice} 循环里遇到零宽匹配会永不前进，渲染死循环（web 端 PR #492 同样点）。
+ *
+ * <p>URL 白名单：只放行 {@code https://} 和相对路径（后者由呼叫方拼到 {@code WKApiConfig.baseUrl}）。
+ * {@code http://}（明文）和其它 scheme（{@code file:} {@code javascript:} {@code intent:} 等）
+ * 一律拒绝——emoji URL 是被 Glide 加载的资源引用，不应放开任意 scheme。
+ */
+public final class EmojiManifestSanitizer {
+
+    /** 单个 key 允许的最大字节长度（防超长恶意 token 拖慢正则匹配）。32 覆盖任何合理表情名。 */
+    static final int MAX_KEY_LEN = 32;
+
+    /** 单个 name 允许的最大长度。宽松些——name 只用作显示，不进正则。 */
+    static final int MAX_NAME_LEN = 64;
+
+    /** 整份清单最多接受的条目数（防 OOM / 拼出巨大正则）。500 远超任何合理内置表情量。 */
+    static final int MAX_ITEMS = 500;
+
+    private EmojiManifestSanitizer() {}
+
+    /**
+     * 过滤并规范化服务端返回的 items 列表。
+     *
+     * @param items 原始 items（可为 null）
+     * @return 已 sanitize 的不可变列表；输入非法或全部条目被 drop 时返回空列表
+     */
+    public static List<EmojiManifestItem> sanitize(List<EmojiManifestItem> items) {
+        if (items == null || items.isEmpty()) return Collections.emptyList();
+        int cap = Math.min(items.size(), MAX_ITEMS);
+        List<EmojiManifestItem> out = new ArrayList<>(cap);
+        Set<String> seen = new HashSet<>(cap * 2);
+        for (int i = 0, n = items.size(); i < n && out.size() < MAX_ITEMS; i++) {
+            EmojiManifestItem it = items.get(i);
+            if (it == null) continue;
+            String key = it.key == null ? "" : it.key.trim();
+            if (!isValidToken(key)) continue;
+            if (key.length() > MAX_KEY_LEN) continue;
+            if (seen.contains(key)) continue; // 服务端保证唯一但客户端仍防
+            seen.add(key);
+
+            String url = it.url == null ? "" : it.url.trim();
+            if (!url.isEmpty() && !isSafeUrl(url)) continue;
+
+            // name 空 → 用 key 去掉 `[` `]` 兜底（宁可显示 key 也不 drop）；超长直接截断
+            String name = it.name == null ? "" : it.name.trim();
+            if (name.isEmpty()) name = key.substring(1, key.length() - 1);
+            if (name.length() > MAX_NAME_LEN) name = name.substring(0, MAX_NAME_LEN);
+
+            EmojiManifestItem clean = new EmojiManifestItem();
+            clean.key = key;
+            clean.name = name;
+            clean.url = url;
+            out.add(clean);
+        }
+        return Collections.unmodifiableList(out);
+    }
+
+    /**
+     * token 是否形如 {@code [xxx]}（跟服务端 {@code isEmojiToken} 保持一致）：
+     * {@code [} 开头、{@code ]} 结尾，中间非空且不含 {@code ]}。
+     */
+    public static boolean isValidToken(String s) {
+        if (s == null || s.length() < 3) return false;
+        if (s.charAt(0) != '[' || s.charAt(s.length() - 1) != ']') return false;
+        // 中间不含 ']' —— 排除嵌套；顺带排除中间全空白（首尾字符本来就非空白就够，但强化下）。
+        String inner = s.substring(1, s.length() - 1);
+        if (inner.trim().isEmpty()) return false;
+        return inner.indexOf(']') < 0;
+    }
+
+    /**
+     * URL 白名单：只放行 {@code https://}（明文 http 拒），或相对路径（呼叫方负责拼到 baseUrl）。
+     * 相对路径不能是 {@code //}（协议相对，安全语义不明）也不能有 scheme（不能含 {@code :}）。
+     */
+    public static boolean isSafeUrl(String url) {
+        if (url == null || url.isEmpty()) return true; // 空 = 用本地打包 asset，允许
+        String lower = url.toLowerCase();
+        if (lower.startsWith("https://")) return true;
+        // 相对路径：不能是绝对 URL 也不能是协议相对
+        if (url.startsWith("//")) return false;
+        // 简易 scheme 检测：`xxx:` 出现在首个 `/` 之前视为 scheme
+        int colon = url.indexOf(':');
+        int slash = url.indexOf('/');
+        if (colon >= 0 && (slash < 0 || colon < slash)) return false;
+        return true;
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/emoji/EmojiManifestSanitizer.java
+++ b/wkbase/src/main/java/com/chat/base/emoji/EmojiManifestSanitizer.java
@@ -152,6 +152,22 @@ public final class EmojiManifestSanitizer {
         int colon = url.indexOf(':');
         int slash = url.indexOf('/');
         if (colon >= 0 && (slash < 0 || colon < slash)) return false;
+        // 路径穿越拒：`..` 组件（防将来 Layer 3 拼到 baseUrl 后被服务端错误解析出目录穿越）。
+        // 严格匹配 `../` `..\` 首尾 `..`，不匹配文件名里含 `..` 的普通字符（如 `file..v2.png`）。
+        if (containsPathTraversal(url)) return false;
         return true;
+    }
+
+    /** URL 里是否存在 {@code ..} 路径组件（不是简单子串——{@code file..v2.png} 不算）。 */
+    private static boolean containsPathTraversal(String url) {
+        int len = url.length();
+        for (int i = 0; i <= len - 2; i++) {
+            if (url.charAt(i) != '.' || url.charAt(i + 1) != '.') continue;
+            boolean leftBoundary = (i == 0) || url.charAt(i - 1) == '/' || url.charAt(i - 1) == '\\';
+            boolean rightEnd = (i + 2 == len);
+            boolean rightSlash = !rightEnd && (url.charAt(i + 2) == '/' || url.charAt(i + 2) == '\\');
+            if (leftBoundary && (rightEnd || rightSlash)) return true;
+        }
+        return false;
     }
 }

--- a/wkbase/src/main/java/com/chat/base/emoji/EmojiManifestSanitizer.java
+++ b/wkbase/src/main/java/com/chat/base/emoji/EmojiManifestSanitizer.java
@@ -51,6 +51,10 @@ public final class EmojiManifestSanitizer {
     /** 单个 name 允许的最大长度。宽松些——name 只用作显示，不进正则。 */
     static final int MAX_NAME_LEN = 64;
 
+    /** 单个 url 允许的最大长度。整体 SP 落盘要一次序列化整份 manifest，单 url 太长会撑爆存储；
+     *  2048 覆盖任何合理 CDN URL（含 query），且远小于典型 SP 单值上限。 */
+    static final int MAX_URL_LEN = 2048;
+
     /** 整份清单最多接受的条目数（防 OOM / 拼出巨大正则）。500 远超任何合理内置表情量。 */
     static final int MAX_ITEMS = 500;
 
@@ -107,16 +111,44 @@ public final class EmojiManifestSanitizer {
     }
 
     /**
-     * URL 白名单：只放行 {@code https://}（明文 http 拒），或相对路径（呼叫方负责拼到 baseUrl）。
-     * 相对路径不能是 {@code //}（协议相对，安全语义不明）也不能有 scheme（不能含 {@code :}）。
+     * URL 白名单：只放行 {@code https://} 或**严格相对路径**。
+     *
+     * <p>为**允许列表 (allow-list) 而非拒绝列表 (deny-list)**：不匹配任何允许模式一律拒绝，
+     * 防止将来 URL parser 差异漏掉的奇葩 scheme（{@code file:} {@code javascript:}
+     * {@code intent:} {@code content:} {@code data:} 等），以及 backslash / 嵌入凭证等灰色区域。
+     *
+     * <p>{@code https://} 分支额外拒绝**嵌入凭证** ({@code https://user:pass@host/...})——
+     * 攻击者可以借此把凭证泄漏给日志、代理或 phishing 到攻击者控制的 host（RFC 3986 允许但不安全）。
+     *
+     * <p>相对路径分支要求：首字符必须 {@code /} 或 ASCII 字母数字；全串不能含 {@code \}
+     * （Windows 风格路径/URL 转义灰色）；不能含 {@code @}；不能有 scheme
+     * （{@code xxx:} 出现在首个 {@code /} 前视为 scheme）。
+     *
+     * <p>{@link #MAX_URL_LEN} 上限统一在此处收——超长 URL 一并拒绝。
      */
     public static boolean isSafeUrl(String url) {
         if (url == null || url.isEmpty()) return true; // 空 = 用本地打包 asset，允许
+        if (url.length() > MAX_URL_LEN) return false;
+        if (url.indexOf('\\') >= 0) return false; // backslash 一律拒
         String lower = url.toLowerCase();
-        if (lower.startsWith("https://")) return true;
-        // 相对路径：不能是绝对 URL 也不能是协议相对
-        if (url.startsWith("//")) return false;
-        // 简易 scheme 检测：`xxx:` 出现在首个 `/` 之前视为 scheme
+        if (lower.startsWith("https://")) {
+            // 拒绝嵌入凭证 user:pass@host —— @ 出现在 authority 段（第一个 / 之前，或无 /）时拒
+            int schemeEnd = 8; // "https://".length()
+            int pathSlash = url.indexOf('/', schemeEnd);
+            int at = url.indexOf('@', schemeEnd);
+            if (at >= 0 && (pathSlash < 0 || at < pathSlash)) return false;
+            return true;
+        }
+        // 相对路径 allow-list
+        if (url.startsWith("//")) return false; // 协议相对拒
+        char first = url.charAt(0);
+        boolean okFirst = first == '/'
+                || (first >= 'A' && first <= 'Z')
+                || (first >= 'a' && first <= 'z')
+                || (first >= '0' && first <= '9');
+        if (!okFirst) return false;
+        if (url.indexOf('@') >= 0) return false; // 相对路径不该有 @
+        // scheme 检测：`xxx:` 出现在首个 `/` 之前视为 scheme
         int colon = url.indexOf(':');
         int slash = url.indexOf('/');
         if (colon >= 0 && (slash < 0 || colon < slash)) return false;

--- a/wkbase/src/main/java/com/chat/base/net/OkHttpUtils.java
+++ b/wkbase/src/main/java/com/chat/base/net/OkHttpUtils.java
@@ -84,12 +84,19 @@ public class OkHttpUtils {
                             .hostnameVerifier(SSLSocketClient.getHostnameVerifier())
                             .addInterceptor(mRewriteCacheControlInterceptor)
                             .addInterceptor(new CommonRequestParamInterceptor())
+                            .addNetworkInterceptor(mRewriteCacheControlInterceptor)
+                            .addInterceptor(new LogInterceptor())
                             // Emoji manifest 端点公开无鉴权，parse 前先做 raw body 字节上限
                             // 检查，防 hostile / MITM 推巨大 body → FastJson buffer 后 OOM。
                             // 只对 URL 路径末尾 common/emojis 生效，不影响其它接口。
-                            .addInterceptor(new EmojiManifestBodyLimitInterceptor())
-                            .addNetworkInterceptor(mRewriteCacheControlInterceptor)
-                            .addInterceptor(new LogInterceptor()).build();
+                            //
+                            // ⚠️ 必须放在 LogInterceptor 之后（即 list 末尾，最内层）：
+                            // application interceptor 按 list order 由外到内包装，list 末尾的
+                            // interceptor 最先看到 response。LogInterceptor 会 body().string()
+                            // 全量读 body 后再打日志，若 BodyLimit 在 Log 之前（更外层），
+                            // Log 已经 OOM 了 BodyLimit 才拿到 response——检查太晚。
+                            // 参考 PR #94 Jerry-Xin round-3 review B2。
+                            .addInterceptor(new EmojiManifestBodyLimitInterceptor()).build();
                 }
             }
         }

--- a/wkbase/src/main/java/com/chat/base/net/OkHttpUtils.java
+++ b/wkbase/src/main/java/com/chat/base/net/OkHttpUtils.java
@@ -19,6 +19,7 @@ package com.chat.base.net;
 import android.util.Log;
 
 import com.chat.base.WKBaseApplication;
+import com.chat.base.emoji.EmojiManifestBodyLimitInterceptor;
 import com.chat.base.utils.WKNetUtil;
 
 import java.io.File;
@@ -83,6 +84,10 @@ public class OkHttpUtils {
                             .hostnameVerifier(SSLSocketClient.getHostnameVerifier())
                             .addInterceptor(mRewriteCacheControlInterceptor)
                             .addInterceptor(new CommonRequestParamInterceptor())
+                            // Emoji manifest 端点公开无鉴权，parse 前先做 raw body 字节上限
+                            // 检查，防 hostile / MITM 推巨大 body → FastJson buffer 后 OOM。
+                            // 只对 URL 路径末尾 common/emojis 生效，不影响其它接口。
+                            .addInterceptor(new EmojiManifestBodyLimitInterceptor())
                             .addNetworkInterceptor(mRewriteCacheControlInterceptor)
                             .addInterceptor(new LogInterceptor()).build();
                 }

--- a/wkbase/src/test/java/com/chat/base/emoji/EmojiManagerMergeTest.java
+++ b/wkbase/src/test/java/com/chat/base/emoji/EmojiManagerMergeTest.java
@@ -219,4 +219,27 @@ public class EmojiManagerMergeTest {
         assertFalse(r.text2entry.containsKey("[新表情B]"));
         assertFalse(r.text2entry.containsKey("[新表情C]"));
     }
+
+    // ---- buildPattern 空 list 兜底（P2-2）：无 entry 时返回永不匹配的 (?!) 而不是零宽 () ----
+
+    @Test
+    public void buildPattern_empty_list_returns_never_matching_pattern() {
+        java.util.regex.Pattern p = EmojiManager.buildPattern(Collections.<EmojiManager.Entry>emptyList());
+        // 空 pattern 不该匹配任何字符串——包括空串
+        assertFalse(p.matcher("").find());
+        assertFalse(p.matcher("hello [使命必达] world").find());
+        assertFalse(p.matcher("[a]").find());
+    }
+
+    @Test
+    public void buildPattern_non_empty_matches_registered_tokens() {
+        List<EmojiManager.Entry> entries = new ArrayList<>();
+        entries.add(xmlEntry("custom_a", "[a]", "emoji/a.png"));
+        entries.add(xmlEntry("custom_b", "[b]", "emoji/b.png"));
+        java.util.regex.Pattern p = EmojiManager.buildPattern(entries);
+        assertTrue(p.matcher("hello [a] world").find());
+        assertTrue(p.matcher("[b]").find());
+        assertFalse(p.matcher("[c]").find());
+        assertFalse(p.matcher("plain text").find());
+    }
 }

--- a/wkbase/src/test/java/com/chat/base/emoji/EmojiManagerMergeTest.java
+++ b/wkbase/src/test/java/com/chat/base/emoji/EmojiManagerMergeTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.base.emoji;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@link EmojiManager#mergeXmlAndManifest} 的合并契约测试。
+ *
+ * 核心保证：
+ * 1. 内置 xml 打底始终保留（"merge 不删"）
+ * 2. manifest 有对应 xml asset 的 key → 合并，id/assetPath 沿用 xml，name/url 用 manifest
+ * 3. manifest 中 xml 未打包的 key → <b>整条跳过</b>（不进 text2entry、不进 defaultEntries），
+ *    避免面板显示空白格子（PR #94 review Jerry-Xin B1）
+ * 4. defaultEntries 排序：manifest customs 在前 → xml-only customs → Unicode
+ * 5. 空 manifest 不破坏原状态（只留 xml）
+ */
+public class EmojiManagerMergeTest {
+
+    private static EmojiManifestItem item(String key, String name, String url) {
+        EmojiManifestItem it = new EmojiManifestItem();
+        it.key = key;
+        it.name = name;
+        it.url = url;
+        return it;
+    }
+
+    private static EmojiManager.Entry xmlEntry(String id, String text, String assetPath) {
+        return new EmojiManager.Entry(id, text, assetPath);
+    }
+
+    /** 模拟真实的 xml 状态：4 custom + 2 Unicode。 */
+    private static Map<String, EmojiManager.Entry> buildXmlMap(List<EmojiManager.Entry> defaults) {
+        Map<String, EmojiManager.Entry> m = new LinkedHashMap<>();
+        for (EmojiManager.Entry e : defaults) m.put(e.text, e);
+        return m;
+    }
+
+    private List<EmojiManager.Entry> xmlDefaults;
+    private Map<String, EmojiManager.Entry> xmlMap;
+
+    private void setupTypicalXml() {
+        xmlDefaults = new ArrayList<>();
+        xmlDefaults.add(xmlEntry("custom_mission", "[使命必达]", "emoji/default/custom_mission.png"));
+        xmlDefaults.add(xmlEntry("custom_action", "[崇尚行动]", "emoji/default/custom_action.png"));
+        xmlDefaults.add(xmlEntry("custom_taste", "[有品位]", "emoji/default/custom_taste.png"));
+        xmlDefaults.add(xmlEntry("custom_shangfang", "[尚方宝剑]", "emoji/default/custom_shangfang.png"));
+        xmlDefaults.add(xmlEntry("0_0", "😀", "emoji/default/0_0.png"));
+        xmlDefaults.add(xmlEntry("0_1", "😃", "emoji/default/0_1.png"));
+        xmlMap = buildXmlMap(xmlDefaults);
+    }
+
+    // ---- 核心契约：manifest 全部对齐 xml → 全部合并 ----
+
+    @Test
+    public void merge_all_manifest_keys_match_xml() {
+        setupTypicalXml();
+        List<EmojiManifestItem> manifest = Arrays.asList(
+                item("[使命必达]", "使命必达", ""),
+                item("[崇尚行动]", "崇尚行动", ""),
+                item("[有品位]", "有品位", ""),
+                item("[尚方宝剑]", "尚方宝剑", ""));
+
+        EmojiManager.MergeResult r = EmojiManager.mergeXmlAndManifest(xmlMap, xmlDefaults, manifest);
+
+        assertEquals(0, r.skippedNoAsset);
+        assertEquals(6, r.defaultEntries.size()); // 4 custom + 2 Unicode
+        // manifest 顺序在前 → 4 个 custom + 2 个 Unicode
+        assertEquals("[使命必达]", r.defaultEntries.get(0).text);
+        assertEquals("[尚方宝剑]", r.defaultEntries.get(3).text);
+        assertEquals("😀", r.defaultEntries.get(4).text);
+        // text2entry 里全部 4 个 custom 都能查到
+        assertTrue(r.text2entry.containsKey("[使命必达]"));
+        assertTrue(r.text2entry.containsKey("[尚方宝剑]"));
+        assertTrue(r.text2entry.containsKey("😀"));
+    }
+
+    // ---- 核心契约（B1）：manifest-only key（xml 未打包）不能进面板也不能进 text2entry ----
+
+    @Test
+    public void merge_manifest_only_key_is_excluded_entirely() {
+        setupTypicalXml();
+        List<EmojiManifestItem> manifest = Arrays.asList(
+                item("[使命必达]", "使命必达", ""),
+                item("[未来新表情]", "未来新", "https://cdn.example.com/new.png"), // xml 未打包
+                item("[尚方宝剑]", "尚方宝剑", ""));
+
+        EmojiManager.MergeResult r = EmojiManager.mergeXmlAndManifest(xmlMap, xmlDefaults, manifest);
+
+        assertEquals("manifest-only key 应计入 skipped", 1, r.skippedNoAsset);
+        // 关键：panel 里不该出现 [未来新表情]（否则显示为空白 tap-able cell）
+        for (EmojiManager.Entry e : r.defaultEntries) {
+            assertFalse("panel 不该含 manifest-only key: " + e.text,
+                    "[未来新表情]".equals(e.text));
+        }
+        // 关键：text2entry 里也不该有 [未来新表情]（否则消息 pattern 会匹配但 getDrawable 返 null）
+        assertFalse("text2entry 不该含 manifest-only key",
+                r.text2entry.containsKey("[未来新表情]"));
+        // sanity：xml 打底的仍在
+        assertTrue(r.text2entry.containsKey("[使命必达]"));
+        assertTrue(r.text2entry.containsKey("[尚方宝剑]"));
+    }
+
+    // ---- 合并契约：xml 已有的 key，url 用 manifest 下发的（remoteUrl 存进 Entry） ----
+
+    @Test
+    public void merge_updates_remote_url_for_matched_xml_key() {
+        setupTypicalXml();
+        String futureUrl = "https://cdn.example.com/mission_v2.png";
+        List<EmojiManifestItem> manifest = Collections.singletonList(
+                item("[使命必达]", "使命必达", futureUrl));
+
+        EmojiManager.MergeResult r = EmojiManager.mergeXmlAndManifest(xmlMap, xmlDefaults, manifest);
+
+        EmojiManager.Entry mission = r.text2entry.get("[使命必达]");
+        // id / assetPath 沿用 xml，remoteUrl 用 manifest
+        assertEquals("custom_mission", mission.id);
+        assertEquals("emoji/default/custom_mission.png", mission.assetPath);
+        assertEquals(futureUrl, mission.remoteUrl);
+    }
+
+    // ---- merge 不删：xml 里有但 manifest 没下发的，保留 ----
+
+    @Test
+    public void merge_preserves_xml_only_customs() {
+        setupTypicalXml();
+        // manifest 只有 2 个，xml 有 4 个 custom
+        List<EmojiManifestItem> manifest = Arrays.asList(
+                item("[使命必达]", "使命必达", ""),
+                item("[尚方宝剑]", "尚方宝剑", ""));
+
+        EmojiManager.MergeResult r = EmojiManager.mergeXmlAndManifest(xmlMap, xmlDefaults, manifest);
+
+        assertEquals(0, r.skippedNoAsset);
+        // 4 custom（2 manifest + 2 xml-only）+ 2 Unicode
+        assertEquals(6, r.defaultEntries.size());
+        // manifest 顺序在前：使命必达, 尚方宝剑
+        assertEquals("[使命必达]", r.defaultEntries.get(0).text);
+        assertEquals("[尚方宝剑]", r.defaultEntries.get(1).text);
+        // xml-only customs 追加：崇尚行动, 有品位
+        assertEquals("[崇尚行动]", r.defaultEntries.get(2).text);
+        assertEquals("[有品位]", r.defaultEntries.get(3).text);
+        // Unicode 最后
+        assertEquals("😀", r.defaultEntries.get(4).text);
+        assertEquals("😃", r.defaultEntries.get(5).text);
+    }
+
+    // ---- 空 manifest：只有 xml 打底 ----
+
+    @Test
+    public void merge_empty_manifest_returns_xml_state() {
+        setupTypicalXml();
+        EmojiManager.MergeResult r = EmojiManager.mergeXmlAndManifest(
+                xmlMap, xmlDefaults, Collections.<EmojiManifestItem>emptyList());
+
+        assertEquals(0, r.skippedNoAsset);
+        assertEquals(6, r.defaultEntries.size());
+        // 顺序与 xml 完全一致
+        for (int i = 0; i < xmlDefaults.size(); i++) {
+            assertEquals(xmlDefaults.get(i).text, r.defaultEntries.get(i).text);
+        }
+    }
+
+    // ---- 返回的容器不可变 ----
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void merge_result_text2entry_is_immutable() {
+        setupTypicalXml();
+        EmojiManager.MergeResult r = EmojiManager.mergeXmlAndManifest(
+                xmlMap, xmlDefaults, Collections.<EmojiManifestItem>emptyList());
+        r.text2entry.put("[hacker]", null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void merge_result_defaults_is_immutable() {
+        setupTypicalXml();
+        EmojiManager.MergeResult r = EmojiManager.mergeXmlAndManifest(
+                xmlMap, xmlDefaults, Collections.<EmojiManifestItem>emptyList());
+        r.defaultEntries.clear();
+    }
+
+    // ---- xml 未打包 + 多 manifest 项 → 全部跳过而不影响其它 ----
+
+    @Test
+    public void merge_multiple_manifest_only_all_skipped_others_intact() {
+        setupTypicalXml();
+        List<EmojiManifestItem> manifest = Arrays.asList(
+                item("[使命必达]", "使命必达", ""),
+                item("[新表情A]", "A", "https://cdn/a.png"),
+                item("[新表情B]", "B", "https://cdn/b.png"),
+                item("[新表情C]", "C", "https://cdn/c.png"));
+
+        EmojiManager.MergeResult r = EmojiManager.mergeXmlAndManifest(xmlMap, xmlDefaults, manifest);
+
+        assertEquals(3, r.skippedNoAsset);
+        // manifest 只处理成功 1 个 (使命必达)，加上 xml-only 3 个 custom + 2 unicode = 6
+        assertEquals(6, r.defaultEntries.size());
+        assertFalse(r.text2entry.containsKey("[新表情A]"));
+        assertFalse(r.text2entry.containsKey("[新表情B]"));
+        assertFalse(r.text2entry.containsKey("[新表情C]"));
+    }
+}

--- a/wkbase/src/test/java/com/chat/base/emoji/EmojiManifestBodyLimitInterceptorTest.java
+++ b/wkbase/src/test/java/com/chat/base/emoji/EmojiManifestBodyLimitInterceptorTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.base.emoji;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.Call;
+import okhttp3.Connection;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * 用手写 fake {@link Interceptor.Chain} 覆盖 {@link EmojiManifestBodyLimitInterceptor}
+ * 的行为——不引入 mockwebserver 依赖，纯 JVM 单测。
+ *
+ * <p>核心保证：
+ * <ol>
+ *   <li>非 emoji URL 请求原样透传</li>
+ *   <li>emoji URL Content-Length 超上限 → 抛 IOException（快路径）</li>
+ *   <li>emoji URL Content-Length 缺失但实际 body 超上限 → 抛 IOException（peek 兜底）</li>
+ *   <li>emoji URL body 在上限内 → 正常返回</li>
+ * </ol>
+ */
+public class EmojiManifestBodyLimitInterceptorTest {
+
+    private static final MediaType JSON = MediaType.get("application/json");
+
+    private static Request req(String url) {
+        return new Request.Builder().url(url).build();
+    }
+
+    private static Response ok(Request request, ResponseBody body) {
+        return new Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(body)
+                .build();
+    }
+
+    /** 允许 declaredContentLength 传 -1 以模拟 "服务端没给 Content-Length"（chunked）。 */
+    private static ResponseBody bodyWith(byte[] bytes, long declaredContentLength) {
+        if (declaredContentLength < 0) {
+            // 走 create(byte[], MediaType) 的默认 —— contentLength() 返 bytes.length。
+            // OkHttp 没有"不带 length"的直接构造器；测试时用一个包装类模拟 -1。
+            return new ResponseBody() {
+                @Override public MediaType contentType() { return JSON; }
+                @Override public long contentLength() { return -1L; }
+                @Override public okio.BufferedSource source() {
+                    okio.Buffer buf = new okio.Buffer();
+                    buf.write(bytes);
+                    return buf;
+                }
+            };
+        }
+        return ResponseBody.create(bytes, JSON);
+    }
+
+    private static class FakeChain implements Interceptor.Chain {
+        final Request request;
+        final Response response;
+
+        FakeChain(Request request, Response response) {
+            this.request = request;
+            this.response = response;
+        }
+
+        @Override public Request request() { return request; }
+        @Override public Response proceed(Request r) throws IOException { return response; }
+        @Override public Connection connection() { return null; }
+        @Override public Call call() { throw new UnsupportedOperationException(); }
+        @Override public int connectTimeoutMillis() { return 0; }
+        @Override public Interceptor.Chain withConnectTimeout(int t, TimeUnit u) { return this; }
+        @Override public int readTimeoutMillis() { return 0; }
+        @Override public Interceptor.Chain withReadTimeout(int t, TimeUnit u) { return this; }
+        @Override public int writeTimeoutMillis() { return 0; }
+        @Override public Interceptor.Chain withWriteTimeout(int t, TimeUnit u) { return this; }
+    }
+
+    // ---- 非 emoji URL：原样透传 ----
+
+    @Test
+    public void non_emoji_url_passes_through_untouched() throws IOException {
+        byte[] payload = new byte[(int) EmojiManifestBodyLimitInterceptor.MAX_MANIFEST_BODY_BYTES + 100];
+        Request request = req("https://example.com/v1/common/other-endpoint");
+        Response response = ok(request, bodyWith(payload, payload.length));
+
+        Response out = new EmojiManifestBodyLimitInterceptor().intercept(new FakeChain(request, response));
+
+        // 非 emoji URL 不做任何检查，即使超上限也应原样返回
+        assertNotNull(out.body());
+        assertEquals(payload.length, out.body().contentLength());
+    }
+
+    // ---- emoji URL + Content-Length 明确超上限 → 快路径抛异常 ----
+
+    @Test
+    public void emoji_url_with_oversized_content_length_throws() {
+        byte[] payload = new byte[(int) EmojiManifestBodyLimitInterceptor.MAX_MANIFEST_BODY_BYTES + 10];
+        Request request = req("https://example.com/v1/common/emojis");
+        Response response = ok(request, bodyWith(payload, payload.length));
+
+        try {
+            new EmojiManifestBodyLimitInterceptor().intercept(new FakeChain(request, response));
+            fail("expected IOException on oversized Content-Length");
+        } catch (IOException e) {
+            assertEquals(true, e.getMessage().contains("Content-Length"));
+        }
+    }
+
+    // ---- emoji URL + Content-Length 缺失（-1）但实际超上限 → peek 兜底抛异常 ----
+
+    @Test
+    public void emoji_url_chunked_oversized_body_throws() {
+        byte[] payload = new byte[(int) EmojiManifestBodyLimitInterceptor.MAX_MANIFEST_BODY_BYTES + 10];
+        Request request = req("https://example.com/v1/common/emojis");
+        Response response = ok(request, bodyWith(payload, -1)); // chunked
+
+        try {
+            new EmojiManifestBodyLimitInterceptor().intercept(new FakeChain(request, response));
+            fail("expected IOException on oversized chunked body");
+        } catch (IOException e) {
+            assertEquals(true, e.getMessage().contains("exceeds"));
+        }
+    }
+
+    // ---- emoji URL + body 在上限内 → 正常返回，body 内容保持一致 ----
+
+    @Test
+    public void emoji_url_within_limit_passes_through() throws IOException {
+        String json = "{\"version\":1,\"list\":[{\"key\":\"[a]\",\"name\":\"a\",\"url\":\"\"}]}";
+        byte[] payload = json.getBytes();
+        Request request = req("https://example.com/v1/common/emojis");
+        Response response = ok(request, bodyWith(payload, payload.length));
+
+        Response out = new EmojiManifestBodyLimitInterceptor().intercept(new FakeChain(request, response));
+
+        assertNotNull(out.body());
+        assertArrayEquals(payload, out.body().bytes());
+    }
+
+    // ---- URL 路径匹配严格：`.../common/emojis-and-more` 不该被误命中 ----
+
+    @Test
+    public void url_path_match_is_strict() throws IOException {
+        byte[] payload = new byte[(int) EmojiManifestBodyLimitInterceptor.MAX_MANIFEST_BODY_BYTES + 100];
+        Request request = req("https://example.com/v1/common/emojis-and-more"); // 前缀相同但非 emojis
+        Response response = ok(request, bodyWith(payload, payload.length));
+
+        Response out = new EmojiManifestBodyLimitInterceptor().intercept(new FakeChain(request, response));
+
+        // 不该被拦截
+        assertEquals(payload.length, out.body().contentLength());
+    }
+}

--- a/wkbase/src/test/java/com/chat/base/emoji/EmojiManifestBodyLimitInterceptorTest.java
+++ b/wkbase/src/test/java/com/chat/base/emoji/EmojiManifestBodyLimitInterceptorTest.java
@@ -173,4 +173,33 @@ public class EmojiManifestBodyLimitInterceptorTest {
         // 不该被拦截
         assertEquals(payload.length, out.body().contentLength());
     }
+
+    // ---- 组合契约（Jerry-Xin round-3 B2）：模拟 LogInterceptor 作为外层调 body().string()
+    //      时，BodyLimit 作为内层要能在外层读 body 之前 short-circuit（否则外层 OOM）。 ----
+
+    @Test
+    public void oversized_body_short_circuits_before_outer_reads_body() {
+        // 模拟：LogInterceptor 是 outer（外层，先被调用），它 chain.proceed() 后
+        // 会 response.body().string() 读全 body。BodyLimit 是 inner（内层，后被调用），
+        // 它先拿到 network response，检查 size 超限 → 抛 IOException →
+        // IOException 沿 chain 传给 outer 的 chain.proceed() 调用点 → 外层永远走不到
+        // body().string()，OOM 被避免。
+        byte[] oversized = new byte[(int) EmojiManifestBodyLimitInterceptor.MAX_MANIFEST_BODY_BYTES + 10];
+        Request request = req("https://example.com/v1/common/emojis");
+        Response networkResp = ok(request, bodyWith(oversized, oversized.length));
+        Interceptor bodyLimit = new EmojiManifestBodyLimitInterceptor();
+
+        boolean outerReachedBodyRead = false;
+        try {
+            // 模拟 outer(LogInterceptor 风格) 的 chain.proceed() —— 内部就是 bodyLimit.intercept
+            Response fromInner = bodyLimit.intercept(new FakeChain(request, networkResp));
+            // 若 bodyLimit 没抛，outer 会来这一步做 body().string()——OOM 高危
+            fromInner.body().string();
+            outerReachedBodyRead = true;
+        } catch (IOException e) {
+            // 期望：bodyLimit 抛，outer 走不到 body 读——OOM 已被避免
+        }
+        assertEquals("outer 不该走到 body 读取（应被 bodyLimit 抛异常 short-circuit）",
+                false, outerReachedBodyRead);
+    }
 }

--- a/wkbase/src/test/java/com/chat/base/emoji/EmojiManifestCacheTest.java
+++ b/wkbase/src/test/java/com/chat/base/emoji/EmojiManifestCacheTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.base.emoji;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+/**
+ * SP 层不测（依赖 Android + KeyStore），只测 serialize / deserialize 纯函数——
+ * 这是"缓存丢失的话到底会不会 crash"的核心防线。
+ */
+public class EmojiManifestCacheTest {
+
+    private static EmojiManifestItem item(String key, String name, String url) {
+        EmojiManifestItem it = new EmojiManifestItem();
+        it.key = key;
+        it.name = name;
+        it.url = url;
+        return it;
+    }
+
+    @Test
+    public void round_trip_preserves_all_fields() {
+        EmojiManifestResp in = new EmojiManifestResp();
+        in.version = 3;
+        in.list = new ArrayList<>();
+        in.list.add(item("[使命必达]", "使命必达", ""));
+        in.list.add(item("[新表情]", "新表情", "https://cdn.example.com/x.png"));
+
+        String json = EmojiManifestCache.serialize(in);
+        assertNotNull(json);
+
+        EmojiManifestResp out = EmojiManifestCache.deserialize(json);
+        assertNotNull(out);
+        assertEquals(3, out.version);
+        assertEquals(2, out.list.size());
+        assertEquals("[使命必达]", out.list.get(0).key);
+        assertEquals("使命必达", out.list.get(0).name);
+        assertEquals("", out.list.get(0).url);
+        assertEquals("[新表情]", out.list.get(1).key);
+        assertEquals("https://cdn.example.com/x.png", out.list.get(1).url);
+    }
+
+    @Test
+    public void serialize_null_returns_empty() {
+        assertEquals("", EmojiManifestCache.serialize(null));
+    }
+
+    @Test
+    public void serialize_null_list_returns_empty() {
+        EmojiManifestResp r = new EmojiManifestResp();
+        r.version = 1;
+        r.list = null;
+        assertEquals("", EmojiManifestCache.serialize(r));
+    }
+
+    @Test
+    public void deserialize_null_returns_null() {
+        assertNull(EmojiManifestCache.deserialize(null));
+    }
+
+    @Test
+    public void deserialize_empty_returns_null() {
+        assertNull(EmojiManifestCache.deserialize(""));
+    }
+
+    @Test
+    public void deserialize_corrupt_returns_null() {
+        // 损坏 JSON——不能 crash，返 null 走内置兜底
+        assertNull(EmojiManifestCache.deserialize("{not valid json"));
+        assertNull(EmojiManifestCache.deserialize("]["));
+        assertNull(EmojiManifestCache.deserialize("just text"));
+    }
+
+    @Test
+    public void deserialize_empty_list_ok() {
+        // 服务端理论上不会下发 empty list（parseEmojiManifest reject），但客户端解析要能吃
+        EmojiManifestResp out = EmojiManifestCache.deserialize("{\"version\":1,\"list\":[]}");
+        assertNotNull(out);
+        assertEquals(1, out.version);
+        assertEquals(0, out.list.size());
+    }
+}

--- a/wkbase/src/test/java/com/chat/base/emoji/EmojiManifestSanitizerTest.java
+++ b/wkbase/src/test/java/com/chat/base/emoji/EmojiManifestSanitizerTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.base.emoji;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 服务端已经在 parseEmojiManifest 做过强校验，客户端 sanitize 是防契约破坏 / 中间人 / 缓存改坏。
+ * 核心目标：**防 Pattern.quote 空 branch 零宽死循环**——空 key 绝不能进 defaultEntries。
+ */
+public class EmojiManifestSanitizerTest {
+
+    private static EmojiManifestItem item(String key, String name, String url) {
+        EmojiManifestItem it = new EmojiManifestItem();
+        it.key = key;
+        it.name = name;
+        it.url = url;
+        return it;
+    }
+
+    @Test
+    public void sanitize_null_returns_empty() {
+        assertTrue(EmojiManifestSanitizer.sanitize(null).isEmpty());
+    }
+
+    @Test
+    public void sanitize_empty_returns_empty() {
+        assertTrue(EmojiManifestSanitizer.sanitize(Collections.<EmojiManifestItem>emptyList()).isEmpty());
+    }
+
+    @Test
+    public void sanitize_valid_items_pass_through() {
+        List<EmojiManifestItem> in = Arrays.asList(
+                item("[使命必达]", "使命必达", ""),
+                item("[尚方宝剑]", "尚方宝剑", "")
+        );
+        List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(in);
+        assertEquals(2, out.size());
+        assertEquals("[使命必达]", out.get(0).key);
+        assertEquals("[尚方宝剑]", out.get(1).key);
+    }
+
+    // ---- KILL bug: 空 key / 空白 key 必须 drop（否则正则零宽死循环）----
+
+    @Test
+    public void sanitize_drops_null_item() {
+        List<EmojiManifestItem> in = new ArrayList<>();
+        in.add(null);
+        in.add(item("[a]", "A", ""));
+        List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(in);
+        assertEquals(1, out.size());
+    }
+
+    @Test
+    public void sanitize_drops_null_key() {
+        List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(
+                Arrays.asList(item(null, "x", ""), item("[a]", "A", "")));
+        assertEquals(1, out.size());
+        assertEquals("[a]", out.get(0).key);
+    }
+
+    @Test
+    public void sanitize_drops_empty_key() {
+        List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(
+                Arrays.asList(item("", "x", ""), item("[a]", "A", "")));
+        assertEquals(1, out.size());
+    }
+
+    @Test
+    public void sanitize_drops_whitespace_only_key() {
+        List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(
+                Arrays.asList(item("   ", "x", ""), item("[  ]", "y", ""), item("[a]", "A", "")));
+        // "   " trim 后为空 → drop
+        // "[  ]" trim 后仍是 "[  ]"，内部是纯空白 → isValidToken 需 drop
+        assertEquals(1, out.size());
+        assertEquals("[a]", out.get(0).key);
+    }
+
+    // ---- token 格式校验 ----
+
+    @Test
+    public void isValidToken_requires_bracket_wrap() {
+        assertTrue(EmojiManifestSanitizer.isValidToken("[a]"));
+        assertTrue(EmojiManifestSanitizer.isValidToken("[使命必达]"));
+        assertFalse(EmojiManifestSanitizer.isValidToken("a"));
+        assertFalse(EmojiManifestSanitizer.isValidToken("[a"));
+        assertFalse(EmojiManifestSanitizer.isValidToken("a]"));
+        assertFalse(EmojiManifestSanitizer.isValidToken("[]"));
+        assertFalse(EmojiManifestSanitizer.isValidToken(""));
+        assertFalse(EmojiManifestSanitizer.isValidToken(null));
+    }
+
+    @Test
+    public void isValidToken_rejects_nested_bracket() {
+        // 内含 ']' 会破坏简单正则匹配（跟服务端 isEmojiToken 一致）
+        assertFalse(EmojiManifestSanitizer.isValidToken("[a]b]"));
+    }
+
+    @Test
+    public void sanitize_drops_overlong_key() {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < EmojiManifestSanitizer.MAX_KEY_LEN + 5; i++) sb.append('a');
+        sb.append("]");
+        List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(
+                Arrays.asList(item(sb.toString(), "x", ""), item("[a]", "A", "")));
+        assertEquals(1, out.size());
+        assertEquals("[a]", out.get(0).key);
+    }
+
+    // ---- 唯一性（服务端保证但客户端 double-check）----
+
+    @Test
+    public void sanitize_drops_duplicate_key_keeping_first() {
+        List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(
+                Arrays.asList(item("[a]", "A1", ""), item("[a]", "A2", ""), item("[b]", "B", "")));
+        assertEquals(2, out.size());
+        assertEquals("A1", out.get(0).name);
+    }
+
+    // ---- name 兜底：空 name 用 key 去括号，不 drop ----
+
+    @Test
+    public void sanitize_empty_name_falls_back_to_key_inner() {
+        List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(
+                Collections.singletonList(item("[使命必达]", "", "")));
+        assertEquals(1, out.size());
+        assertEquals("使命必达", out.get(0).name);
+    }
+
+    @Test
+    public void sanitize_overlong_name_truncated() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < EmojiManifestSanitizer.MAX_NAME_LEN + 10; i++) sb.append('a');
+        List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(
+                Collections.singletonList(item("[k]", sb.toString(), "")));
+        assertEquals(EmojiManifestSanitizer.MAX_NAME_LEN, out.get(0).name.length());
+    }
+
+    // ---- URL 白名单：只放 https + 相对路径 ----
+
+    @Test
+    public void isSafeUrl_empty_ok() {
+        assertTrue(EmojiManifestSanitizer.isSafeUrl(""));
+        assertTrue(EmojiManifestSanitizer.isSafeUrl(null));
+    }
+
+    @Test
+    public void isSafeUrl_https_ok() {
+        assertTrue(EmojiManifestSanitizer.isSafeUrl("https://cdn.example.com/e.png"));
+        assertTrue(EmojiManifestSanitizer.isSafeUrl("HTTPS://cdn.example.com/e.png"));
+    }
+
+    @Test
+    public void isSafeUrl_http_rejected() {
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("http://cdn.example.com/e.png"));
+    }
+
+    @Test
+    public void isSafeUrl_relative_ok() {
+        assertTrue(EmojiManifestSanitizer.isSafeUrl("emojis/e.png"));
+        assertTrue(EmojiManifestSanitizer.isSafeUrl("/emojis/e.png"));
+    }
+
+    @Test
+    public void isSafeUrl_protocol_relative_rejected() {
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("//cdn.example.com/e.png"));
+    }
+
+    @Test
+    public void isSafeUrl_unknown_scheme_rejected() {
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("file:///etc/passwd"));
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("javascript:alert(1)"));
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("intent://xxx#Intent;end"));
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("data:image/png;base64,aaa"));
+    }
+
+    @Test
+    public void sanitize_drops_item_with_unsafe_url_but_keeps_others() {
+        List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(
+                Arrays.asList(
+                        item("[a]", "A", "javascript:alert(1)"),
+                        item("[b]", "B", "https://cdn.example.com/b.png"),
+                        item("[c]", "C", "")));
+        assertEquals(2, out.size());
+        assertEquals("[b]", out.get(0).key);
+        assertEquals("[c]", out.get(1).key);
+    }
+
+    // ---- 输入长度上限 ----
+
+    @Test
+    public void sanitize_caps_at_max_items() {
+        List<EmojiManifestItem> in = new ArrayList<>();
+        for (int i = 0; i < EmojiManifestSanitizer.MAX_ITEMS + 10; i++) {
+            in.add(item("[k" + i + "]", "n" + i, ""));
+        }
+        List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(in);
+        assertEquals(EmojiManifestSanitizer.MAX_ITEMS, out.size());
+    }
+
+    // ---- 输出不可变（防呼叫方误改）----
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void sanitize_result_is_immutable() {
+        List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(
+                Collections.singletonList(item("[a]", "A", "")));
+        assertNotNull(out);
+        out.add(item("[b]", "B", ""));
+    }
+}

--- a/wkbase/src/test/java/com/chat/base/emoji/EmojiManifestSanitizerTest.java
+++ b/wkbase/src/test/java/com/chat/base/emoji/EmojiManifestSanitizerTest.java
@@ -192,6 +192,63 @@ public class EmojiManifestSanitizerTest {
         assertFalse(EmojiManifestSanitizer.isSafeUrl("data:image/png;base64,aaa"));
     }
 
+    // ---- B4：URL allow-list 加固 ----
+
+    @Test
+    public void isSafeUrl_backslash_rejected() {
+        // Windows-style path / URL 转义灰色区域，一律拒
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("\\evil.com/x"));
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("https://cdn.example.com/e\\bad.png"));
+    }
+
+    @Test
+    public void isSafeUrl_https_embedded_credentials_rejected() {
+        // RFC 3986 允许 user:pass@host 但不安全（可能被日志/代理泄漏）
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("https://user:pass@evil.com/e.png"));
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("https://user@evil.com/e.png"));
+    }
+
+    @Test
+    public void isSafeUrl_https_at_in_path_ok() {
+        // @ 出现在 path 部分（第一个 / 之后）是合法的，不该被拒
+        assertTrue(EmojiManifestSanitizer.isSafeUrl("https://cdn.example.com/path@version/e.png"));
+    }
+
+    @Test
+    public void isSafeUrl_relative_at_rejected() {
+        // 相对路径不该含 @——防被误解析成 user:pass@host
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("emojis@evil.com/e.png"));
+    }
+
+    @Test
+    public void isSafeUrl_relative_non_alnum_first_rejected() {
+        // allow-list：首字符必须 / 或 ASCII 字母数字
+        assertFalse(EmojiManifestSanitizer.isSafeUrl(".hidden/e.png"));
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("-dash/e.png"));
+        assertFalse(EmojiManifestSanitizer.isSafeUrl(" emojis/e.png"));
+    }
+
+    // ---- B2：MAX_URL_LEN 上限 ----
+
+    @Test
+    public void isSafeUrl_overlong_rejected() {
+        StringBuilder sb = new StringBuilder("https://cdn.example.com/");
+        while (sb.length() < EmojiManifestSanitizer.MAX_URL_LEN + 10) sb.append('a');
+        assertFalse(EmojiManifestSanitizer.isSafeUrl(sb.toString()));
+    }
+
+    @Test
+    public void sanitize_drops_item_with_overlong_url() {
+        StringBuilder sb = new StringBuilder("https://cdn.example.com/");
+        while (sb.length() < EmojiManifestSanitizer.MAX_URL_LEN + 10) sb.append('a');
+        List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(
+                Arrays.asList(
+                        item("[a]", "A", sb.toString()),
+                        item("[b]", "B", "https://cdn.example.com/short.png")));
+        assertEquals(1, out.size());
+        assertEquals("[b]", out.get(0).key);
+    }
+
     @Test
     public void sanitize_drops_item_with_unsafe_url_but_keeps_others() {
         List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(

--- a/wkbase/src/test/java/com/chat/base/emoji/EmojiManifestSanitizerTest.java
+++ b/wkbase/src/test/java/com/chat/base/emoji/EmojiManifestSanitizerTest.java
@@ -249,6 +249,23 @@ public class EmojiManifestSanitizerTest {
         assertEquals("[b]", out.get(0).key);
     }
 
+    // ---- P2-1：`..` 路径穿越拒绝（防未来 Layer 3 拼到 baseUrl 后被误解析） ----
+
+    @Test
+    public void isSafeUrl_relative_path_traversal_rejected() {
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("../secret/e.png"));
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("emojis/../../secret/e.png"));
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("emojis/.."));
+        assertFalse(EmojiManifestSanitizer.isSafeUrl("/emojis/../etc"));
+    }
+
+    @Test
+    public void isSafeUrl_dot_dot_in_filename_ok() {
+        // `.` `..` 只在作为完整路径组件时才拒，文件名里含 `..` 的普通字符不拒
+        assertTrue(EmojiManifestSanitizer.isSafeUrl("emojis/file..v2.png"));
+        assertTrue(EmojiManifestSanitizer.isSafeUrl("emojis/..hidden.png")); // 首字符是 `.` 但整段不是 `..`
+    }
+
     @Test
     public void sanitize_drops_item_with_unsafe_url_but_keeps_others() {
         List<EmojiManifestItem> out = EmojiManifestSanitizer.sanitize(


### PR DESCRIPTION
## Scope（本 PR 明确不覆盖服务端新增表情的用户可见渲染）

**当前 PR 只处理**：拉取服务端 `GET /v1/common/emojis`，对**客户端已打包 asset 的内置表情**做元数据同步（name / 服务端顺序 / 未来 CDN URL 字段先存不用），把 wire 契约 + 客户端防线基础设施建起来。

**当前 PR 不覆盖**：服务端下发**客户端未打包 asset** 的新 emoji 让用户可见——这类条目 `mergeXmlAndManifest` 已明确 skip（不进 `text2entry`、不进 `defaultEntries`、面板不显示、消息里显示为 `[xxx]` 文本降级），避免面板出现空白 tap-able cell。**这是 Layer 3 独立 PR 的工作**（Glide 预下载 + ImageSpan 异步刷新 + 面板刷新事件）。

Refs #81（部分覆盖：验收标准 1；标准 3「服务端后续新增表情 Android 无需重新发版即可正确渲染」由 Layer 3 交付）

## Summary
- 接入服务端 `GET /v1/common/emojis`：冷启动后同步一次 manifest，合并进 `EmojiManager.text2entry` + `defaultEntries` + `pattern`
- 两层客户端防线：
  - **`EmojiManifestSanitizer`** — token 必须形如 `[xxx]`；URL 白名单（`https://` 或严格相对路径，拒 backslash / 嵌入凭证 / `..` 路径穿越）；`MAX_ITEMS=500` / `MAX_KEY_LEN=32` / `MAX_URL_LEN=2048`；防 `Pattern.quote` 空 branch 零宽死循环
  - **`EmojiManifestCache`** — SP 版本化持久化，冷启动首屏立即可用
- **`EmojiManifestBodyLimitInterceptor`** — HTTP 层 raw body 1 MB 上限（Content-Length 快路径 + `peekBody` 慢路径双保险），URL 严格匹配 `common/emojis` 结尾；挂在 `LogInterceptor` 之后以确保 body-limit 在 log 全量读 body 之前生效
- `EmojiManager` 重构为并发安全：hot-path 字段 `volatile` + copy-on-write 原子 swap；merge 策略「不删」；用 sig 短路无变化 apply；apply + save hop 到后台 executor 避免主线程 jank

## 关键设计取舍
- **服务端 manifest 只用来同步已打包 emoji 的元数据**（本 PR 阶段）——若 xml 未打包，manifest 条目整条 skip，不显示、不匹配、不进 pattern。避免面板出现空白 cell，避免消息 pattern 匹配到但 render 失败
- **合并不删**：manifest 未下发的 xml 已有 emoji 保留（网络失败/服务端配置回退时用户不丢表情）
- **fire-and-forget**：冷启动后异步拉取，失败静默保留 xml + 上次缓存
- **HTTP body 1 MB 上限**：`/common/emojis` 公开无鉴权 + 项目 OkHttp 装 trust-all TrustManager（预存问题），必须在 parse 前限 raw bytes

## 文件
- **DTO** — `EmojiManifestResp` / `EmojiManifestItem`（顶层无信封契约）
- **网络层** — `WKCommonService#getEmojis` + `WKCommonModel#getEmojis` + `EmojiManifestBodyLimitInterceptor`
- **工具** — `EmojiManifestSanitizer` / `EmojiManifestCache`（纯函数，JVM 单测覆盖）
- **管理器** — `EmojiManager`：`refreshFromServer` / `applyManifestInternal` / 抽 `mergeXmlAndManifest` 纯函数
- **冷启动** — `WKBaseApplication.AppStartup.postPhaseC` init 后追加 `refreshFromServer`
- **proguard** — keep 两个 DTO 防 R8 混淆字段名

## Fallback 语义
| 场景 | 行为 |
|------|------|
| 网络失败 / 反序列化失败 | 保留 xml + 上次 SP 缓存 |
| HTTP body > 1 MB | Interceptor 抛 IOException → onFail → 保留兜底 |
| sanitize 后为空 | 保留当前状态 |
| **manifest 有但 xml 未打包 asset** | **整条 skip**（Layer 3 待续） |

## Test plan
- [x] `EmojiManifestSanitizerTest` (31 case)：token / URL 白名单 / 长度上限 / `..` 拒
- [x] `EmojiManifestCacheTest` (7 case)：序列化往返 / 损坏 JSON 兜底
- [x] `EmojiManifestBodyLimitInterceptorTest` (6 case)：Content-Length 快路径 / peekBody 慢路径 / URL 严格匹配 / 组合契约（outer body-read short-circuit）
- [x] `EmojiManagerMergeTest` (10 case)：manifest-only key 被 skip / xml-only 保留 / 空 list buildPattern 兜底
- [x] dogfood 冷启动：`adb logcat` 可见 `applyManifest: manifestItems=4 panelEntries=404 skippedNoAsset=0 sigHash=...`
- [ ] release 构建冷启动：验证 proguard keep 生效
- [ ] 长期跟进：Layer 3 独立 PR 处理 remoteUrl 加载 + 面板刷新事件

## Review 处理历史
- Round 1 blocker「manifest-only 显示空白 cell」→ 已改为 skip
- Round 1/2 major「长度上限 / 主线程 apply / URL allow-list / 日志压缩」→ 已修
- Round 2 blocker「HTTP raw body 无 size cap」→ 新加 Interceptor
- Round 3 blocker「Interceptor 顺序」→ 挪到 LogInterceptor 之后
- Round 3 blocker「headline 过度承诺」→ 本 PR 标题/描述已收窄