### PR TITLE
feat(search): 全局搜索接入服务端聚合 L1 + L2 深度浏览

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -163,6 +163,9 @@
 # 频道内搜索 DTO：CursorList/FileHit/MediaHit/MessageHit/CombinedHit/AroundResult/Pagination
 # 走 FastJson 反射按字段名映射 JSON，不 keep 会被 R8 重命名字段导致反序列化产物类型错乱 → checkcast CCE
 -keep class com.chat.base.search.channel.dto.** { *; }
+# 全局聚合搜索 DTO (L1 _search_global_groups / L2 _search_global_messages)：同上 FastJson 反射映射，
+# release 构建 R8 rename 会导致 L1 groups[] 解析为空/lateinit 崩，PR #95 review 阻塞级。
+-keep class com.chat.base.search.global.dto.** { *; }
 #----------登录模块---------------
 -keep class com.chat.login.entity.** { *; }
 #----------uikit模块--------------

--- a/wkbase/src/main/java/com/chat/base/net/OkHttpUtils.java
+++ b/wkbase/src/main/java/com/chat/base/net/OkHttpUtils.java
@@ -20,6 +20,7 @@ import android.util.Log;
 
 import com.chat.base.WKBaseApplication;
 import com.chat.base.emoji.EmojiManifestBodyLimitInterceptor;
+import com.chat.base.search.global.SearchGlobalBodyLimitInterceptor;
 import com.chat.base.utils.WKNetUtil;
 
 import java.io.File;
@@ -96,7 +97,11 @@ public class OkHttpUtils {
                             // 全量读 body 后再打日志，若 BodyLimit 在 Log 之前（更外层），
                             // Log 已经 OOM 了 BodyLimit 才拿到 response——检查太晚。
                             // 参考 PR #94 Jerry-Xin round-3 review B2。
-                            .addInterceptor(new EmojiManifestBodyLimitInterceptor()).build();
+                            .addInterceptor(new EmojiManifestBodyLimitInterceptor())
+                            // 全局搜索 L1/L2 端点也做 body 大小上限（同 Emoji 拦截器语义），
+                            // 挂在 LogInterceptor 之后避免 Log 先 body().string() OOM。
+                            // PR #95 review 主要级 - OctoBoooot: 新聚合端点缺 body cap。
+                            .addInterceptor(new SearchGlobalBodyLimitInterceptor()).build();
                 }
             }
         }

--- a/wkbase/src/main/java/com/chat/base/search/channel/dto/FileHit.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/dto/FileHit.kt
@@ -29,4 +29,8 @@ class FileHit {
     var sender_name: String? = null
     var sender_avatar_url: String? = null
     lateinit var sent_at: String               // RFC3339
+    // 全局搜索场景（`_search_global_messages` / `_search_global_files`）由服务端回填。
+    // 频道内 `_search_files` / `_search_all` 响应中不带，保留默认空/0，向后兼容。
+    var channel_id: String = ""
+    var channel_type: Byte = 0
 }

--- a/wkbase/src/main/java/com/chat/base/search/channel/dto/MessageHit.kt
+++ b/wkbase/src/main/java/com/chat/base/search/channel/dto/MessageHit.kt
@@ -33,6 +33,9 @@ class MessageHit {
     var outer_preview: OuterPreview? = null
     var inner_messages: List<InnerMessage>? = null
     var channel_id: String = ""
+    // 全局搜索 preview 场景由服务端回填（`_search_global_groups`/`_search_global_messages`）。
+    // 频道内 `_search`/`_search_all` 响应中不携带，保留默认 0。
+    var channel_type: Byte = 0
 
     /** 服务端 snippet 内 <mark> 标签替换为客户端紫色 font，与 GlobalMessage.getHtmlText 同色规则。 */
     fun getHighlightedHtml(): String {

--- a/wkbase/src/main/java/com/chat/base/search/global/SearchGlobalBodyLimitInterceptor.java
+++ b/wkbase/src/main/java/com/chat/base/search/global/SearchGlobalBodyLimitInterceptor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global;
+
+import androidx.annotation.NonNull;
+
+import java.io.IOException;
+import java.util.List;
+
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * 对全局聚合搜索两个端点的 HTTP 响应做 raw-body 字节上限检查，防止 hostile / 误配服务端
+ * 或异常 payload 让 Retrofit + FastJson buffer 全量后 OOM。
+ *
+ * <p>覆盖端点（严格路径匹配，防子路径误命中）：
+ * <ul>
+ *   <li>{@code POST /v1/messages/_search_global_groups} (L1)</li>
+ *   <li>{@code POST /v1/messages/_search_global_messages} (L2)</li>
+ * </ul>
+ *
+ * <p>不覆盖 {@code _search_global_files}（未接入）以及其它 {@code /messages/_search*}
+ * 频道内端点（走 auth 且响应可控）。同 {@link com.chat.base.emoji.EmojiManifestBodyLimitInterceptor}
+ * 一样必须挂在 {@code LogInterceptor} 之后（list 末尾，最内层），否则 LogInterceptor
+ * 已经 body().string() 全量读完，本 interceptor 检查太晚。
+ *
+ * <p>双保险策略：先看 {@code Content-Length}，无 length / chunked 时再用
+ * {@link ResponseBody#peekBody(long)} peek 到上限 + 1 字节。
+ *
+ * <p>上限 2 MB：
+ * <ul>
+ *   <li>L1 服务端上限 maxGroups=200，每桶 preview 最多 20 条，snippet + 元信息
+ *       约 500B/条 → ~2MB 上限估算</li>
+ *   <li>L2 page_size max=100，每条含合并转发 inner_messages 可能 5KB → ~500KB 上限估算</li>
+ * </ul>
+ * 保守取 2MB，命中即拒（Retrofit onFail → UI FALLBACK_TO_LOCAL 走本地兜底）。
+ */
+public final class SearchGlobalBodyLimitInterceptor implements Interceptor {
+
+    /** 2 MB。参见 KDoc 中的上限估算。 */
+    static final long MAX_SEARCH_BODY_BYTES = 2L * 1024L * 1024L;
+
+    private static final String ENDPOINT_L1 = "_search_global_groups";
+    private static final String ENDPOINT_L2 = "_search_global_messages";
+
+    @NonNull
+    @Override
+    public Response intercept(@NonNull Chain chain) throws IOException {
+        Request request = chain.request();
+        if (!isTargetUrl(request)) {
+            return chain.proceed(request);
+        }
+        Response response = chain.proceed(request);
+        ResponseBody body = response.body();
+        if (body == null) {
+            return response;
+        }
+
+        // 快路径：Content-Length 已知且超上限直接拒
+        long contentLength = body.contentLength();
+        if (contentLength > MAX_SEARCH_BODY_BYTES) {
+            response.close();
+            throw new IOException("search global body too large: Content-Length="
+                    + contentLength + " > " + MAX_SEARCH_BODY_BYTES);
+        }
+
+        // 慢路径：Content-Length 缺失 / chunked / 服务端说谎——peek 上限+1 字节
+        ResponseBody peeked = response.peekBody(MAX_SEARCH_BODY_BYTES + 1);
+        byte[] bytes = peeked.bytes();
+        if (bytes.length > MAX_SEARCH_BODY_BYTES) {
+            response.close();
+            throw new IOException("search global body exceeds "
+                    + MAX_SEARCH_BODY_BYTES + " bytes");
+        }
+
+        // 已 peek 到的字节复用为新 body，让下游 Retrofit 消费
+        MediaType contentType = body.contentType();
+        response.close();
+        return response.newBuilder()
+                .body(ResponseBody.create(bytes, contentType))
+                .build();
+    }
+
+    /** 匹配 URL 路径末尾为 {@code messages/_search_global_groups}
+     *  或 {@code messages/_search_global_messages}——严格路径匹配。 */
+    private static boolean isTargetUrl(Request request) {
+        List<String> segments = request.url().pathSegments();
+        int n = segments.size();
+        if (n < 2 || !"messages".equals(segments.get(n - 2))) {
+            return false;
+        }
+        String last = segments.get(n - 1);
+        return ENDPOINT_L1.equals(last) || ENDPOINT_L2.equals(last);
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/search/global/SearchGlobalGroupsBodyBuilder.kt
+++ b/wkbase/src/main/java/com/chat/base/search/global/SearchGlobalGroupsBodyBuilder.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global
+
+import com.alibaba.fastjson.JSONArray
+import com.alibaba.fastjson.JSONObject
+import com.chat.base.search.global.dto.GlobalChannelRef
+import com.chat.base.search.global.dto.GlobalSearchFilters
+import com.chat.base.search.global.dto.SearchGlobalGroupsReq
+
+/**
+ * 序列化 L1 请求体为 FastJSON [JSONObject]，对齐 octo-server
+ * `modules/messages_search/search_global_groups.go` 的 `SearchGlobalGroupsReq` 与
+ * `04-aggregation-api-spec.md` §2.1。
+ *
+ * 关键规则：
+ *  - keyword 为空**不写入** body（触发门交给 [GlobalSearchFilters.canTriggerL1] 判断，此处不做二次校验）。
+ *  - sequence 恒写入（服务端原样回带，用于 UI 层丢弃过期响应）。
+ *  - filters 各字段为空/空集合时**省略**该字段，避免出现空数组导致的语义歧义。
+ *  - filters 完全为空时整个 filters 字段省略。
+ *  - 客户端不做长度/枚举校验，交由服务端 400 反馈以避免规则漂移。
+ */
+internal object SearchGlobalGroupsBodyBuilder {
+
+    fun build(req: SearchGlobalGroupsReq): JSONObject {
+        val body = JSONObject()
+        if (!req.keyword.isNullOrEmpty()) {
+            body["keyword"] = req.keyword
+        }
+        body["sequence"] = req.sequence
+        req.filters?.takeUnless { it.isEmpty() }?.let { body["filters"] = filtersToJson(it) }
+        return body
+    }
+
+    private fun filtersToJson(f: GlobalSearchFilters): JSONObject {
+        val out = JSONObject()
+        f.senderIds?.takeIf { it.isNotEmpty() }?.let { out["sender_ids"] = it }
+        f.memberUids?.takeIf { it.isNotEmpty() }?.let { out["member_uids"] = it }
+        f.memberUid?.takeIf { it.isNotEmpty() }?.let { out["member_uid"] = it }
+        f.channelIds?.takeIf { it.isNotEmpty() }?.let { out["channel_ids"] = channelRefsToJson(it) }
+        f.channelTypes?.takeIf { it.isNotEmpty() }?.let { list ->
+            out["channel_types"] = list.map { it.toInt() }
+        }
+        f.contentTypes?.takeIf { it.isNotEmpty() }?.let { out["content_types"] = it }
+        f.sentAtFrom?.takeIf { it.isNotEmpty() }?.let { out["sent_at_from"] = it }
+        f.sentAtTo?.takeIf { it.isNotEmpty() }?.let { out["sent_at_to"] = it }
+        return out
+    }
+
+    private fun channelRefsToJson(refs: List<GlobalChannelRef>): JSONArray {
+        val arr = JSONArray()
+        for (r in refs) {
+            val o = JSONObject()
+            o["channel_id"] = r.channelId
+            o["channel_type"] = r.channelType.toInt()
+            arr.add(o)
+        }
+        return arr
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/search/global/SearchGlobalGroupsModel.kt
+++ b/wkbase/src/main/java/com/chat/base/search/global/SearchGlobalGroupsModel.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global
+
+import com.chat.base.base.WKBaseModel
+import com.chat.base.net.IRequestResultErrorInfoListener
+import com.chat.base.search.channel.ChannelSearchErrorParser
+import com.chat.base.search.channel.ChannelSearchOutcome
+import com.chat.base.search.channel.dto.SearchErrorCode
+import com.chat.base.search.global.dto.SearchGlobalGroupsReq
+import com.chat.base.search.global.dto.SearchGlobalGroupsResp
+import io.reactivex.rxjava3.core.Observable
+
+/**
+ * 全局聚合搜索（L1）数据编排层。负责：
+ *  - 序列化请求体（[SearchGlobalGroupsBodyBuilder]）
+ *  - 发起 `POST /v1/messages/_search_global_groups`
+ *  - 把服务端结构化错误码解析进 [ChannelSearchOutcome]
+ *
+ * 本地兜底不在此层处理。UI 层根据 [com.chat.base.search.channel.uiAction] 判断是否
+ * 调用 `WKIM.msgManager.search(keyword)` 取本地聚合结果，并在 [ChannelSearchOutcome.success]
+ * 时把 `fromLocalFallback=true` 标记上。
+ *
+ * `X-Space-Id` 由 `CommonRequestParamInterceptor` 自动注入。
+ */
+object SearchGlobalGroupsModel : WKBaseModel() {
+
+    private val service by lazy { createService(SearchGlobalGroupsService::class.java) }
+
+    fun searchGroups(
+        req: SearchGlobalGroupsReq,
+        callback: (ChannelSearchOutcome<SearchGlobalGroupsResp>) -> Unit,
+    ) {
+        dispatch(service.searchGlobalGroups(SearchGlobalGroupsBodyBuilder.build(req)), callback)
+    }
+
+    private fun <T : Any> dispatch(
+        observable: Observable<T>,
+        callback: (ChannelSearchOutcome<T>) -> Unit,
+    ) {
+        requestAndErrorBack(observable, object : IRequestResultErrorInfoListener<T> {
+            override fun onSuccess(result: T) {
+                callback(ChannelSearchOutcome.success(result))
+            }
+
+            override fun onFail(code: Int, msg: String, errJson: String) {
+                callback(mapFailure(code, msg, errJson))
+            }
+        })
+    }
+
+    private fun <T : Any> mapFailure(
+        httpStatus: Int,
+        msg: String,
+        errJson: String,
+    ): ChannelSearchOutcome<T> {
+        val parsed = ChannelSearchErrorParser.parse(errJson)
+        if (parsed != null) {
+            return ChannelSearchOutcome.failure(
+                httpStatus = httpStatus,
+                errorCode = parsed.code,
+                errorMessage = parsed.message.ifBlank { msg },
+                retryAfterSec = parsed.retryAfterSec,
+            )
+        }
+        // 无结构化 error body：按 HTTP 状态码兜底分类。
+        // ResponseExceptionHandle 对连接失败/超时等传输层异常分配 code = -1；
+        // 任何非正数都视作传输层错误，走 LOCAL_ERROR_NETWORK → FALLBACK_TO_LOCAL 触发本地兜底。
+        // 特殊：L1 端点没有 channel 概念，裸 404（nginx 未挂路由，body 非结构化）只可能是"接口未部署"，
+        // 与频道内搜索的 404="频道不可见"语义完全不同，这里也走本地兜底而不是 BLOCK_NOT_FOUND。
+        // 若服务端明确返回结构化 NOT_FOUND（如缺 X-Space-Id 且 RequireSpaceID=true），则 parsed 分支
+        // 已提前 return，不会走到这里。
+        val fallbackCode = when {
+            httpStatus in 500..599 -> SearchErrorCode.UPSTREAM_UNAVAILABLE
+            httpStatus == 429 -> SearchErrorCode.RATE_LIMITED
+            httpStatus == 404 -> ChannelSearchOutcome.LOCAL_ERROR_NETWORK
+            httpStatus == 400 -> SearchErrorCode.VALIDATION_FAILED
+            httpStatus <= 0 -> ChannelSearchOutcome.LOCAL_ERROR_NETWORK
+            else -> SearchErrorCode.INTERNAL
+        }
+        return ChannelSearchOutcome.failure(
+            httpStatus = httpStatus,
+            errorCode = fallbackCode,
+            errorMessage = msg,
+        )
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/search/global/SearchGlobalGroupsService.kt
+++ b/wkbase/src/main/java/com/chat/base/search/global/SearchGlobalGroupsService.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global
+
+import com.alibaba.fastjson.JSONObject
+import com.chat.base.search.global.dto.SearchGlobalGroupsResp
+import io.reactivex.rxjava3.core.Observable
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+/**
+ * 全局聚合搜索 L1 端点（`POST /v1/messages/_search_global_groups`）。
+ *
+ * `X-Space-Id` / `token` 由 [com.chat.base.net.CommonRequestParamInterceptor] 自动注入。
+ * 与 [com.chat.base.search.channel.ChannelSearchService] 共享错误信封 [com.chat.base.search.channel.dto.SearchErrorCode]
+ * 与 401 auth 中间件行为。
+ */
+interface SearchGlobalGroupsService {
+    @POST("messages/_search_global_groups")
+    fun searchGlobalGroups(@Body body: JSONObject): Observable<SearchGlobalGroupsResp>
+}

--- a/wkbase/src/main/java/com/chat/base/search/global/SearchGlobalMessagesBodyBuilder.kt
+++ b/wkbase/src/main/java/com/chat/base/search/global/SearchGlobalMessagesBodyBuilder.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global
+
+import com.alibaba.fastjson.JSONArray
+import com.alibaba.fastjson.JSONObject
+import com.chat.base.search.global.dto.GlobalChannelRef
+import com.chat.base.search.global.dto.GlobalSearchFilters
+import com.chat.base.search.global.dto.SearchGlobalMessagesReq
+
+/**
+ * 序列化 L2 请求体为 FastJSON [JSONObject]，对齐 octo-server
+ * `search_global_messages.go` 的 `SearchGlobalMessagesReq` 与 `04-aggregation-api-spec.md` §3。
+ *
+ * 关键规则（与 L1 [SearchGlobalGroupsBodyBuilder] 保持一致，避免行为漂移）：
+ *  - keyword 为空**不写入** body（浏览模式：仅按 filters 排序）。
+ *  - cursor 为空**不写入** body（首页请求）。
+ *  - filters 各字段为空/空集合时省略；filters 完全为空整个字段省略。
+ *  - sort / page_size 恒写入。
+ *  - 客户端不做长度/枚举校验，交由服务端 400 反馈以避免规则漂移。
+ */
+internal object SearchGlobalMessagesBodyBuilder {
+
+    fun build(req: SearchGlobalMessagesReq): JSONObject {
+        val body = JSONObject()
+        if (!req.keyword.isNullOrEmpty()) {
+            body["keyword"] = req.keyword
+        }
+        req.filters.takeUnless { it.isEmpty() }?.let { body["filters"] = filtersToJson(it) }
+        body["sort"] = req.sort
+        body["page_size"] = req.pageSize
+        if (!req.cursor.isNullOrEmpty()) body["cursor"] = req.cursor
+        return body
+    }
+
+    private fun filtersToJson(f: GlobalSearchFilters): JSONObject {
+        val out = JSONObject()
+        f.senderIds?.takeIf { it.isNotEmpty() }?.let { out["sender_ids"] = it }
+        f.memberUids?.takeIf { it.isNotEmpty() }?.let { out["member_uids"] = it }
+        f.memberUid?.takeIf { it.isNotEmpty() }?.let { out["member_uid"] = it }
+        f.channelIds?.takeIf { it.isNotEmpty() }?.let { out["channel_ids"] = channelRefsToJson(it) }
+        f.channelTypes?.takeIf { it.isNotEmpty() }?.let { list ->
+            out["channel_types"] = list.map { it.toInt() }
+        }
+        f.contentTypes?.takeIf { it.isNotEmpty() }?.let { out["content_types"] = it }
+        f.sentAtFrom?.takeIf { it.isNotEmpty() }?.let { out["sent_at_from"] = it }
+        f.sentAtTo?.takeIf { it.isNotEmpty() }?.let { out["sent_at_to"] = it }
+        return out
+    }
+
+    private fun channelRefsToJson(refs: List<GlobalChannelRef>): JSONArray {
+        val arr = JSONArray()
+        for (r in refs) {
+            val o = JSONObject()
+            o["channel_id"] = r.channelId
+            o["channel_type"] = r.channelType.toInt()
+            arr.add(o)
+        }
+        return arr
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/search/global/SearchGlobalMessagesModel.kt
+++ b/wkbase/src/main/java/com/chat/base/search/global/SearchGlobalMessagesModel.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global
+
+import com.chat.base.base.WKBaseModel
+import com.chat.base.net.IRequestResultErrorInfoListener
+import com.chat.base.search.channel.ChannelSearchErrorParser
+import com.chat.base.search.channel.ChannelSearchOutcome
+import com.chat.base.search.channel.dto.CombinedHit
+import com.chat.base.search.channel.dto.CursorList
+import com.chat.base.search.channel.dto.SearchErrorCode
+import com.chat.base.search.global.dto.SearchGlobalMessagesReq
+import io.reactivex.rxjava3.core.Observable
+
+/**
+ * 全局聚合搜索（L2）数据编排层。负责：
+ *  - 序列化请求体（[SearchGlobalMessagesBodyBuilder]）
+ *  - 发起 `POST /v1/messages/_search_global_messages`
+ *  - 把服务端结构化错误码解析进 [ChannelSearchOutcome]
+ *
+ * UI 层根据 `uiAction()` 决定是否回退（`FALLBACK_TO_LOCAL` 场景由 UI 层自行处理，
+ * ViewModel 保持不依赖 IMSDK 以利单测）。
+ *
+ * `X-Space-Id` 由 `CommonRequestParamInterceptor` 自动注入。
+ */
+object SearchGlobalMessagesModel : WKBaseModel() {
+
+    private val service by lazy { createService(SearchGlobalMessagesService::class.java) }
+
+    fun searchMessages(
+        req: SearchGlobalMessagesReq,
+        callback: (ChannelSearchOutcome<CursorList<CombinedHit>>) -> Unit,
+    ) {
+        dispatch(service.searchGlobalMessages(SearchGlobalMessagesBodyBuilder.build(req)), callback)
+    }
+
+    private fun <T : Any> dispatch(
+        observable: Observable<T>,
+        callback: (ChannelSearchOutcome<T>) -> Unit,
+    ) {
+        requestAndErrorBack(observable, object : IRequestResultErrorInfoListener<T> {
+            override fun onSuccess(result: T) {
+                callback(ChannelSearchOutcome.success(result))
+            }
+
+            override fun onFail(code: Int, msg: String, errJson: String) {
+                callback(mapFailure(code, msg, errJson))
+            }
+        })
+    }
+
+    private fun <T : Any> mapFailure(
+        httpStatus: Int,
+        msg: String,
+        errJson: String,
+    ): ChannelSearchOutcome<T> {
+        val parsed = ChannelSearchErrorParser.parse(errJson)
+        if (parsed != null) {
+            return ChannelSearchOutcome.failure(
+                httpStatus = httpStatus,
+                errorCode = parsed.code,
+                errorMessage = parsed.message.ifBlank { msg },
+                retryAfterSec = parsed.retryAfterSec,
+            )
+        }
+        // 与 [SearchGlobalGroupsModel.mapFailure] 完全对齐：L2 也无 channel 概念，
+        // 裸 404（nginx 未挂路由）视为接口未部署 → 走本地兜底而不是 BLOCK_NOT_FOUND。
+        val fallbackCode = when {
+            httpStatus in 500..599 -> SearchErrorCode.UPSTREAM_UNAVAILABLE
+            httpStatus == 429 -> SearchErrorCode.RATE_LIMITED
+            httpStatus == 404 -> ChannelSearchOutcome.LOCAL_ERROR_NETWORK
+            httpStatus == 400 -> SearchErrorCode.VALIDATION_FAILED
+            httpStatus <= 0 -> ChannelSearchOutcome.LOCAL_ERROR_NETWORK
+            else -> SearchErrorCode.INTERNAL
+        }
+        return ChannelSearchOutcome.failure(
+            httpStatus = httpStatus,
+            errorCode = fallbackCode,
+            errorMessage = msg,
+        )
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/search/global/SearchGlobalMessagesService.kt
+++ b/wkbase/src/main/java/com/chat/base/search/global/SearchGlobalMessagesService.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global
+
+import com.alibaba.fastjson.JSONObject
+import com.chat.base.search.channel.dto.CombinedHit
+import com.chat.base.search.channel.dto.CursorList
+import io.reactivex.rxjava3.core.Observable
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+/**
+ * 全局聚合搜索 L2 端点（`POST /v1/messages/_search_global_messages`）。
+ *
+ * 契约与频道内 `_search_all` 完全对齐——响应体是 `{data: List<SearchAllHit>, pagination}`，
+ * 其中 SearchAllHit 就是 [CombinedHit]（message 与 file 混排，按 result_type 判断）。
+ *
+ * L2 与 L1 是两条独立分页轴：L2 的 cursor 与 L1 无关，互不复用。
+ * `X-Space-Id` / `token` 由 [com.chat.base.net.CommonRequestParamInterceptor] 自动注入。
+ */
+interface SearchGlobalMessagesService {
+    @POST("messages/_search_global_messages")
+    fun searchGlobalMessages(@Body body: JSONObject): Observable<CursorList<CombinedHit>>
+}

--- a/wkbase/src/main/java/com/chat/base/search/global/dto/GlobalSearchFilters.kt
+++ b/wkbase/src/main/java/com/chat/base/search/global/dto/GlobalSearchFilters.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global.dto
+
+/**
+ * 全局搜索通用 filters，语义等同 octo-server `modules/messages_search` 的
+ * `_search_global_messages` / `_search_global_groups`。
+ *
+ * 服务端约束（详见 `04-aggregation-api-spec.md` §2.1 与 `global-search-api.md`）：
+ *  - senderIds / memberUids ≤ 50 个
+ *  - channelTypes ⊆ {1(DM), 2(Group), 5(Thread)}
+ *  - contentTypes ⊆ {1(text), 2(image), 5(video), 8(file), 11(forward), 14(richtext)}
+ *  - sentAtFrom / sentAtTo 支持 YYYY-MM-DD 或 RFC3339；from ≤ to
+ */
+class GlobalSearchFilters(
+    val senderIds: List<String>? = null,
+    val memberUids: List<String>? = null,
+    /** legacy 单选兼容字段，一般用 [memberUids]。 */
+    val memberUid: String? = null,
+    /** 指定群/子区/DM。key=channel_id，type∈{1,2,5}。L1 一般不传。 */
+    val channelIds: List<GlobalChannelRef>? = null,
+    val channelTypes: List<Byte>? = null,
+    val contentTypes: List<Int>? = null,
+    val sentAtFrom: String? = null,
+    val sentAtTo: String? = null,
+) {
+    fun isEmpty(): Boolean =
+        senderIds.isNullOrEmpty() &&
+            memberUids.isNullOrEmpty() &&
+            memberUid.isNullOrEmpty() &&
+            channelIds.isNullOrEmpty() &&
+            channelTypes.isNullOrEmpty() &&
+            contentTypes.isNullOrEmpty() &&
+            sentAtFrom.isNullOrEmpty() &&
+            sentAtTo.isNullOrEmpty()
+
+    /** L1 触发条件：至少一项非空（见 §2.3），否则服务端 400 VALIDATION_ERROR。 */
+    fun canTriggerL1(hasKeyword: Boolean): Boolean =
+        hasKeyword ||
+            !senderIds.isNullOrEmpty() ||
+            !memberUids.isNullOrEmpty() ||
+            !memberUid.isNullOrEmpty() ||
+            !channelIds.isNullOrEmpty()
+}
+
+class GlobalChannelRef(
+    val channelId: String,
+    val channelType: Byte,
+)

--- a/wkbase/src/main/java/com/chat/base/search/global/dto/GroupBucket.kt
+++ b/wkbase/src/main/java/com/chat/base/search/global/dto/GroupBucket.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global.dto
+
+import com.chat.base.search.channel.dto.MessageHit
+
+/**
+ * L1 聚合桶。一个桶 = 一个群 / 一个子区 / 一个 DM。
+ *
+ * 语义（见 `04-aggregation-api-spec.md` §2.4）：
+ *  - presence 精确（K2=500 内 100% 精确）：列出的桶点进 L2 至少 1 条可见，不会"点进去空"
+ *  - [match_count] / [match_count_approx]=true：pre-visibility 近似，UI 显示 "约 N 条"
+ *  - [preview] 每条已做可见性过滤，可直接渲染，[MessageHit.snippet] 已带 `<mark>` 高亮
+ *  - DM 桶：channel_type=1，group_name 为对端用户名，无 parent_group_no / thread_*
+ *  - 子区桶：channel_type=5，parent_group_no + thread_id + thread_name 均非空
+ */
+class GroupBucket {
+    lateinit var channel_id: String
+    var channel_type: Byte = 0
+    /** 群/子区共父群号；DM 桶为空。 */
+    var parent_group_no: String? = null
+    var group_name: String = ""
+    /** 仅子区桶（channel_type=5）非空。 */
+    var thread_id: String? = null
+    var thread_name: String? = null
+    var match_count: Long = 0L
+    var match_count_approx: Boolean = true
+    /** RFC3339。基于可见 hit 重算，不会泄露隐藏消息时间。 */
+    var latest_at: String = ""
+    var preview: List<MessageHit> = emptyList()
+}

--- a/wkbase/src/main/java/com/chat/base/search/global/dto/GroupBucket.kt
+++ b/wkbase/src/main/java/com/chat/base/search/global/dto/GroupBucket.kt
@@ -29,7 +29,10 @@ import com.chat.base.search.channel.dto.MessageHit
  *  - 子区桶：channel_type=5，parent_group_no + thread_id + thread_name 均非空
  */
 class GroupBucket {
-    lateinit var channel_id: String
+    // 服务端契约保证非空，但客户端不用 lateinit：漏字段场景 lateinit 会抛
+    // UninitializedPropertyAccessException 崩 UI 层；给默认空串让下游 `bucketToDataVO`
+    // 走 fallback 分支（`channel_id.ifEmpty { ... }` / adapter 校验），可控降级。
+    var channel_id: String = ""
     var channel_type: Byte = 0
     /** 群/子区共父群号；DM 桶为空。 */
     var parent_group_no: String? = null

--- a/wkbase/src/main/java/com/chat/base/search/global/dto/SearchGlobalGroupsReq.kt
+++ b/wkbase/src/main/java/com/chat/base/search/global/dto/SearchGlobalGroupsReq.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global.dto
+
+/**
+ * L1 请求。对应 `POST /v1/messages/_search_global_groups`。
+ *
+ * - [keyword] ≤ 64 rune；见 [GlobalSearchFilters.canTriggerL1] 触发门。
+ * - [sequence] 前端自增，服务端原样回带，UI 层用于丢弃过期响应（§4 竞态防护）。
+ * - 无 sort / page_size / cursor：L1 一次返回聚合总览，桶固定按 latest_at 倒序，
+ *   preview 条数由服务端 config 分配（`previewBudget=500` / `perGroupMax=20`）。
+ */
+class SearchGlobalGroupsReq(
+    val keyword: String? = null,
+    val sequence: Long = 0L,
+    val filters: GlobalSearchFilters? = null,
+) {
+    companion object {
+        const val MAX_KEYWORD_RUNES = 64
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/search/global/dto/SearchGlobalGroupsResp.kt
+++ b/wkbase/src/main/java/com/chat/base/search/global/dto/SearchGlobalGroupsResp.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global.dto
+
+import com.chat.base.search.channel.dto.Pagination
+
+/**
+ * L1 响应。外层信封 `{data, pagination}` 与频道内搜索保持一致（复用 [Pagination]）。
+ *
+ * `pagination.has_more=true` 表示命中群数超过服务端配置的 `maxGroups`（默认 200），
+ * 仅返回最活跃前 N 群；`next_cursor` 恒为 ""（L1 无逐条翻页）。
+ */
+class SearchGlobalGroupsResp {
+    var data: GroupsResult = GroupsResult()
+    var pagination: Pagination = Pagination()
+}
+
+class GroupsResult {
+    /** 客户端 [SearchGlobalGroupsReq.sequence] 的原样回带。 */
+    var sequence: Long = 0L
+    var query_id: String = ""
+    /** 命中群/子区/DM 总数，HLL cardinality 近似。 */
+    var total_groups: Long = 0L
+    var total_groups_approx: Boolean = true
+    var groups: List<GroupBucket> = emptyList()
+}

--- a/wkbase/src/main/java/com/chat/base/search/global/dto/SearchGlobalMessagesReq.kt
+++ b/wkbase/src/main/java/com/chat/base/search/global/dto/SearchGlobalMessagesReq.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global.dto
+
+/**
+ * L2 请求。对应 `POST /v1/messages/_search_global_messages`。
+ *
+ * 契约与频道内 `_search` / `_search_all` 一致（详见 `04-aggregation-api-spec.md` §3 与
+ * `global-search-api.md`）：
+ *  - [keyword] ≤ 64 rune；服务端做验证。
+ *  - [filters] 必须包含 `channel_ids`（选群/子区/DM），传群 id 服务端会自动展开群+子区。
+ *  - [sort] 支持 `time_desc` / `time_asc` / `relevance`（仅在有 keyword 时启用）。
+ *  - [pageSize] ∈ [1, 100]，默认 20。
+ *  - [cursor] 服务端 HMAC 签名的不透明字符串，翻页时原样回传；首次请求为空。
+ *  - [sequence] 前端自增，服务端**不解析**（L2 不做 echo 回带，客户端仅在 UI 层用于本地竞态）。
+ */
+class SearchGlobalMessagesReq(
+    val keyword: String? = null,
+    val filters: GlobalSearchFilters,
+    val sort: String = SORT_TIME_DESC,
+    val pageSize: Int = DEFAULT_PAGE_SIZE,
+    val cursor: String? = null,
+    val sequence: Long = 0L,
+) {
+    companion object {
+        const val DEFAULT_PAGE_SIZE = 20
+        const val MAX_PAGE_SIZE = 100
+        const val MAX_KEYWORD_RUNES = 64
+
+        const val SORT_TIME_DESC = "time_desc"
+        const val SORT_TIME_ASC = "time_asc"
+        const val SORT_RELEVANCE = "relevance"
+    }
+}

--- a/wkbase/src/test/java/com/chat/base/search/global/GlobalSearchFiltersTest.kt
+++ b/wkbase/src/test/java/com/chat/base/search/global/GlobalSearchFiltersTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global
+
+import com.chat.base.search.global.dto.GlobalChannelRef
+import com.chat.base.search.global.dto.GlobalSearchFilters
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GlobalSearchFiltersTest {
+
+    @Test
+    fun isEmpty_returns_true_when_all_null() {
+        assertTrue(GlobalSearchFilters().isEmpty())
+    }
+
+    @Test
+    fun isEmpty_returns_true_when_all_blank_or_empty() {
+        val f = GlobalSearchFilters(
+            senderIds = emptyList(),
+            memberUids = emptyList(),
+            memberUid = "",
+            channelIds = emptyList(),
+            channelTypes = emptyList(),
+            contentTypes = emptyList(),
+            sentAtFrom = "",
+            sentAtTo = "",
+        )
+        assertTrue(f.isEmpty())
+    }
+
+    @Test
+    fun isEmpty_false_when_any_field_present() {
+        assertFalse(GlobalSearchFilters(senderIds = listOf("u1")).isEmpty())
+        assertFalse(GlobalSearchFilters(memberUids = listOf("u1")).isEmpty())
+        assertFalse(GlobalSearchFilters(memberUid = "u1").isEmpty())
+        assertFalse(GlobalSearchFilters(channelIds = listOf(GlobalChannelRef("c", 2))).isEmpty())
+        assertFalse(GlobalSearchFilters(channelTypes = listOf(2)).isEmpty())
+        assertFalse(GlobalSearchFilters(contentTypes = listOf(1)).isEmpty())
+        assertFalse(GlobalSearchFilters(sentAtFrom = "2026-06-01").isEmpty())
+        assertFalse(GlobalSearchFilters(sentAtTo = "2026-06-30").isEmpty())
+    }
+
+    @Test
+    fun canTriggerL1_true_when_keyword_present() {
+        assertTrue(GlobalSearchFilters().canTriggerL1(hasKeyword = true))
+    }
+
+    @Test
+    fun canTriggerL1_true_when_sender_or_member_or_channel_present() {
+        assertTrue(GlobalSearchFilters(senderIds = listOf("u1")).canTriggerL1(hasKeyword = false))
+        assertTrue(GlobalSearchFilters(memberUids = listOf("u1")).canTriggerL1(hasKeyword = false))
+        assertTrue(GlobalSearchFilters(memberUid = "u1").canTriggerL1(hasKeyword = false))
+        assertTrue(
+            GlobalSearchFilters(channelIds = listOf(GlobalChannelRef("c", 2)))
+                .canTriggerL1(hasKeyword = false),
+        )
+    }
+
+    @Test
+    fun canTriggerL1_false_when_only_time_or_content_type_present() {
+        // 服务端 §2.3 明确：sent_at / content_types / channel_types 单独存在不触发 L1
+        assertFalse(GlobalSearchFilters(sentAtFrom = "2026-06-01").canTriggerL1(hasKeyword = false))
+        assertFalse(GlobalSearchFilters(contentTypes = listOf(1)).canTriggerL1(hasKeyword = false))
+        assertFalse(GlobalSearchFilters(channelTypes = listOf(2)).canTriggerL1(hasKeyword = false))
+    }
+
+    @Test
+    fun canTriggerL1_false_when_empty_and_no_keyword() {
+        assertFalse(GlobalSearchFilters().canTriggerL1(hasKeyword = false))
+    }
+}

--- a/wkbase/src/test/java/com/chat/base/search/global/SearchGlobalBodyLimitInterceptorTest.java
+++ b/wkbase/src/test/java/com/chat/base/search/global/SearchGlobalBodyLimitInterceptorTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.Call;
+import okhttp3.Connection;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * 覆盖 {@link SearchGlobalBodyLimitInterceptor}：路径匹配 + Content-Length 快路径 +
+ * chunked 慢路径 + 严格路径匹配（不误伤子路径）。
+ */
+public class SearchGlobalBodyLimitInterceptorTest {
+
+    private static final MediaType JSON = MediaType.get("application/json");
+
+    private static Request req(String url) {
+        return new Request.Builder().url(url).build();
+    }
+
+    private static Response ok(Request request, ResponseBody body) {
+        return new Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(body)
+                .build();
+    }
+
+    private static ResponseBody bodyWith(final byte[] bytes, long declaredContentLength) {
+        if (declaredContentLength < 0) {
+            return new ResponseBody() {
+                @Override public MediaType contentType() { return JSON; }
+                @Override public long contentLength() { return -1L; }
+                @Override public okio.BufferedSource source() {
+                    okio.Buffer buf = new okio.Buffer();
+                    buf.write(bytes);
+                    return buf;
+                }
+            };
+        }
+        return ResponseBody.create(bytes, JSON);
+    }
+
+    private static class FakeChain implements Interceptor.Chain {
+        final Request request;
+        final Response response;
+
+        FakeChain(Request request, Response response) {
+            this.request = request;
+            this.response = response;
+        }
+
+        @Override public Request request() { return request; }
+        @Override public Response proceed(Request r) throws IOException { return response; }
+        @Override public Connection connection() { return null; }
+        @Override public Call call() { throw new UnsupportedOperationException(); }
+        @Override public int connectTimeoutMillis() { return 0; }
+        @Override public Interceptor.Chain withConnectTimeout(int t, TimeUnit u) { return this; }
+        @Override public int readTimeoutMillis() { return 0; }
+        @Override public Interceptor.Chain withReadTimeout(int t, TimeUnit u) { return this; }
+        @Override public int writeTimeoutMillis() { return 0; }
+        @Override public Interceptor.Chain withWriteTimeout(int t, TimeUnit u) { return this; }
+    }
+
+    @Test
+    public void non_target_url_passes_through_untouched() throws IOException {
+        // 频道内搜索 /messages/_search 不该被拦
+        byte[] payload = new byte[(int) SearchGlobalBodyLimitInterceptor.MAX_SEARCH_BODY_BYTES + 100];
+        Request request = req("https://example.com/v1/messages/_search");
+        Response response = ok(request, bodyWith(payload, payload.length));
+
+        Response out = new SearchGlobalBodyLimitInterceptor().intercept(new FakeChain(request, response));
+
+        assertNotNull(out.body());
+        assertEquals(payload.length, out.body().contentLength());
+    }
+
+    @Test
+    public void l1_oversized_content_length_throws() {
+        byte[] payload = new byte[(int) SearchGlobalBodyLimitInterceptor.MAX_SEARCH_BODY_BYTES + 10];
+        Request request = req("https://example.com/v1/messages/_search_global_groups");
+        Response response = ok(request, bodyWith(payload, payload.length));
+
+        try {
+            new SearchGlobalBodyLimitInterceptor().intercept(new FakeChain(request, response));
+            fail("expected IOException on oversized Content-Length");
+        } catch (IOException e) {
+            assertEquals(true, e.getMessage().contains("Content-Length"));
+        }
+    }
+
+    @Test
+    public void l2_oversized_chunked_body_throws() {
+        byte[] payload = new byte[(int) SearchGlobalBodyLimitInterceptor.MAX_SEARCH_BODY_BYTES + 10];
+        Request request = req("https://example.com/v1/messages/_search_global_messages");
+        Response response = ok(request, bodyWith(payload, -1));
+
+        try {
+            new SearchGlobalBodyLimitInterceptor().intercept(new FakeChain(request, response));
+            fail("expected IOException on oversized chunked body");
+        } catch (IOException e) {
+            assertEquals(true, e.getMessage().contains("exceeds"));
+        }
+    }
+
+    @Test
+    public void l1_within_limit_passes_through() throws IOException {
+        String json = "{\"data\":{\"sequence\":1,\"groups\":[]},\"pagination\":{\"has_more\":false,\"next_cursor\":\"\"}}";
+        byte[] payload = json.getBytes();
+        Request request = req("https://example.com/v1/messages/_search_global_groups");
+        Response response = ok(request, bodyWith(payload, payload.length));
+
+        Response out = new SearchGlobalBodyLimitInterceptor().intercept(new FakeChain(request, response));
+
+        assertNotNull(out.body());
+        assertArrayEquals(payload, out.body().bytes());
+    }
+
+    @Test
+    public void similar_prefix_url_not_matched() throws IOException {
+        // 未接入的 _search_global_files 不该被这个拦截器覆盖（本 interceptor 明确不管它）
+        byte[] payload = new byte[(int) SearchGlobalBodyLimitInterceptor.MAX_SEARCH_BODY_BYTES + 100];
+        Request request = req("https://example.com/v1/messages/_search_global_files");
+        Response response = ok(request, bodyWith(payload, payload.length));
+
+        Response out = new SearchGlobalBodyLimitInterceptor().intercept(new FakeChain(request, response));
+
+        // 不该被拦
+        assertEquals(payload.length, out.body().contentLength());
+    }
+
+    @Test
+    public void non_messages_path_not_matched() throws IOException {
+        // /other/_search_global_groups 不该被拦（严格要求前一段是 messages）
+        byte[] payload = new byte[(int) SearchGlobalBodyLimitInterceptor.MAX_SEARCH_BODY_BYTES + 100];
+        Request request = req("https://example.com/v1/other/_search_global_groups");
+        Response response = ok(request, bodyWith(payload, payload.length));
+
+        Response out = new SearchGlobalBodyLimitInterceptor().intercept(new FakeChain(request, response));
+
+        assertEquals(payload.length, out.body().contentLength());
+    }
+}

--- a/wkbase/src/test/java/com/chat/base/search/global/SearchGlobalGroupsBodyBuilderTest.kt
+++ b/wkbase/src/test/java/com/chat/base/search/global/SearchGlobalGroupsBodyBuilderTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global
+
+import com.chat.base.search.global.dto.GlobalChannelRef
+import com.chat.base.search.global.dto.GlobalSearchFilters
+import com.chat.base.search.global.dto.SearchGlobalGroupsReq
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchGlobalGroupsBodyBuilderTest {
+
+    @Test
+    fun build_minimal_keyword_only() {
+        val req = SearchGlobalGroupsReq(keyword = "hello", sequence = 42L)
+        val body = SearchGlobalGroupsBodyBuilder.build(req)
+
+        assertEquals("hello", body["keyword"])
+        assertEquals(42L, body["sequence"])
+        assertFalse("filters 缺省时不应写入 body", body.containsKey("filters"))
+    }
+
+    @Test
+    fun build_omits_empty_keyword() {
+        val req = SearchGlobalGroupsReq(
+            keyword = null,
+            sequence = 1L,
+            filters = GlobalSearchFilters(senderIds = listOf("u1")),
+        )
+        val body = SearchGlobalGroupsBodyBuilder.build(req)
+        assertFalse(body.containsKey("keyword"))
+        assertTrue(body.containsKey("filters"))
+    }
+
+    @Test
+    fun build_always_writes_sequence_even_zero() {
+        val req = SearchGlobalGroupsReq(keyword = "x", sequence = 0L)
+        val body = SearchGlobalGroupsBodyBuilder.build(req)
+        assertEquals("sequence 恒回带，即便 0 也应写入", 0L, body["sequence"])
+    }
+
+    @Test
+    fun build_strips_empty_filters_block() {
+        val req = SearchGlobalGroupsReq(
+            keyword = "x",
+            sequence = 1L,
+            filters = GlobalSearchFilters(
+                senderIds = emptyList(),
+                sentAtFrom = "",
+                sentAtTo = "",
+            ),
+        )
+        val body = SearchGlobalGroupsBodyBuilder.build(req)
+        assertFalse(body.containsKey("filters"))
+    }
+
+    @Test
+    fun build_passes_filters_snake_case() {
+        val req = SearchGlobalGroupsReq(
+            keyword = "hello",
+            sequence = 100L,
+            filters = GlobalSearchFilters(
+                senderIds = listOf("u1", "u2"),
+                memberUids = listOf("u3"),
+                channelTypes = listOf(1, 2, 5),
+                contentTypes = listOf(1, 2, 8),
+                sentAtFrom = "2026-06-01",
+                sentAtTo = "2026-06-30",
+            ),
+        )
+        val body = SearchGlobalGroupsBodyBuilder.build(req)
+        val filters = body.getJSONObject("filters")
+        assertEquals(listOf("u1", "u2"), filters["sender_ids"])
+        assertEquals(listOf("u3"), filters["member_uids"])
+        // channel_types 序列化为 Int 列表（服务端 uint8 期望 JSON number）
+        assertEquals(listOf(1, 2, 5), filters["channel_types"])
+        assertEquals(listOf(1, 2, 8), filters["content_types"])
+        assertEquals("2026-06-01", filters["sent_at_from"])
+        assertEquals("2026-06-30", filters["sent_at_to"])
+    }
+
+    @Test
+    fun build_channel_ids_serialised_as_ref_objects() {
+        val req = SearchGlobalGroupsReq(
+            keyword = "x",
+            sequence = 1L,
+            filters = GlobalSearchFilters(
+                channelIds = listOf(
+                    GlobalChannelRef("g_xxx", 2),
+                    GlobalChannelRef("g_xxx____thr1", 5),
+                ),
+            ),
+        )
+        val body = SearchGlobalGroupsBodyBuilder.build(req)
+        val filters = body.getJSONObject("filters")
+        val arr = filters.getJSONArray("channel_ids")
+        assertEquals(2, arr.size)
+        val first = arr.getJSONObject(0)
+        assertEquals("g_xxx", first["channel_id"])
+        assertEquals(2, first["channel_type"])
+        val second = arr.getJSONObject(1)
+        assertEquals("g_xxx____thr1", second["channel_id"])
+        assertEquals(5, second["channel_type"])
+    }
+
+    @Test
+    fun build_omits_empty_memberUid_legacy() {
+        val req = SearchGlobalGroupsReq(
+            keyword = "x",
+            sequence = 1L,
+            filters = GlobalSearchFilters(memberUid = ""),
+        )
+        val body = SearchGlobalGroupsBodyBuilder.build(req)
+        assertFalse(body.containsKey("filters"))
+    }
+
+    @Test
+    fun build_writes_legacy_memberUid_when_present() {
+        val req = SearchGlobalGroupsReq(
+            keyword = "x",
+            sequence = 1L,
+            filters = GlobalSearchFilters(memberUid = "legacy_uid"),
+        )
+        val body = SearchGlobalGroupsBodyBuilder.build(req)
+        assertEquals("legacy_uid", body.getJSONObject("filters")["member_uid"])
+    }
+}

--- a/wkbase/src/test/java/com/chat/base/search/global/SearchGlobalGroupsRespParseTest.kt
+++ b/wkbase/src/test/java/com/chat/base/search/global/SearchGlobalGroupsRespParseTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global
+
+import com.alibaba.fastjson.JSON
+import com.chat.base.search.global.dto.SearchGlobalGroupsResp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 反序列化对齐 octo-server `search_global_groups.go` 的响应契约与
+ * `04-aggregation-api-spec.md` §2.2 示例。字段名必须一一匹配，否则线上会静默丢字段。
+ */
+class SearchGlobalGroupsRespParseTest {
+
+    @Test
+    fun parse_full_response_with_group_thread_and_dm_buckets() {
+        val json = """
+            {
+              "data": {
+                "sequence": 1042,
+                "query_id": "01J-abcd",
+                "total_groups": 37,
+                "total_groups_approx": true,
+                "groups": [
+                  {
+                    "channel_id": "g_xxx",
+                    "channel_type": 2,
+                    "parent_group_no": "g_xxx",
+                    "group_name": "项目群",
+                    "match_count": 128,
+                    "match_count_approx": true,
+                    "latest_at": "2026-07-14T10:20:00+08:00",
+                    "preview": [
+                      {
+                        "message_id": "m1",
+                        "message_seq": 100,
+                        "message_kind": "text",
+                        "snippet": "hello <mark>foo</mark> world",
+                        "sender_id": "u1",
+                        "sender_name": "张三",
+                        "sent_at": "2026-07-14T10:20:00+08:00",
+                        "channel_id": "g_xxx",
+                        "channel_type": 2
+                      }
+                    ]
+                  },
+                  {
+                    "channel_id": "g_xxx____thr1",
+                    "channel_type": 5,
+                    "parent_group_no": "g_xxx",
+                    "group_name": "项目群",
+                    "thread_id": "g_xxx____thr1",
+                    "thread_name": "需求评审",
+                    "match_count": 12,
+                    "match_count_approx": true,
+                    "latest_at": "2026-07-13T09:00:00+08:00",
+                    "preview": []
+                  },
+                  {
+                    "channel_id": "u_peer123",
+                    "channel_type": 1,
+                    "group_name": "张三",
+                    "match_count": 8,
+                    "match_count_approx": true,
+                    "latest_at": "2026-07-12T18:30:00+08:00",
+                    "preview": []
+                  }
+                ]
+              },
+              "pagination": {
+                "has_more": false,
+                "next_cursor": ""
+              }
+            }
+        """.trimIndent()
+
+        val resp = JSON.parseObject(json, SearchGlobalGroupsResp::class.java)
+        assertNotNull(resp)
+        assertEquals(1042L, resp.data.sequence)
+        assertEquals("01J-abcd", resp.data.query_id)
+        assertEquals(37L, resp.data.total_groups)
+        assertTrue(resp.data.total_groups_approx)
+        assertEquals(3, resp.data.groups.size)
+
+        // 群桶
+        val group = resp.data.groups[0]
+        assertEquals("g_xxx", group.channel_id)
+        assertEquals(2, group.channel_type.toInt())
+        assertEquals("g_xxx", group.parent_group_no)
+        assertEquals("项目群", group.group_name)
+        assertNull("群桶无 thread_id", group.thread_id)
+        assertEquals(128L, group.match_count)
+        assertTrue(group.match_count_approx)
+        assertEquals("2026-07-14T10:20:00+08:00", group.latest_at)
+        assertEquals(1, group.preview.size)
+        val hit = group.preview[0]
+        assertEquals("m1", hit.message_id)
+        assertEquals("hello <mark>foo</mark> world", hit.snippet)
+        assertEquals(2, hit.channel_type.toInt())
+
+        // 子区桶
+        val thread = resp.data.groups[1]
+        assertEquals(5, thread.channel_type.toInt())
+        assertEquals("g_xxx____thr1", thread.thread_id)
+        assertEquals("需求评审", thread.thread_name)
+        assertEquals("g_xxx", thread.parent_group_no)
+
+        // DM 桶
+        val dm = resp.data.groups[2]
+        assertEquals(1, dm.channel_type.toInt())
+        assertEquals("张三", dm.group_name)
+        assertNull("DM 桶无 parent_group_no", dm.parent_group_no)
+        assertNull("DM 桶无 thread_id", dm.thread_id)
+
+        // pagination
+        assertFalse(resp.pagination.has_more)
+        assertEquals("", resp.pagination.next_cursor)
+    }
+
+    @Test
+    fun parse_empty_groups() {
+        val json = """
+            {
+              "data": {
+                "sequence": 1,
+                "query_id": "q1",
+                "total_groups": 0,
+                "total_groups_approx": true,
+                "groups": []
+              },
+              "pagination": { "has_more": false, "next_cursor": "" }
+            }
+        """.trimIndent()
+        val resp = JSON.parseObject(json, SearchGlobalGroupsResp::class.java)
+        assertEquals(0L, resp.data.total_groups)
+        assertTrue(resp.data.groups.isEmpty())
+    }
+
+    @Test
+    fun parse_has_more_true_when_exceeding_max_groups() {
+        val json = """
+            {
+              "data": {
+                "sequence": 1,
+                "query_id": "q1",
+                "total_groups": 500,
+                "total_groups_approx": true,
+                "groups": []
+              },
+              "pagination": { "has_more": true, "next_cursor": "" }
+            }
+        """.trimIndent()
+        val resp = JSON.parseObject(json, SearchGlobalGroupsResp::class.java)
+        assertTrue("超过 maxGroups 时 has_more=true", resp.pagination.has_more)
+    }
+}

--- a/wkbase/src/test/java/com/chat/base/search/global/SearchGlobalMessagesBodyBuilderTest.kt
+++ b/wkbase/src/test/java/com/chat/base/search/global/SearchGlobalMessagesBodyBuilderTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global
+
+import com.chat.base.search.global.dto.GlobalChannelRef
+import com.chat.base.search.global.dto.GlobalSearchFilters
+import com.chat.base.search.global.dto.SearchGlobalMessagesReq
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SearchGlobalMessagesBodyBuilderTest {
+
+    private fun channelIdsFilter(vararg refs: GlobalChannelRef): GlobalSearchFilters =
+        GlobalSearchFilters(channelIds = refs.toList())
+
+    @Test
+    fun build_minimal_with_channel_id_only() {
+        val req = SearchGlobalMessagesReq(
+            keyword = "hello",
+            filters = channelIdsFilter(GlobalChannelRef("g_xxx", 2)),
+        )
+        val body = SearchGlobalMessagesBodyBuilder.build(req)
+
+        assertEquals("hello", body["keyword"])
+        assertEquals("time_desc", body["sort"])
+        assertEquals(20, body["page_size"])
+        assertFalse("cursor 缺省时不应写入 body", body.containsKey("cursor"))
+        val filters = body.getJSONObject("filters")
+        val arr = filters.getJSONArray("channel_ids")
+        assertEquals(1, arr.size)
+        assertEquals("g_xxx", arr.getJSONObject(0)["channel_id"])
+        assertEquals(2, arr.getJSONObject(0)["channel_type"])
+    }
+
+    @Test
+    fun build_omits_empty_keyword_for_browse_mode() {
+        val req = SearchGlobalMessagesReq(
+            keyword = null,
+            filters = channelIdsFilter(GlobalChannelRef("g_xxx", 2)),
+        )
+        val body = SearchGlobalMessagesBodyBuilder.build(req)
+        assertFalse("空 keyword 是 browse 模式，不应写入", body.containsKey("keyword"))
+    }
+
+    @Test
+    fun build_writes_cursor_byte_exact() {
+        val cursor = "eyJ0cyI6MTcwMDAwMDAwMH0.abcd1234"
+        val req = SearchGlobalMessagesReq(
+            keyword = "x",
+            filters = channelIdsFilter(GlobalChannelRef("g", 2)),
+            cursor = cursor,
+        )
+        val body = SearchGlobalMessagesBodyBuilder.build(req)
+        assertEquals("游标必须原样回传不得改动", cursor, body["cursor"])
+    }
+
+    @Test
+    fun build_passes_sort_and_page_size() {
+        val req = SearchGlobalMessagesReq(
+            keyword = "x",
+            filters = channelIdsFilter(GlobalChannelRef("g", 2)),
+            sort = SearchGlobalMessagesReq.SORT_RELEVANCE,
+            pageSize = 50,
+        )
+        val body = SearchGlobalMessagesBodyBuilder.build(req)
+        assertEquals("relevance", body["sort"])
+        assertEquals(50, body["page_size"])
+    }
+
+    @Test
+    fun build_thread_channel_ref_serialised() {
+        val req = SearchGlobalMessagesReq(
+            keyword = "x",
+            filters = channelIdsFilter(GlobalChannelRef("g_xxx____thr1", 5)),
+        )
+        val body = SearchGlobalMessagesBodyBuilder.build(req)
+        val arr = body.getJSONObject("filters").getJSONArray("channel_ids")
+        assertEquals("g_xxx____thr1", arr.getJSONObject(0)["channel_id"])
+        assertEquals(5, arr.getJSONObject(0)["channel_type"])
+    }
+
+    @Test
+    fun build_dm_channel_ref_serialised() {
+        val req = SearchGlobalMessagesReq(
+            keyword = "x",
+            filters = channelIdsFilter(GlobalChannelRef("u_peer123", 1)),
+        )
+        val body = SearchGlobalMessagesBodyBuilder.build(req)
+        val arr = body.getJSONObject("filters").getJSONArray("channel_ids")
+        assertEquals("u_peer123", arr.getJSONObject(0)["channel_id"])
+        assertEquals(1, arr.getJSONObject(0)["channel_type"])
+    }
+
+    @Test
+    fun build_full_filters_combined() {
+        val req = SearchGlobalMessagesReq(
+            keyword = "x",
+            filters = GlobalSearchFilters(
+                senderIds = listOf("u1"),
+                channelIds = listOf(GlobalChannelRef("g", 2)),
+                contentTypes = listOf(1, 8),
+                sentAtFrom = "2026-06-01",
+                sentAtTo = "2026-06-30",
+            ),
+        )
+        val body = SearchGlobalMessagesBodyBuilder.build(req)
+        val filters = body.getJSONObject("filters")
+        assertEquals(listOf("u1"), filters["sender_ids"])
+        assertEquals(listOf(1, 8), filters["content_types"])
+        assertEquals("2026-06-01", filters["sent_at_from"])
+        assertEquals("2026-06-30", filters["sent_at_to"])
+    }
+}

--- a/wkbase/src/test/java/com/chat/base/search/global/SearchGlobalMessagesRespParseTest.kt
+++ b/wkbase/src/test/java/com/chat/base/search/global/SearchGlobalMessagesRespParseTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.search.global
+
+import com.alibaba.fastjson.JSON
+import com.chat.base.search.channel.dto.CombinedHit
+import com.chat.base.search.channel.dto.CursorList
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 反序列化对齐 octo-server `search_global_messages.go` 的响应契约。
+ * L2 响应壳与 `_search_all` 完全一致 = `{data: List<SearchAllHit>, pagination}`，
+ * 其中 SearchAllHit 就是 [CombinedHit]，此处只需覆盖 message + file 混排 + channel_type 字段。
+ */
+class SearchGlobalMessagesRespParseTest {
+
+    private val respType by lazy {
+        object : com.alibaba.fastjson.TypeReference<CursorList<CombinedHit>>() {}.type
+    }
+
+    @Test
+    fun parse_mixed_message_and_file_hits_with_channel_type() {
+        val json = """
+            {
+              "data": [
+                {
+                  "result_type": "message",
+                  "sorted_at": "2026-07-01T09:59:12Z",
+                  "message": {
+                    "message_id": "m1",
+                    "message_seq": 100,
+                    "message_kind": "text",
+                    "snippet": "hello <mark>foo</mark> world",
+                    "sender_id": "u1",
+                    "sender_name": "张三",
+                    "sent_at": "2026-07-01T09:59:12Z",
+                    "channel_id": "g_xxx",
+                    "channel_type": 2
+                  }
+                },
+                {
+                  "result_type": "file",
+                  "sorted_at": "2026-06-30T10:00:00Z",
+                  "file": {
+                    "message_id": "m2",
+                    "message_seq": 99,
+                    "file_name": "report.xlsx",
+                    "file_size_bytes": 12345,
+                    "file_ext": "xlsx",
+                    "download_url": "https://cdn/report.xlsx",
+                    "sender_id": "u2",
+                    "sender_name": "李四",
+                    "sent_at": "2026-06-30T10:00:00Z",
+                    "channel_id": "g_xxx",
+                    "channel_type": 2
+                  }
+                }
+              ],
+              "pagination": { "has_more": true, "next_cursor": "opaque-cursor-xyz" }
+            }
+        """.trimIndent()
+
+        val resp: CursorList<CombinedHit>? = JSON.parseObject(json, respType)
+        assertNotNull(resp)
+        assertEquals(2, resp!!.data.size)
+
+        val msgHit = resp.data[0]
+        assertTrue(msgHit.isMessage())
+        assertFalse(msgHit.isFile())
+        assertNotNull(msgHit.message)
+        assertNull(msgHit.file)
+        assertEquals("m1", msgHit.message!!.message_id)
+        assertEquals("g_xxx", msgHit.message!!.channel_id)
+        assertEquals(2, msgHit.message!!.channel_type.toInt())
+        assertEquals("hello <mark>foo</mark> world", msgHit.message!!.snippet)
+
+        val fileHit = resp.data[1]
+        assertTrue(fileHit.isFile())
+        assertFalse(fileHit.isMessage())
+        assertNotNull(fileHit.file)
+        assertNull(fileHit.message)
+        assertEquals("report.xlsx", fileHit.file!!.file_name)
+        assertEquals(12345L, fileHit.file!!.file_size_bytes)
+        assertEquals("xlsx", fileHit.file!!.file_ext)
+        assertEquals("g_xxx", fileHit.file!!.channel_id)
+        assertEquals(2, fileHit.file!!.channel_type.toInt())
+
+        assertTrue(resp.pagination.has_more)
+        assertEquals("opaque-cursor-xyz", resp.pagination.next_cursor)
+    }
+
+    @Test
+    fun parse_empty_result() {
+        val json = """{"data": [], "pagination": {"has_more": false, "next_cursor": ""}}"""
+        val resp: CursorList<CombinedHit>? = JSON.parseObject(json, respType)
+        assertNotNull(resp)
+        assertTrue(resp!!.data.isEmpty())
+        assertFalse(resp.pagination.has_more)
+        assertEquals("", resp.pagination.next_cursor)
+    }
+}

--- a/wkuikit/build.gradle
+++ b/wkuikit/build.gradle
@@ -60,4 +60,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.json:json:20240303'
     testImplementation 'com.google.code.gson:gson:2.8.9'
+    // ViewModel/StateFlow + debounce 单测：kotlinx-coroutines-test 提供 runTest + StandardTestDispatcher，
+    // 与 wkbase 保持同版本；用于 GlobalSearchViewModel debounce/sequence 乱序防护验证。
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2'
 }

--- a/wkuikit/src/main/AndroidManifest.xml
+++ b/wkuikit/src/main/AndroidManifest.xml
@@ -112,6 +112,9 @@
             android:resizeableActivity="true"
             android:configChanges="screenSize|screenLayout|smallestScreenSize|orientation|keyboardHidden" />
         <activity android:name="com.chat.uikit.chat.search.MessageRecordActivity" />
+        <activity android:name="com.chat.uikit.search.remote.drill.GroupDrillActivity"
+            android:configChanges="screenSize|screenLayout|smallestScreenSize|orientation|keyboardHidden"
+            android:windowSoftInputMode="stateVisible|adjustResize" />
         <activity android:name="com.chat.uikit.chat.search.member.SearchWithMemberActivity" />
         <activity android:name="com.chat.uikit.chat.search.date.SearchWithDateActivity" />
         <activity android:name="com.chat.uikit.chat.search.image.SearchWithImgActivity" />

--- a/wkuikit/src/main/java/com/chat/uikit/search/remote/GlobalActivity.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/search/remote/GlobalActivity.kt
@@ -21,13 +21,19 @@ import android.text.Editable
 import android.text.TextUtils
 import android.text.TextWatcher
 import android.view.inputmethod.EditorInfo
+import androidx.activity.viewModels
 import androidx.core.view.ViewCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.chat.base.base.WKBaseActivity
 import com.chat.base.endpoint.EndpointManager
 import com.chat.base.endpoint.EndpointSID
 import com.chat.base.endpoint.entity.ChatViewMenu
 import com.chat.base.msgitem.WKContentType
 import com.chat.base.net.HttpResponseCode
+import com.chat.base.search.channel.ChannelSearchUiAction
+import com.chat.base.search.global.dto.GroupBucket
 import com.chat.base.ui.Theme
 import com.chat.base.utils.SoftKeyboardUtils
 import com.chat.base.utils.WKReader
@@ -42,13 +48,22 @@ import com.scwang.smart.refresh.layout.api.RefreshLayout
 import com.scwang.smart.refresh.layout.listener.OnRefreshLoadMoreListener
 import com.xinbida.wukongim.WKIM
 import com.xinbida.wukongim.entity.WKChannelType
-import com.xinbida.wukongim.entity.WKMessageSearchResult
 import java.util.Objects
+import kotlinx.coroutines.launch
 
 class GlobalActivity : WKBaseActivity<ActGlobalLayoutBinding>() {
     lateinit var adapter: GlobalAdapter
     private var keyword: String = ""
-    private var page = 1
+
+    private val viewModel: GlobalSearchViewModel by viewModels()
+
+    // 三段结果缓存。任一段变化时 [rebuildList] 组合成最终列表提交给 adapter，
+    // 避免联系人/群段（老 /search/global 异步）和聊天记录段（新 L1 异步）之间的顺序竞态。
+    private var friendsList: List<GlobalChannel> = emptyList()
+    private var groupsList: List<GlobalChannel> = emptyList()
+    private var searchShortcut: DataVO? = null
+    private var chatRecords: List<DataVO> = emptyList()
+
     override fun getViewBinding(): ActGlobalLayoutBinding {
         return ActGlobalLayoutBinding.inflate(layoutInflater)
     }
@@ -61,9 +76,12 @@ class GlobalActivity : WKBaseActivity<ActGlobalLayoutBinding>() {
             .showSoftKeyBoard(this@GlobalActivity, wkVBinding.searchEt)
 
         wkVBinding.refreshLayout.setEnableRefresh(false)
-        wkVBinding.refreshLayout.setEnableLoadMore(true)
+        // L1 聚合端点无逐条翻页（服务端契约 §2.2 next_cursor 恒空），关闭 loadMore。
+        // 命中群 > maxGroups 时通过 state.hasMore 由 [rebuildList] 追加"缩小范围"提示项。
+        wkVBinding.refreshLayout.setEnableLoadMore(false)
         adapter = GlobalAdapter()
         initAdapter(wkVBinding.recyclerView, adapter)
+        observeChatRecordsState()
     }
 
     override fun initListener() {
@@ -72,6 +90,7 @@ class GlobalActivity : WKBaseActivity<ActGlobalLayoutBinding>() {
             if (actionId == EditorInfo.IME_ACTION_SEARCH) {
                 SoftKeyboardUtils.getInstance()
                     .hideSoftKeyboard(this@GlobalActivity)
+                viewModel.triggerNow()
                 return@setOnEditorActionListener true
             }
             false
@@ -86,20 +105,26 @@ class GlobalActivity : WKBaseActivity<ActGlobalLayoutBinding>() {
 
             override fun afterTextChanged(s: Editable?) {
                 val content = s.toString()
+                keyword = content
+                // 聊天记录段：服务端 L1 + 竞态防护（debounce/sequence/cancel）由 ViewModel 统管。
+                viewModel.setKeyword(content)
                 if (TextUtils.isEmpty(content)) {
+                    friendsList = emptyList()
+                    groupsList = emptyList()
+                    searchShortcut = null
+                    chatRecords = emptyList()
                     adapter.setList(ArrayList())
                 } else {
-                    keyword = content
-                    page = 1
-                    getData(0)
+                    // 联系人/群段仍走本地 + 老 /search/global；见 [loadContactsAndGroups]。
+                    loadContactsAndGroups()
                 }
             }
 
         })
         wkVBinding.refreshLayout.setOnRefreshLoadMoreListener(object : OnRefreshLoadMoreListener {
             override fun onLoadMore(refreshLayout: RefreshLayout) {
-                page++
-                getData(1)
+                // L1 无翻页；enableLoadMore=false 后此回调不会被触发，保留仅为 API 完整性。
+                refreshLayout.finishLoadMore()
             }
 
             override fun onRefresh(refreshLayout: RefreshLayout) {}
@@ -179,97 +204,166 @@ class GlobalActivity : WKBaseActivity<ActGlobalLayoutBinding>() {
         }
     }
 
-    private fun getData(onlyMessage: Int) {
+    /**
+     * 拉联系人 + 群段：本地会话搜索合并老 /search/global（保留原来的 friends/groups 逻辑）。
+     * 老接口的 messages 段不再消费（服务端 L1 已覆盖），避免同一条消息被展示两次。
+     */
+    private fun loadContactsAndGroups() {
         val contentType = ArrayList<Int>()
         contentType.add(WKContentType.WK_TEXT)
         contentType.add(WKContentType.WK_FILE)
-        val req = GlobalSearchReq(onlyMessage, keyword, "", 0, "", "", contentType, page, 20, 0, 0)
+        val req = GlobalSearchReq(0, keyword, "", 0, "", "", contentType, 1, 20, 0, 0)
+        val requestKeyword = keyword
         GlobalSearchModel.search(req) { code, msg, resp ->
             wkVBinding.refreshLayout.finishRefresh()
             wkVBinding.refreshLayout.finishLoadMore()
-            if (code == HttpResponseCode.success) {
-                if (resp == null) {
-                    return@search
-                }
-                if (page == 1) {
-                    // 合并本地会话搜索结果（群组和联系人），弥补服务端 space_id 过滤不完整
-                    val localResult = searchLocalConversations(keyword)
-                    val allFriends = mergeChannels(resp.friends, localResult.first)
-                    val allGroups = mergeChannels(resp.groups, localResult.second)
-
-                    val list = ArrayList<DataVO>()
-                    if (WKReader.isNotEmpty(allFriends)) {
-                        list.add(DataVO(DataVO.TEXT, null, null, getString(R.string.contacts)))
-                        for (channel in allFriends) {
-                            list.add(DataVO(DataVO.CHANNEL, channel, null, ""))
-                        }
-                        list.add(DataVO(DataVO.SPAN, null, null, ""))
-                    }
-                    if (WKReader.isNotEmpty(allGroups)) {
-                        list.add(DataVO(DataVO.TEXT, null, null, getString(R.string.group_chat)))
-                        for (channel in allGroups) {
-                            list.add(DataVO(DataVO.CHANNEL, channel, null, ""))
-                        }
-                        list.add(DataVO(DataVO.SPAN, null, null, ""))
-                    }
-
-                    list.add(DataVO(DataVO.SEARCH, null, null, keyword))
-                    list.add(DataVO(DataVO.SPAN, null, null, ""))
-
-                    // 本地消息内容搜索
-                    val localMsgResults = WKIM.getInstance().msgManager.search(keyword)
-                    if (WKReader.isNotEmpty(localMsgResults)) {
-                        list.add(DataVO(DataVO.TEXT, null, null, getString(R.string.chat_records)))
-                        for (result in localMsgResults) {
-                            val ch = result.wkChannel
-                            val fullChannel = if (ch != null) {
-                                WKIM.getInstance().channelManager.getChannel(ch.channelID, ch.channelType) ?: ch
-                            } else null
-                            val displayName = fullChannel?.channelRemark?.takeIf { it.isNotEmpty() }
-                                ?: fullChannel?.channelName?.takeIf { it.isNotEmpty() }
-                                ?: fullChannel?.channelID ?: ""
-                            val gc = GlobalChannel().apply {
-                                channel_id = fullChannel?.channelID ?: ""
-                                channel_type = fullChannel?.channelType ?: 0
-                                channel_name = displayName
-                            }
-                            val snippet = if (result.messageCount == 1 && !result.searchableWord.isNullOrEmpty()) {
-                                snippetFromText(result.searchableWord, keyword, 40)
-                            } else {
-                                "${result.messageCount} 条相关聊天记录"
-                            }
-                            list.add(DataVO(DataVO.LOCAL_MSG, gc, null, snippet, keyword, result.messageCount, result.orderSeq))
-                        }
-                        list.add(DataVO(DataVO.SPAN, null, null, ""))
-                    }
-
-                    // API 远程消息搜索
-                    if (WKReader.isNotEmpty(resp.messages)) {
-                        if (!WKReader.isNotEmpty(localMsgResults)) {
-                            list.add(DataVO(DataVO.TEXT, null, null, getString(R.string.chat_records)))
-                        }
-                        for (message in resp.messages) {
-                            list.add(DataVO(DataVO.MESSAGE, message.channel, message, ""))
-                        }
-                    }
-                    adapter.setList(list)
-                } else {
-                    if (WKReader.isNotEmpty(resp.messages)) {
-                        val list = ArrayList<DataVO>()
-                        for (message in resp.messages) {
-                            val messageVO =
-                                DataVO(DataVO.MESSAGE, message.channel, message, "")
-                            list.add(messageVO)
-                        }
-                        adapter.addData(list)
-                    } else {
-                        wkVBinding.refreshLayout.setEnableLoadMore(false)
-                    }
-                }
-            } else {
-                showToast(msg)
+            // 关键词已变或已清空时丢弃这次响应，避免过期结果覆盖当前段
+            if (requestKeyword != keyword || TextUtils.isEmpty(keyword)) return@search
+            if (code == HttpResponseCode.success && resp != null) {
+                // 合并本地会话搜索，弥补服务端 space_id 对群组过滤不完整
+                val localResult = searchLocalConversations(keyword)
+                friendsList = mergeChannels(resp.friends, localResult.first)
+                groupsList = mergeChannels(resp.groups, localResult.second)
+                searchShortcut = DataVO(DataVO.SEARCH, null, null, keyword)
+                rebuildList()
+            } else if (code != HttpResponseCode.success) {
+                // 老接口失败也要退化：仅用本地会话结果，保证联系人/群段不因服务端问题空掉
+                val localResult = searchLocalConversations(keyword)
+                friendsList = localResult.first
+                groupsList = localResult.second
+                searchShortcut = DataVO(DataVO.SEARCH, null, null, keyword)
+                rebuildList()
+                if (!msg.isNullOrEmpty()) showToast(msg)
             }
         }
+    }
+
+    /** 订阅 [GlobalSearchViewModel.state]：把 L1 [GroupBucket] 映射为 [DataVO.LOCAL_MSG]，
+     * 失败/离线时自动回退到 IMSDK 本地聚合（与频道内搜索 FALLBACK_TO_LOCAL 语义一致）。 */
+    private fun observeChatRecordsState() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.state.collect { state ->
+                    // 关键词已被用户清空 → 强制清聊天记录段
+                    if (state.keyword.isEmpty()) {
+                        if (chatRecords.isNotEmpty()) {
+                            chatRecords = emptyList()
+                            rebuildList()
+                        }
+                        return@collect
+                    }
+                    chatRecords = when (state.uiAction()) {
+                        null -> state.groups.map { bucketToDataVO(it, state.keyword) }
+                        ChannelSearchUiAction.FALLBACK_TO_LOCAL -> localMessagesAsDataVO(state.keyword)
+                        // 其他错误（限流 / 未启用 / 权限 / 校验 / 通用错误）：清空聊天记录段
+                        // 让用户明确知道服务端没有返回结果；对应 toast 由 [showErrorToast] 处理
+                        else -> {
+                            showErrorToast(state)
+                            emptyList()
+                        }
+                    }
+                    rebuildList()
+                }
+            }
+        }
+    }
+
+    private fun bucketToDataVO(bucket: GroupBucket, keyword: String): DataVO {
+        val displayName = when {
+            bucket.channel_type == WKChannelType.COMMUNITY_TOPIC && !bucket.thread_name.isNullOrEmpty() ->
+                bucket.thread_name!!
+            bucket.group_name.isNotEmpty() -> bucket.group_name
+            else -> bucket.channel_id
+        }
+        val gc = GlobalChannel().apply {
+            channel_id = bucket.channel_id
+            channel_type = bucket.channel_type
+            channel_name = displayName
+        }
+        // 单条命中直接展示 snippet；多条则展示"约 N 条"折叠。
+        // 服务端 snippet 带 <mark>...</mark>，客户端 Adapter 走 keyword 高亮，先剥掉 mark 标签。
+        val text = if (bucket.match_count <= 1L && bucket.preview.isNotEmpty()) {
+            stripMarkTags(bucket.preview[0].snippet)
+        } else {
+            val prefix = if (bucket.match_count_approx) "约 " else ""
+            "$prefix${bucket.match_count} 条相关聊天记录"
+        }
+        // messageCount>1 且 orderSeq=0 → 点击落到 MessageRecordActivity（GlobalActivity.kt:170 分支）
+        val count = bucket.match_count.coerceIn(0L, Int.MAX_VALUE.toLong()).toInt()
+        return DataVO(DataVO.LOCAL_MSG, gc, null, text, keyword, count, 0L)
+    }
+
+    /** 服务端失败/离线兜底：本地 IMSDK 消息聚合，输出 shape 与 L1 结果一致。 */
+    private fun localMessagesAsDataVO(keyword: String): List<DataVO> {
+        val local = WKIM.getInstance().msgManager.search(keyword) ?: return emptyList()
+        return local.mapNotNull { result ->
+            val ch = result.wkChannel ?: return@mapNotNull null
+            val fullChannel = WKIM.getInstance().channelManager.getChannel(ch.channelID, ch.channelType) ?: ch
+            val displayName = fullChannel.channelRemark?.takeIf { it.isNotEmpty() }
+                ?: fullChannel.channelName?.takeIf { it.isNotEmpty() }
+                ?: fullChannel.channelID
+                ?: ""
+            val gc = GlobalChannel().apply {
+                channel_id = fullChannel.channelID ?: ""
+                channel_type = fullChannel.channelType
+                channel_name = displayName
+            }
+            val snippet = if (result.messageCount == 1 && !result.searchableWord.isNullOrEmpty()) {
+                snippetFromText(result.searchableWord, keyword, 40)
+            } else {
+                "${result.messageCount} 条相关聊天记录"
+            }
+            DataVO(DataVO.LOCAL_MSG, gc, null, snippet, keyword, result.messageCount, result.orderSeq)
+        }
+    }
+
+    private fun stripMarkTags(text: String): String =
+        text.replace("<mark>", "").replace("</mark>", "")
+
+    private fun showErrorToast(state: GlobalSearchViewModel.State) {
+        val msg = when (state.uiAction()) {
+            ChannelSearchUiAction.RATE_LIMITED ->
+                if (state.retryAfterSec > 0) "请求过于频繁，${state.retryAfterSec}s 后重试"
+                else "请求过于频繁，请稍后重试"
+            ChannelSearchUiAction.FEATURE_DISABLED -> "搜索功能未启用"
+            ChannelSearchUiAction.BLOCK_NOT_FOUND -> null   // 不打扰
+            ChannelSearchUiAction.VALIDATION_ERROR -> null  // 触发条件不满足是常态
+            else -> state.errorMessage?.takeIf { it.isNotEmpty() } ?: "搜索失败，请重试"
+        }
+        msg?.let { showToast(it) }
+    }
+
+    /** 组合三段 + 分隔符，一次提交给 adapter。空字符串场景由 [afterTextChanged] 直接 setList(空) 处理。 */
+    private fun rebuildList() {
+        if (TextUtils.isEmpty(keyword)) {
+            adapter.setList(ArrayList())
+            return
+        }
+        val list = ArrayList<DataVO>()
+        if (WKReader.isNotEmpty(friendsList)) {
+            list.add(DataVO(DataVO.TEXT, null, null, getString(R.string.contacts)))
+            for (channel in friendsList) {
+                list.add(DataVO(DataVO.CHANNEL, channel, null, ""))
+            }
+            list.add(DataVO(DataVO.SPAN, null, null, ""))
+        }
+        if (WKReader.isNotEmpty(groupsList)) {
+            list.add(DataVO(DataVO.TEXT, null, null, getString(R.string.group_chat)))
+            for (channel in groupsList) {
+                list.add(DataVO(DataVO.CHANNEL, channel, null, ""))
+            }
+            list.add(DataVO(DataVO.SPAN, null, null, ""))
+        }
+        searchShortcut?.let {
+            list.add(it)
+            list.add(DataVO(DataVO.SPAN, null, null, ""))
+        }
+        if (chatRecords.isNotEmpty()) {
+            list.add(DataVO(DataVO.TEXT, null, null, getString(R.string.chat_records)))
+            list.addAll(chatRecords)
+            list.add(DataVO(DataVO.SPAN, null, null, ""))
+        }
+        adapter.setList(list)
     }
 
     private fun snippetFromText(text: String, keyword: String, maxLength: Int): String {

--- a/wkuikit/src/main/java/com/chat/uikit/search/remote/GlobalActivity.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/search/remote/GlobalActivity.kt
@@ -42,8 +42,8 @@ import com.chat.uikit.databinding.ActGlobalLayoutBinding
 import com.chat.base.entity.GlobalChannel
 import com.chat.base.entity.GlobalSearchReq
 import com.chat.base.search.GlobalSearchModel
-import com.chat.uikit.chat.search.MessageRecordActivity
 import com.chat.uikit.search.SearchUserActivity
+import com.chat.uikit.search.remote.drill.GroupDrillActivity
 import com.scwang.smart.refresh.layout.api.RefreshLayout
 import com.scwang.smart.refresh.layout.listener.OnRefreshLoadMoreListener
 import com.xinbida.wukongim.WKIM
@@ -192,7 +192,12 @@ class GlobalActivity : WKBaseActivity<ActGlobalLayoutBinding>() {
                                 )
                             )
                         } else {
-                            val intent = Intent(this@GlobalActivity, MessageRecordActivity::class.java)
+                            // 服务端 L1 桶 (item.orderSeq=0 硬编码): 跳 GroupDrillActivity
+                            // 走 L2 (_search_global_messages)，传群 id 自动展开群+子区，
+                            // 让用户一次看到该会话下所有关键词命中 (对齐服务端契约 §3)。
+                            // 老 IMSDK 本地聚合桶 (orderSeq>0 只走定位分支; orderSeq=0 且
+                            // messageCount>1 也走这里) 也跳 GroupDrill，服务端 L2 补齐历史。
+                            val intent = Intent(this@GlobalActivity, GroupDrillActivity::class.java)
                             intent.putExtra("channel_id", item.channel!!.channel_id)
                             intent.putExtra("channel_type", item.channel.channel_type)
                             intent.putExtra("keyword", item.keyword)
@@ -269,9 +274,13 @@ class GlobalActivity : WKBaseActivity<ActGlobalLayoutBinding>() {
     }
 
     private fun bucketToDataVO(bucket: GroupBucket, keyword: String): DataVO {
+        val isThread = bucket.channel_type == WKChannelType.COMMUNITY_TOPIC
+        // 子区展示 "父群名 · 子区名"，方便用户识别归属；纯群/DM 直接展 group_name
         val displayName = when {
-            bucket.channel_type == WKChannelType.COMMUNITY_TOPIC && !bucket.thread_name.isNullOrEmpty() ->
-                bucket.thread_name!!
+            isThread && !bucket.thread_name.isNullOrEmpty() -> {
+                if (bucket.group_name.isNotEmpty()) "${bucket.group_name} · ${bucket.thread_name}"
+                else bucket.thread_name!!
+            }
             bucket.group_name.isNotEmpty() -> bucket.group_name
             else -> bucket.channel_id
         }
@@ -288,7 +297,7 @@ class GlobalActivity : WKBaseActivity<ActGlobalLayoutBinding>() {
             val prefix = if (bucket.match_count_approx) "约 " else ""
             "$prefix${bucket.match_count} 条相关聊天记录"
         }
-        // messageCount>1 且 orderSeq=0 → 点击落到 MessageRecordActivity（GlobalActivity.kt:170 分支）
+        // messageCount>1 且 orderSeq=0 → 点击落到 GroupDrillActivity 走 L2
         val count = bucket.match_count.coerceIn(0L, Int.MAX_VALUE.toLong()).toInt()
         return DataVO(DataVO.LOCAL_MSG, gc, null, text, keyword, count, 0L)
     }

--- a/wkuikit/src/main/java/com/chat/uikit/search/remote/GlobalActivity.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/search/remote/GlobalActivity.kt
@@ -64,6 +64,11 @@ class GlobalActivity : WKBaseActivity<ActGlobalLayoutBinding>() {
     private var searchShortcut: DataVO? = null
     private var chatRecords: List<DataVO> = emptyList()
 
+    // Toast 去重：state.collect 每次 emission 都触发（含 repeatOnLifecycle 从 STOPPED 恢复时重放
+    // 上一次 state），无去重会让同一 errorCode 重复弹 toast 打扰用户。
+    // 新一轮请求发起时 errorCode 被清 null，允许下次错误再次弹。
+    private var lastToastedErrorCode: String? = null
+
     override fun getViewBinding(): ActGlobalLayoutBinding {
         return ActGlobalLayoutBinding.inflate(layoutInflater)
     }
@@ -258,12 +263,19 @@ class GlobalActivity : WKBaseActivity<ActGlobalLayoutBinding>() {
                         return@collect
                     }
                     chatRecords = when (state.uiAction()) {
-                        null -> state.groups.map { bucketToDataVO(it, state.keyword) }
+                        null -> {
+                            // 新请求成功或刚发起时 errorCode 被清空 → 允许下次 toast
+                            lastToastedErrorCode = null
+                            state.groups.map { bucketToDataVO(it, state.keyword) }
+                        }
                         ChannelSearchUiAction.FALLBACK_TO_LOCAL -> localMessagesAsDataVO(state.keyword)
                         // 其他错误（限流 / 未启用 / 权限 / 校验 / 通用错误）：清空聊天记录段
                         // 让用户明确知道服务端没有返回结果；对应 toast 由 [showErrorToast] 处理
                         else -> {
-                            showErrorToast(state)
+                            if (state.errorCode != lastToastedErrorCode) {
+                                lastToastedErrorCode = state.errorCode
+                                showErrorToast(state)
+                            }
                             emptyList()
                         }
                     }

--- a/wkuikit/src/main/java/com/chat/uikit/search/remote/GlobalAdapter.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/search/remote/GlobalAdapter.kt
@@ -26,9 +26,11 @@ import android.widget.TextView
 import com.chad.library.adapter.base.BaseMultiItemQuickAdapter
 import com.chad.library.adapter.base.viewholder.BaseViewHolder
 import com.chat.base.msgitem.WKContentType
+import com.chat.base.space.SpaceFilter
 import com.chat.base.ui.components.AvatarView
 import com.chat.base.utils.WKTimeUtils
 import com.chat.uikit.R
+import com.xinbida.wukongim.entity.WKChannelType
 
 class GlobalAdapter : BaseMultiItemQuickAdapter<DataVO, BaseViewHolder>() {
     init {
@@ -80,8 +82,16 @@ class GlobalAdapter : BaseMultiItemQuickAdapter<DataVO, BaseViewHolder>() {
         } else if (item.itemType == 4) {
             val avatarView = holder.getView<AvatarView>(R.id.avatarView)
             avatarView.setSize(40f)
-            avatarView.showAvatar(item.channel?.channel_id, item.channel!!.channel_type)
-            holder.setText(R.id.nameTv, item.channel.channel_name ?: "")
+            // 子区（channel_type=5）的 channel_id 是 "{parent}____{thread}" 复合结构，
+            // AvatarView 无法直接加载；子区在产品上没有独立头像，沿用父群头像。
+            val ch = item.channel!!
+            if (ch.channel_type == WKChannelType.COMMUNITY_TOPIC) {
+                val parent = SpaceFilter.extractParentGroupId(ch.channel_id) ?: ch.channel_id
+                avatarView.showAvatar(parent, WKChannelType.GROUP)
+            } else {
+                avatarView.showAvatar(ch.channel_id, ch.channel_type)
+            }
+            holder.setText(R.id.nameTv, ch.channel_name ?: "")
             val contentTv = holder.getView<TextView>(R.id.contentTv)
             contentTv.text = highlightKeyword(item.text, item.keyword)
             holder.setText(R.id.timeTv, "")

--- a/wkuikit/src/main/java/com/chat/uikit/search/remote/GlobalSearchViewModel.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/search/remote/GlobalSearchViewModel.kt
@@ -147,17 +147,23 @@ class GlobalSearchViewModel(
             sequence = mySeq,
         )
         val req = SearchGlobalGroupsReq(keyword = keyword, sequence = mySeq)
-        searchCaller.call(req) { outcome -> handleResponse(mySeq, outcome) }
+        searchCaller.call(req) { outcome -> handleResponse(mySeq, keyword, outcome) }
     }
 
     private fun handleResponse(
         reqSeq: Long,
+        requestKeyword: String,
         outcome: ChannelSearchOutcome<SearchGlobalGroupsResp>,
     ) {
         // 乱序防护 1：本地已发出更新的请求 → 丢弃此响应
         if (reqSeq != nextSequence) return
         // 乱序防护 2：keyword 已被用户清空 → 丢弃
         if (_state.value.keyword.isEmpty()) return
+        // 乱序防护 3：keyword 已变（debounce 窗口内响应到达但用户已改词）→ 丢弃
+        // 场景：setKeyword("foo") → seq=1 在飞；用户改 "bar" → state.keyword 立即更新但
+        // ++nextSequence 要等 debounce 300ms 后 triggerSearch。foo 响应在此窗口回来时，
+        // reqSeq(1)==nextSequence(1) 通过，此处 requestKeyword("foo")!=state.keyword("bar") → 丢弃。
+        if (_state.value.keyword != requestKeyword) return
 
         if (outcome.ok) {
             val body = outcome.data ?: return

--- a/wkuikit/src/main/java/com/chat/uikit/search/remote/GlobalSearchViewModel.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/search/remote/GlobalSearchViewModel.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.search.remote
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chat.base.search.channel.ChannelSearchOutcome
+import com.chat.base.search.channel.uiAction
+import com.chat.base.search.global.SearchGlobalGroupsModel
+import com.chat.base.search.global.dto.GlobalSearchFilters
+import com.chat.base.search.global.dto.GroupBucket
+import com.chat.base.search.global.dto.SearchGlobalGroupsReq
+import com.chat.base.search.global.dto.SearchGlobalGroupsResp
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * 全局搜索"聊天记录聚合"段 (L1 `_search_global_groups`) 的 ViewModel。
+ *
+ * 职责：
+ *  - 输入 keyword 做 300ms debounce，与服务端 5 QPS / 20 burst 限流配合
+ *  - 递增 [sequence] 回带服务端，只渲染最新序号的响应（§4 竞态防护）
+ *  - state 分发 loading / groups / error 三态，UI 层订阅
+ *
+ * 不做本地兜底：`FALLBACK_TO_LOCAL` 语义由 UI 层根据 [State.uiAction] 决定是否
+ * 调用 `WKIM.msgManager.search()` 显示离线结果。ViewModel 保持不依赖 IMSDK，便于纯 JVM 单测。
+ *
+ * 联系人/群段的搜索走独立本地路径，不在此 ViewModel。
+ */
+class GlobalSearchViewModel(
+    /** 注入服务端调用，测试时替换为 fake。 */
+    private val searchCaller: SearchCaller = DefaultSearchCaller,
+    private val debounceMillis: Long = DEBOUNCE_MS,
+) : ViewModel() {
+
+    /** UI 侧观察的完整状态。所有派生数据（分组数量等）都可从此对象取得。 */
+    data class State(
+        val keyword: String = "",
+        val isLoading: Boolean = false,
+        val groups: List<GroupBucket> = emptyList(),
+        val totalGroups: Long = 0L,
+        val totalGroupsApprox: Boolean = true,
+        val hasMore: Boolean = false,
+        /** 服务端结构化错误码；无错误时为 null。 */
+        val errorCode: String? = null,
+        val errorMessage: String? = null,
+        val retryAfterSec: Int = 0,
+        /** 当前渲染中的响应对应的 sequence。0 表示还未发起过请求。 */
+        val sequence: Long = 0L,
+    ) {
+        /** null 时 UI 无需响应；非 null 时按枚举决定 toast / banner / 本地兜底。 */
+        fun uiAction(): com.chat.base.search.channel.ChannelSearchUiAction? =
+            errorCode?.let {
+                ChannelSearchOutcome.failure<Unit>(
+                    httpStatus = 0,
+                    errorCode = it,
+                ).uiAction()
+            }
+    }
+
+    /** ViewModel 内部对服务端的调用抽象，仅为可测试性存在。 */
+    fun interface SearchCaller {
+        fun call(
+            req: SearchGlobalGroupsReq,
+            callback: (ChannelSearchOutcome<SearchGlobalGroupsResp>) -> Unit,
+        )
+    }
+
+    private object DefaultSearchCaller : SearchCaller {
+        override fun call(
+            req: SearchGlobalGroupsReq,
+            callback: (ChannelSearchOutcome<SearchGlobalGroupsResp>) -> Unit,
+        ) {
+            SearchGlobalGroupsModel.searchGroups(req, callback)
+        }
+    }
+
+    private val _state = MutableStateFlow(State())
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    private var debounceJob: Job? = null
+
+    /** 单调递增的请求序号。用于识别乱序响应。 */
+    private var nextSequence: Long = 0L
+
+    /**
+     * 关键词变更入口。空串立即清空结果并取消所有在途 debounce；
+     * 非空串等 [debounceMillis] 之后触发一次搜索。
+     */
+    fun setKeyword(value: String) {
+        if (_state.value.keyword == value) return
+        _state.value = _state.value.copy(keyword = value)
+        debounceJob?.cancel()
+        if (value.isEmpty()) {
+            // 清空回到初始态，但保留 nextSequence 单调性
+            _state.value = State()
+            return
+        }
+        debounceJob = viewModelScope.launch {
+            delay(debounceMillis)
+            triggerSearch(value)
+        }
+    }
+
+    /**
+     * 显式强制触发（用户点击键盘搜索键、外部调用等）。跳过 debounce，
+     * 但仍会取消上一个 debounce job 保持串行。
+     */
+    fun triggerNow() {
+        val keyword = _state.value.keyword
+        if (keyword.isEmpty()) return
+        debounceJob?.cancel()
+        triggerSearch(keyword)
+    }
+
+    /** 释放 debounce job，供 Activity onDestroy 之外的显式清理。 */
+    fun reset() {
+        debounceJob?.cancel()
+        _state.value = State()
+    }
+
+    private fun triggerSearch(keyword: String) {
+        val mySeq = ++nextSequence
+        _state.value = _state.value.copy(
+            isLoading = true,
+            errorCode = null,
+            errorMessage = null,
+            retryAfterSec = 0,
+            sequence = mySeq,
+        )
+        val req = SearchGlobalGroupsReq(keyword = keyword, sequence = mySeq)
+        searchCaller.call(req) { outcome -> handleResponse(mySeq, outcome) }
+    }
+
+    private fun handleResponse(
+        reqSeq: Long,
+        outcome: ChannelSearchOutcome<SearchGlobalGroupsResp>,
+    ) {
+        // 乱序防护 1：本地已发出更新的请求 → 丢弃此响应
+        if (reqSeq != nextSequence) return
+        // 乱序防护 2：keyword 已被用户清空 → 丢弃
+        if (_state.value.keyword.isEmpty()) return
+
+        if (outcome.ok) {
+            val body = outcome.data ?: return
+            val data = body.data
+            // 乱序防护 3：服务端 echo 回的 sequence 与本次请求不匹配（理论上不应发生，防御性检查）
+            if (data.sequence != reqSeq) return
+            _state.value = _state.value.copy(
+                isLoading = false,
+                groups = data.groups,
+                totalGroups = data.total_groups,
+                totalGroupsApprox = data.total_groups_approx,
+                hasMore = body.pagination.has_more,
+                errorCode = null,
+                errorMessage = null,
+                retryAfterSec = 0,
+            )
+        } else {
+            _state.value = _state.value.copy(
+                isLoading = false,
+                groups = emptyList(),
+                totalGroups = 0L,
+                hasMore = false,
+                errorCode = outcome.errorCode,
+                errorMessage = outcome.errorMessage,
+                retryAfterSec = outcome.retryAfterSec,
+            )
+        }
+    }
+
+    override fun onCleared() {
+        debounceJob?.cancel()
+        super.onCleared()
+    }
+
+    companion object {
+        const val DEBOUNCE_MS = 300L
+    }
+}
+
+/** filters 触发门辅助：目前 [GlobalSearchViewModel] 只用 keyword 场景，此处保留兼容占位。 */
+internal fun GlobalSearchFilters?.orEmptyForL1(): GlobalSearchFilters =
+    this ?: GlobalSearchFilters()

--- a/wkuikit/src/main/java/com/chat/uikit/search/remote/drill/GroupDrillActivity.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/search/remote/drill/GroupDrillActivity.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.search.remote.drill
+
+import android.text.Editable
+import android.text.TextUtils
+import android.text.TextWatcher
+import android.view.inputmethod.EditorInfo
+import androidx.activity.viewModels
+import androidx.core.view.ViewCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.chat.base.base.WKBaseActivity
+import com.chat.base.endpoint.EndpointManager
+import com.chat.base.endpoint.EndpointSID
+import com.chat.base.endpoint.entity.ChatViewMenu
+import com.chat.base.search.channel.ChannelSearchUiAction
+import com.chat.base.search.channel.dto.CombinedHit
+import com.chat.base.ui.Theme
+import com.chat.base.utils.SoftKeyboardUtils
+import com.chat.uikit.R
+import com.chat.uikit.databinding.ActGroupDrillLayoutBinding
+import com.scwang.smart.refresh.layout.api.RefreshLayout
+import com.scwang.smart.refresh.layout.listener.OnRefreshLoadMoreListener
+import com.xinbida.wukongim.WKIM
+import kotlinx.coroutines.launch
+
+/**
+ * L2 深度浏览页。从 [com.chat.uikit.search.remote.GlobalActivity] 聊天记录段点某桶进入，
+ * 展示该群/子区/DM 内所有关键词命中（服务端 `_search_global_messages`，
+ * 传群 id 自动展开群+子区）。
+ *
+ * Intent extras:
+ *  - "channel_id" String（必填）
+ *  - "channel_type" Byte（必填）
+ *  - "keyword" String（必填，非空）
+ */
+class GroupDrillActivity : WKBaseActivity<ActGroupDrillLayoutBinding>() {
+
+    private val viewModel: GroupDrillViewModel by viewModels()
+
+    private lateinit var adapter: GroupDrillAdapter
+    private var channelId: String = ""
+    private var channelType: Byte = 0
+
+    // Toast 去重：同一个 errorCode 只弹一次，避免用户下一个按键触发 state 变化时重复打扰。
+    // errorCode 变化（新一轮请求发起清空为 null 后再次出错）会重新弹。
+    private var lastToastedErrorCode: String? = null
+
+    override fun getViewBinding(): ActGroupDrillLayoutBinding =
+        ActGroupDrillLayoutBinding.inflate(layoutInflater)
+
+    override fun initPresenter() {
+        channelId = intent.getStringExtra("channel_id") ?: ""
+        channelType = intent.getByteExtra("channel_type", 0)
+    }
+
+    override fun initView() {
+        Theme.setColorFilter(this, wkVBinding.searchIv, R.color.popupTextColor)
+        ViewCompat.setTransitionName(wkVBinding.searchIv, "searchView")
+        Theme.setPressedBackground(wkVBinding.cancelTv)
+
+        wkVBinding.refreshLayout.setEnableRefresh(false)
+        wkVBinding.refreshLayout.setEnableLoadMore(true)
+
+        adapter = GroupDrillAdapter()
+        initAdapter(wkVBinding.recyclerView, adapter)
+
+        val initialKeyword = intent.getStringExtra("keyword") ?: ""
+        wkVBinding.searchEt.setText(initialKeyword)
+        if (initialKeyword.isNotEmpty()) {
+            wkVBinding.searchEt.setSelection(initialKeyword.length)
+        }
+        // 立即触发首屏搜索（skip debounce）
+        viewModel.init(channelId, channelType, initialKeyword)
+
+        SoftKeyboardUtils.getInstance().showSoftKeyBoard(this, wkVBinding.searchEt)
+        observeState()
+    }
+
+    override fun initListener() {
+        wkVBinding.searchEt.imeOptions = EditorInfo.IME_ACTION_SEARCH
+        wkVBinding.searchEt.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                SoftKeyboardUtils.getInstance().hideSoftKeyboard(this)
+                return@setOnEditorActionListener true
+            }
+            false
+        }
+        wkVBinding.searchEt.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
+            override fun afterTextChanged(s: Editable?) {
+                viewModel.setKeyword(s.toString())
+            }
+        })
+        wkVBinding.refreshLayout.setOnRefreshLoadMoreListener(object : OnRefreshLoadMoreListener {
+            override fun onLoadMore(refreshLayout: RefreshLayout) {
+                viewModel.loadMore()
+            }
+
+            override fun onRefresh(refreshLayout: RefreshLayout) = Unit
+        })
+        wkVBinding.cancelTv.setOnClickListener {
+            SoftKeyboardUtils.getInstance().hideSoftKeyboard(this)
+            finish()
+        }
+        adapter.setOnItemClickListener { _, _, position ->
+            val item = adapter.data.getOrNull(position) ?: return@setOnItemClickListener
+            openHit(item)
+        }
+    }
+
+    /**
+     * 点击命中：跳 ChatActivity 尝试定位到具体消息。
+     *
+     * 本地有 orderSeq → 定位成功；本地无 → ChatActivity 打开但正文空
+     * （已知历史问题，跟本次 L2 无关，追踪见 GlobalActivity 类似分支的 KDoc）。
+     */
+    private fun openHit(item: CombinedHit) {
+        val (hitChannelId, hitChannelType, hitMessageSeq) = when {
+            item.isMessage() && item.message != null -> {
+                val m = item.message!!
+                Triple(m.channel_id, m.channel_type, m.message_seq)
+            }
+            item.isFile() && item.file != null -> {
+                val f = item.file!!
+                Triple(f.channel_id, f.channel_type, f.message_seq)
+            }
+            else -> return
+        }
+        if (hitChannelId.isEmpty()) return
+        val orderSeq = WKIM.getInstance().msgManager.getMessageOrderSeq(
+            hitMessageSeq, hitChannelId, hitChannelType,
+        )
+        EndpointManager.getInstance().invoke(
+            EndpointSID.chatView,
+            ChatViewMenu(this, hitChannelId, hitChannelType, orderSeq, false),
+        )
+    }
+
+    private fun observeState() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.state.collect { state ->
+                    wkVBinding.refreshLayout.finishLoadMore()
+                    wkVBinding.refreshLayout.setEnableLoadMore(state.hasMore)
+
+                    if (state.keyword.isEmpty()) {
+                        adapter.setList(emptyList())
+                        return@collect
+                    }
+                    adapter.setList(state.hits)
+
+                    val action = state.uiAction()
+                    if (action == null) {
+                        // 新请求成功或刚发起时 errorCode 被清空 → 允许下次 toast
+                        lastToastedErrorCode = null
+                    } else if (state.errorCode != lastToastedErrorCode) {
+                        lastToastedErrorCode = state.errorCode
+                        when (action) {
+                            ChannelSearchUiAction.RATE_LIMITED -> {
+                                val msg = if (state.retryAfterSec > 0)
+                                    "请求过于频繁，${state.retryAfterSec}s 后重试"
+                                else "请求过于频繁，请稍后重试"
+                                showToast(msg)
+                            }
+                            ChannelSearchUiAction.FEATURE_DISABLED -> showToast("搜索功能未启用")
+                            ChannelSearchUiAction.FALLBACK_TO_LOCAL -> {
+                                // L2 场景本地几乎不可能有匹配（L1 已经是跨群），仅 toast 提示
+                                showToast("网络异常，请稍后重试")
+                            }
+                            ChannelSearchUiAction.BLOCK_NOT_FOUND,
+                            ChannelSearchUiAction.VALIDATION_ERROR -> Unit
+                            ChannelSearchUiAction.GENERIC_ERROR -> {
+                                showToast(state.errorMessage?.takeIf { it.isNotEmpty() } ?: "搜索失败，请重试")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/search/remote/drill/GroupDrillAdapter.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/search/remote/drill/GroupDrillAdapter.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.search.remote.drill
+
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import com.chad.library.adapter.base.BaseQuickAdapter
+import com.chad.library.adapter.base.viewholder.BaseViewHolder
+import com.chat.base.search.channel.dto.CombinedHit
+import com.chat.base.space.SpaceFilter
+import com.chat.base.ui.components.AvatarView
+import com.chat.base.utils.WKTimeUtils
+import com.chat.uikit.R
+import com.xinbida.wukongim.entity.WKChannelType
+
+/**
+ * L2 深度浏览页 adapter。展示 [CombinedHit] 混合流（message + file 混排，按 sorted_at 倒序）。
+ *
+ * 复用 `item_global_message_layout`：avatar + 顶行 (name+time) + 底行 ([icon]+content)。
+ * MESSAGE 和 FILE 使用同一 layout，通过 result_type 分派内容渲染，无需 multi-item。
+ * - MESSAGE：avatar=会话头像，name=发送者名，content=snippet（服务端 `<mark>` 转紫色前景色）
+ * - FILE：avatar=会话头像，name=文件名，content=大小 · 发送者名，前置文件图标
+ */
+class GroupDrillAdapter :
+    BaseQuickAdapter<CombinedHit, BaseViewHolder>(R.layout.item_global_message_layout) {
+
+    override fun convert(holder: BaseViewHolder, item: CombinedHit) {
+        val avatar = holder.getView<AvatarView>(R.id.avatarView)
+        avatar.setSize(40f)
+        val nameTv = holder.getView<TextView>(R.id.nameTv)
+        val timeTv = holder.getView<TextView>(R.id.timeTv)
+        val contentTv = holder.getView<TextView>(R.id.contentTv)
+        val fileIcon = holder.getView<ImageView>(R.id.fileTagIv)
+
+        if (item.isFile() && item.file != null) {
+            val f = item.file!!
+            showChannelAvatar(avatar, f.channel_id, f.channel_type)
+            nameTv.text = f.file_name
+            timeTv.text = f.sent_at?.let { formatTime(it) } ?: ""
+            fileIcon.visibility = View.VISIBLE
+            val senderName = f.sender_name?.takeIf { it.isNotEmpty() } ?: f.sender_id
+            contentTv.text = "${formatFileSize(f.file_size_bytes)} · $senderName"
+        } else if (item.isMessage() && item.message != null) {
+            val m = item.message!!
+            showChannelAvatar(avatar, m.channel_id, m.channel_type)
+            nameTv.text = m.sender_name?.takeIf { it.isNotEmpty() } ?: m.sender_id
+            timeTv.text = formatTime(m.sent_at)
+            fileIcon.visibility = View.GONE
+            contentTv.text = markToSpannable(m.snippet)
+        }
+    }
+
+    /**
+     * 子区（channel_type=5）channel_id 是 "{parent}____{thread}" 复合结构，
+     * [AvatarView] 无法直接加载；子区在产品上没有独立头像，沿用父群头像。
+     */
+    private fun showChannelAvatar(avatar: AvatarView, channelId: String, channelType: Byte) {
+        if (channelType == WKChannelType.COMMUNITY_TOPIC) {
+            val parent = SpaceFilter.extractParentGroupId(channelId) ?: channelId
+            avatar.showAvatar(parent, WKChannelType.GROUP)
+        } else {
+            avatar.showAvatar(channelId, channelType)
+        }
+    }
+
+    private fun formatTime(rfc3339: String): String {
+        // sorted_at 与 sent_at 都是 RFC3339；WKTimeUtils 需要 ms。这里做简单解析，
+        // 失败则回退到原字符串（不影响功能，仅显示形式）。
+        return try {
+            val ts = java.time.OffsetDateTime.parse(rfc3339).toInstant().toEpochMilli()
+            WKTimeUtils.getInstance().getTimeString(ts)
+        } catch (t: Throwable) {
+            rfc3339
+        }
+    }
+
+    private fun formatFileSize(bytes: Long): String = when {
+        bytes < 1024 -> "$bytes B"
+        bytes < 1024 * 1024 -> "%.1f KB".format(bytes / 1024.0)
+        bytes < 1024L * 1024 * 1024 -> "%.1f MB".format(bytes / (1024.0 * 1024))
+        else -> "%.2f GB".format(bytes / (1024.0 * 1024 * 1024))
+    }
+
+    /** 把服务端 `<mark>` 高亮标记转成前景色 SpannableString，与全局搜索一致的紫色。 */
+    private fun markToSpannable(snippet: String?): CharSequence {
+        if (snippet.isNullOrEmpty()) return ""
+        val marks = mutableListOf<IntRange>()
+        val plain = StringBuilder()
+        var i = 0
+        while (i < snippet.length) {
+            when {
+                snippet.startsWith("<mark>", i) -> {
+                    val end = snippet.indexOf("</mark>", i + 6)
+                    if (end < 0) {
+                        plain.append(snippet, i, snippet.length)
+                        break
+                    }
+                    val start = plain.length
+                    plain.append(snippet, i + 6, end)
+                    marks += start until plain.length
+                    i = end + 7
+                }
+                else -> {
+                    plain.append(snippet[i])
+                    i++
+                }
+            }
+        }
+        val sp = SpannableString(plain.toString())
+        for (r in marks) {
+            sp.setSpan(
+                ForegroundColorSpan(HIGHLIGHT_COLOR),
+                r.first, r.last + 1,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
+        }
+        return sp
+    }
+
+    companion object {
+        private const val HIGHLIGHT_COLOR = 0xFF7761F4.toInt()
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/search/remote/drill/GroupDrillAdapter.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/search/remote/drill/GroupDrillAdapter.kt
@@ -24,6 +24,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import com.chad.library.adapter.base.BaseQuickAdapter
 import com.chad.library.adapter.base.viewholder.BaseViewHolder
+import com.chat.base.search.channel.Rfc3339
 import com.chat.base.search.channel.dto.CombinedHit
 import com.chat.base.space.SpaceFilter
 import com.chat.base.ui.components.AvatarView
@@ -82,14 +83,10 @@ class GroupDrillAdapter :
     }
 
     private fun formatTime(rfc3339: String): String {
-        // sorted_at 与 sent_at 都是 RFC3339；WKTimeUtils 需要 ms。这里做简单解析，
-        // 失败则回退到原字符串（不影响功能，仅显示形式）。
-        return try {
-            val ts = java.time.OffsetDateTime.parse(rfc3339).toInstant().toEpochMilli()
-            WKTimeUtils.getInstance().getTimeString(ts)
-        } catch (t: Throwable) {
-            rfc3339
-        }
+        // 项目 minSdk=23 未开 coreLibraryDesugaring，禁用 java.time；用现有 Rfc3339 helper。
+        // 解析失败返回 0，此时显示为空串，UI 上表现为无时间（可接受）。
+        val seconds = Rfc3339.toEpochSeconds(rfc3339)
+        return if (seconds > 0L) WKTimeUtils.getInstance().getTimeString(seconds * 1000L) else ""
     }
 
     private fun formatFileSize(bytes: Long): String = when {

--- a/wkuikit/src/main/java/com/chat/uikit/search/remote/drill/GroupDrillViewModel.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/search/remote/drill/GroupDrillViewModel.kt
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.search.remote.drill
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chat.base.search.channel.ChannelSearchOutcome
+import com.chat.base.search.channel.ChannelSearchUiAction
+import com.chat.base.search.channel.dto.CombinedHit
+import com.chat.base.search.channel.dto.CursorList
+import com.chat.base.search.channel.uiAction
+import com.chat.base.search.global.SearchGlobalMessagesModel
+import com.chat.base.search.global.dto.GlobalChannelRef
+import com.chat.base.search.global.dto.GlobalSearchFilters
+import com.chat.base.search.global.dto.SearchGlobalMessagesReq
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * L2 深度浏览页 ViewModel。对应 `POST /v1/messages/_search_global_messages`。
+ *
+ * 职责：
+ *  - 关键词输入 300ms debounce
+ *  - 递增 [nextSequence] 用于新查询乱序防护（reset 递增；loadMore 不递增）
+ *  - cursor 分页：首屏用 null cursor，翻页用 [State.nextCursor]
+ *  - state 分发 loading / hits / hasMore / error 供 UI 订阅
+ *
+ * 服务端契约（详见 `04-aggregation-api-spec.md` §3）：
+ *  - 传群 channel_id（type=2）自动展开群+子区所有可见命中
+ *  - 传子区 channel_id（type=5）只搜该子区
+ *  - 传 DM peer uid（type=1）搜该 DM
+ *  - 返回 SearchAllHit 混排（message + file）+ 独立 cursor
+ *
+ * 不做本地兜底：`FALLBACK_TO_LOCAL` 场景由 UI 层根据 [State.uiAction] 决定
+ * （L2 场景下本地几乎必空，一般也只能空态提示）。
+ */
+class GroupDrillViewModel(
+    private val searchCaller: SearchCaller = DefaultSearchCaller,
+    private val debounceMillis: Long = DEBOUNCE_MS,
+) : ViewModel() {
+
+    /** UI 订阅的完整状态。 */
+    data class State(
+        val keyword: String = "",
+        /** 首屏加载中（keyword 变化触发的重置查询）。 */
+        val isLoading: Boolean = false,
+        /** 分页加载中。 */
+        val isLoadingMore: Boolean = false,
+        val hits: List<CombinedHit> = emptyList(),
+        val hasMore: Boolean = false,
+        val nextCursor: String? = null,
+        val errorCode: String? = null,
+        val errorMessage: String? = null,
+        val retryAfterSec: Int = 0,
+        val sequence: Long = 0L,
+    ) {
+        /** null 时 UI 无需响应；非 null 时按枚举决定 toast / banner / 兜底。 */
+        fun uiAction(): ChannelSearchUiAction? =
+            errorCode?.let {
+                ChannelSearchOutcome.failure<Unit>(
+                    httpStatus = 0,
+                    errorCode = it,
+                ).uiAction()
+            }
+    }
+
+    fun interface SearchCaller {
+        fun call(
+            req: SearchGlobalMessagesReq,
+            callback: (ChannelSearchOutcome<CursorList<CombinedHit>>) -> Unit,
+        )
+    }
+
+    private object DefaultSearchCaller : SearchCaller {
+        override fun call(
+            req: SearchGlobalMessagesReq,
+            callback: (ChannelSearchOutcome<CursorList<CombinedHit>>) -> Unit,
+        ) {
+            SearchGlobalMessagesModel.searchMessages(req, callback)
+        }
+    }
+
+    private val _state = MutableStateFlow(State())
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    private var debounceJob: Job? = null
+
+    /** 单调递增的请求序号；只在 reset（新 keyword）时递增，loadMore 复用当前序号。 */
+    private var nextSequence: Long = 0L
+
+    /** 目标 channel（来自 GlobalActivity 的桶点击）。init 后不变。 */
+    private var targetChannel: GlobalChannelRef? = null
+
+    /**
+     * Activity onCreate 时调用一次。触发首屏搜索（若 [initialKeyword] 非空）。
+     */
+    fun init(channelId: String, channelType: Byte, initialKeyword: String) {
+        targetChannel = GlobalChannelRef(channelId, channelType)
+        if (initialKeyword.isEmpty()) {
+            _state.value = State(keyword = "")
+            return
+        }
+        _state.value = State(keyword = initialKeyword)
+        // 立即触发首屏（跳过 debounce），保证从 L1 点进来无空窗
+        triggerSearch(initialKeyword, cursor = null, isReset = true)
+    }
+
+    /** 关键词变更；300ms debounce 后触发新查询，重置 cursor + hits。 */
+    fun setKeyword(value: String) {
+        if (_state.value.keyword == value) return
+        _state.value = _state.value.copy(keyword = value)
+        debounceJob?.cancel()
+        if (value.isEmpty()) {
+            _state.value = State(keyword = "")
+            return
+        }
+        debounceJob = viewModelScope.launch {
+            delay(debounceMillis)
+            triggerSearch(value, cursor = null, isReset = true)
+        }
+    }
+
+    /** 上滑触底加载更多。有 hasMore 且非 loading 时才执行。 */
+    fun loadMore() {
+        val s = _state.value
+        if (!s.hasMore || s.isLoading || s.isLoadingMore || s.keyword.isEmpty()) return
+        val cursor = s.nextCursor ?: return
+        triggerSearch(s.keyword, cursor = cursor, isReset = false)
+    }
+
+    fun reset() {
+        debounceJob?.cancel()
+        _state.value = State()
+    }
+
+    private fun triggerSearch(keyword: String, cursor: String?, isReset: Boolean) {
+        val target = targetChannel ?: return
+        val seq = if (isReset) ++nextSequence else nextSequence
+        _state.value = _state.value.copy(
+            isLoading = isReset,
+            isLoadingMore = !isReset,
+            errorCode = null,
+            errorMessage = null,
+            retryAfterSec = 0,
+            sequence = seq,
+        )
+        val req = SearchGlobalMessagesReq(
+            keyword = keyword,
+            filters = GlobalSearchFilters(channelIds = listOf(target)),
+            sort = SearchGlobalMessagesReq.SORT_TIME_DESC,
+            pageSize = PAGE_SIZE,
+            cursor = cursor,
+            sequence = seq,
+        )
+        searchCaller.call(req) { outcome -> handleResponse(seq, isReset, outcome) }
+    }
+
+    private fun handleResponse(
+        reqSeq: Long,
+        isReset: Boolean,
+        outcome: ChannelSearchOutcome<CursorList<CombinedHit>>,
+    ) {
+        // 乱序防护：本地已发出更新的请求 → 丢弃此响应（reset 递增 sequence 会覆盖 loadMore）
+        if (reqSeq != nextSequence) return
+        // keyword 已被清空 → 丢弃迟到响应
+        if (_state.value.keyword.isEmpty()) return
+
+        if (outcome.ok) {
+            val body = outcome.data ?: return
+            val newHits = if (isReset) body.data else _state.value.hits + body.data
+            _state.value = _state.value.copy(
+                isLoading = false,
+                isLoadingMore = false,
+                hits = newHits,
+                hasMore = body.pagination.has_more,
+                nextCursor = body.pagination.next_cursor.takeIf { it.isNotEmpty() },
+                errorCode = null,
+                errorMessage = null,
+                retryAfterSec = 0,
+            )
+        } else {
+            // 失败：reset 场景清空 hits；loadMore 场景保留已加载的
+            _state.value = _state.value.copy(
+                isLoading = false,
+                isLoadingMore = false,
+                hits = if (isReset) emptyList() else _state.value.hits,
+                hasMore = if (isReset) false else _state.value.hasMore,
+                errorCode = outcome.errorCode,
+                errorMessage = outcome.errorMessage,
+                retryAfterSec = outcome.retryAfterSec,
+            )
+        }
+    }
+
+    override fun onCleared() {
+        debounceJob?.cancel()
+        super.onCleared()
+    }
+
+    companion object {
+        const val DEBOUNCE_MS = 300L
+        const val PAGE_SIZE = 20
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/search/remote/drill/GroupDrillViewModel.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/search/remote/drill/GroupDrillViewModel.kt
@@ -170,11 +170,12 @@ class GroupDrillViewModel(
             cursor = cursor,
             sequence = seq,
         )
-        searchCaller.call(req) { outcome -> handleResponse(seq, isReset, outcome) }
+        searchCaller.call(req) { outcome -> handleResponse(seq, keyword, isReset, outcome) }
     }
 
     private fun handleResponse(
         reqSeq: Long,
+        requestKeyword: String,
         isReset: Boolean,
         outcome: ChannelSearchOutcome<CursorList<CombinedHit>>,
     ) {
@@ -182,6 +183,8 @@ class GroupDrillViewModel(
         if (reqSeq != nextSequence) return
         // keyword 已被清空 → 丢弃迟到响应
         if (_state.value.keyword.isEmpty()) return
+        // keyword 已变（debounce 窗口 / loadMore 在飞时用户改词）→ 丢弃，避免用旧词结果污染新词状态
+        if (_state.value.keyword != requestKeyword) return
 
         if (outcome.ok) {
             val body = outcome.data ?: return

--- a/wkuikit/src/main/res/layout/act_group_drill_layout.xml
+++ b/wkuikit/src/main/res/layout/act_group_drill_layout.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/homeColor"
+    android:fitsSystemWindows="true"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:id="@+id/searchLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@drawable/radian_normal_layout"
+            android:fitsSystemWindows="true">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/searchIv"
+                android:layout_width="25dp"
+                android:layout_height="25dp"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="15dp"
+                android:layout_marginEnd="5dp"
+                android:src="@mipmap/ic_ab_search" />
+
+            <androidx.appcompat.widget.AppCompatEditText
+                android:id="@+id/searchEt"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginEnd="10dp"
+                android:background="@color/transparent"
+                android:focusable="true"
+                android:gravity="center_vertical"
+                android:hint="@string/str_search"
+                android:imeOptions="actionSearch"
+                android:maxLines="1"
+                android:minHeight="40dp"
+                android:singleLine="true"
+                android:textColor="@color/colorDark"
+                android:textColorHint="@color/color999"
+                android:textSize="14sp" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/cancelTv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:padding="10dp"
+            android:text="@string/cancel"
+            android:textColor="@color/popupTextColor"
+            android:textSize="16sp" />
+    </LinearLayout>
+
+    <com.scwang.smart.refresh.layout.SmartRefreshLayout
+        android:id="@+id/refreshLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/transparent"
+        app:srlEnableFooterFollowWhenLoadFinished="true"
+        app:srlEnableScrollContentWhenLoaded="true">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/transparent" />
+
+        <com.scwang.smart.refresh.footer.ClassicsFooter
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/homeColor"
+            app:srlTextNothing="@string/refresh_footer" />
+    </com.scwang.smart.refresh.layout.SmartRefreshLayout>
+</LinearLayout>

--- a/wkuikit/src/test/java/com/chat/uikit/search/remote/GlobalSearchViewModelTest.kt
+++ b/wkuikit/src/test/java/com/chat/uikit/search/remote/GlobalSearchViewModelTest.kt
@@ -362,4 +362,42 @@ class GlobalSearchViewModelTest {
         advanceUntilIdle()
         assertTrue("keyword 已清空时迟到响应应丢弃", vm.state.value.groups.isEmpty())
     }
+
+    @Test
+    fun `response arriving in debounce window with mismatched keyword is discarded`() = runTest {
+        // 回归测试 PR #95 review 阻塞级 (Jerry-Xin)：debounce 窗口 stale response。
+        // 场景：seq=1 (foo) 已发出 → 用户改 "bar" (state.keyword 立即更新但 nextSequence
+        // 还没递增，要等 debounce 触发) → foo 响应此刻回来 → reqSeq(1)==nextSequence(1)
+        // 通过 + keyword("bar") 非空 → 旧 requestKeyword 检查是唯一防线，否则 foo 结果
+        // 会被渲染成 bar 的结果，用户点桶还会带 bar 打开 L2。
+        val caller = RecordingCaller()
+        val vm = GlobalSearchViewModel(caller, debounceMillis = 300L)
+
+        vm.setKeyword("foo"); tick(300L)       // seq=1 pending (foo)
+        assertEquals(1, caller.pending.size)
+
+        vm.setKeyword("bar")                    // state.keyword 立即变 bar；debounce 未触发
+        assertEquals("nextSequence 未递增，仍是 1", 1, caller.pending.size)
+        assertEquals("bar", vm.state.value.keyword)
+
+        // foo 响应在此窗口到达 —— 应该被 requestKeyword 检查丢弃
+        caller.completeAt(0, resp(seq = 1L, groups = listOf(bucket("g_foo_stale"))))
+        advanceUntilIdle()
+        assertTrue(
+            "debounce 窗口内旧 keyword 的响应必须丢弃，不能污染新 keyword state",
+            vm.state.value.groups.isEmpty(),
+        )
+        assertEquals("bar", vm.state.value.keyword)
+
+        // debounce 触发 bar 的新请求
+        tick(300L)
+        assertEquals(2, caller.pending.size)
+        assertEquals("bar", caller.pending[1].req.keyword)
+        assertEquals(2L, caller.pending[1].req.sequence)
+
+        caller.completeAt(1, resp(seq = 2L, groups = listOf(bucket("g_bar"))))
+        advanceUntilIdle()
+        assertEquals(1, vm.state.value.groups.size)
+        assertEquals("g_bar", vm.state.value.groups[0].channel_id)
+    }
 }

--- a/wkuikit/src/test/java/com/chat/uikit/search/remote/GlobalSearchViewModelTest.kt
+++ b/wkuikit/src/test/java/com/chat/uikit/search/remote/GlobalSearchViewModelTest.kt
@@ -1,0 +1,365 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.search.remote
+
+import com.chat.base.search.channel.ChannelSearchOutcome
+import com.chat.base.search.channel.ChannelSearchUiAction
+import com.chat.base.search.channel.dto.Pagination
+import com.chat.base.search.channel.dto.SearchErrorCode
+import com.chat.base.search.global.dto.GroupBucket
+import com.chat.base.search.global.dto.GroupsResult
+import com.chat.base.search.global.dto.SearchGlobalGroupsReq
+import com.chat.base.search.global.dto.SearchGlobalGroupsResp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * StandardTestDispatcher 语义：
+ *  - `advanceTimeBy(N)` 只推进虚拟时间，不执行到期任务；到期任务需 `runCurrent()` 显式 dispatch。
+ *  - `advanceUntilIdle()` = 推进 + 反复执行直到无任务。
+ * 本文用 [tick] 封装 "advance + runCurrent" 组合，语义等同"等待 debounce 到期"。
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class GlobalSearchViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun TestScope.tick(ms: Long) {
+        advanceTimeBy(ms)
+        runCurrent()
+    }
+
+    private class RecordingCaller : GlobalSearchViewModel.SearchCaller {
+        data class Pending(
+            val req: SearchGlobalGroupsReq,
+            val callback: (ChannelSearchOutcome<SearchGlobalGroupsResp>) -> Unit,
+        )
+
+        val pending = mutableListOf<Pending>()
+
+        override fun call(
+            req: SearchGlobalGroupsReq,
+            callback: (ChannelSearchOutcome<SearchGlobalGroupsResp>) -> Unit,
+        ) {
+            pending += Pending(req, callback)
+        }
+
+        fun completeAt(index: Int, resp: SearchGlobalGroupsResp) {
+            pending[index].callback(ChannelSearchOutcome.success(resp))
+        }
+
+        fun failAt(
+            index: Int,
+            errorCode: String,
+            httpStatus: Int = 500,
+            retryAfterSec: Int = 0,
+        ) {
+            pending[index].callback(
+                ChannelSearchOutcome.failure(
+                    httpStatus = httpStatus,
+                    errorCode = errorCode,
+                    retryAfterSec = retryAfterSec,
+                ),
+            )
+        }
+    }
+
+    private fun resp(
+        seq: Long,
+        groups: List<GroupBucket> = emptyList(),
+        hasMore: Boolean = false,
+    ): SearchGlobalGroupsResp {
+        val r = SearchGlobalGroupsResp()
+        r.data = GroupsResult().apply {
+            sequence = seq
+            query_id = "q$seq"
+            total_groups = groups.size.toLong()
+            total_groups_approx = true
+            this.groups = groups
+        }
+        r.pagination = Pagination().apply {
+            has_more = hasMore
+            next_cursor = ""
+        }
+        return r
+    }
+
+    private fun bucket(channelId: String, matchCount: Long = 1L): GroupBucket =
+        GroupBucket().apply {
+            channel_id = channelId
+            channel_type = 2
+            group_name = "grp-$channelId"
+            match_count = matchCount
+            match_count_approx = true
+            latest_at = "2026-07-14T10:00:00+08:00"
+        }
+
+    @Test
+    fun `initial state is empty`() = runTest {
+        val vm = GlobalSearchViewModel(RecordingCaller())
+        val s = vm.state.value
+        assertEquals("", s.keyword)
+        assertFalse(s.isLoading)
+        assertTrue(s.groups.isEmpty())
+        assertNull(s.errorCode)
+        assertEquals(0L, s.sequence)
+    }
+
+    @Test
+    fun `keyword change triggers request only after debounce`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GlobalSearchViewModel(caller, debounceMillis = 300L)
+
+        vm.setKeyword("hello")
+        assertEquals("hello", vm.state.value.keyword)
+        assertTrue("debounce 未过前不应触发请求", caller.pending.isEmpty())
+
+        tick(299L)
+        assertTrue("到 299ms 时仍不应触发", caller.pending.isEmpty())
+
+        tick(1L)
+        assertEquals("到 300ms 应触发一次", 1, caller.pending.size)
+        assertEquals("hello", caller.pending[0].req.keyword)
+        assertEquals(1L, caller.pending[0].req.sequence)
+    }
+
+    @Test
+    fun `rapid keyword changes cancel earlier debounce and only send latest`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GlobalSearchViewModel(caller, debounceMillis = 300L)
+
+        vm.setKeyword("h"); tick(100L)
+        vm.setKeyword("he"); tick(100L)
+        vm.setKeyword("hel"); tick(100L)
+        vm.setKeyword("hell"); tick(100L)
+        vm.setKeyword("hello"); tick(299L)
+        assertTrue(caller.pending.isEmpty())
+        tick(1L)
+        assertEquals("多次快速输入只应触发最后一次", 1, caller.pending.size)
+        assertEquals("hello", caller.pending[0].req.keyword)
+    }
+
+    @Test
+    fun `empty keyword clears state and cancels pending debounce`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GlobalSearchViewModel(caller, debounceMillis = 300L)
+
+        vm.setKeyword("hello"); tick(300L)
+        caller.completeAt(0, resp(seq = 1L, groups = listOf(bucket("g1"))))
+        advanceUntilIdle()
+        assertEquals(1, vm.state.value.groups.size)
+
+        vm.setKeyword("")
+        assertEquals("", vm.state.value.keyword)
+        assertTrue("清空 keyword 后 groups 应清空", vm.state.value.groups.isEmpty())
+        assertFalse(vm.state.value.isLoading)
+
+        // 后续再快速输入然后立刻清空，都不应再触发
+        vm.setKeyword("x")
+        vm.setKeyword("")
+        tick(500L)
+        assertEquals("清空后无新输入不应发请求", 1, caller.pending.size)
+    }
+
+    @Test
+    fun `sequence increments per triggered request and echoes back`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GlobalSearchViewModel(caller, debounceMillis = 300L)
+
+        vm.setKeyword("a"); tick(300L)
+        assertEquals(1L, caller.pending[0].req.sequence)
+
+        caller.completeAt(0, resp(seq = 1L))
+        advanceUntilIdle()
+
+        vm.setKeyword("ab"); tick(300L)
+        assertEquals(2L, caller.pending[1].req.sequence)
+    }
+
+    @Test
+    fun `stale response with older sequence is discarded`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GlobalSearchViewModel(caller, debounceMillis = 300L)
+
+        vm.setKeyword("a"); tick(300L)
+        vm.setKeyword("ab"); tick(300L)
+
+        // 服务端先返回 seq=2（新），再返回 seq=1（旧）
+        caller.completeAt(1, resp(seq = 2L, groups = listOf(bucket("g_new"))))
+        advanceUntilIdle()
+        assertEquals(listOf("g_new"), vm.state.value.groups.map { it.channel_id })
+
+        caller.completeAt(0, resp(seq = 1L, groups = listOf(bucket("g_old"))))
+        advanceUntilIdle()
+        assertEquals(
+            "过期响应必须丢弃，state 保持最新",
+            listOf("g_new"),
+            vm.state.value.groups.map { it.channel_id },
+        )
+    }
+
+    @Test
+    fun `response with mismatched echo sequence is discarded`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GlobalSearchViewModel(caller, debounceMillis = 300L)
+
+        vm.setKeyword("hello"); tick(300L)
+        // 请求 seq=1，但服务端 echo 回 seq=99（防御性检查）
+        caller.completeAt(0, resp(seq = 99L, groups = listOf(bucket("bogus"))))
+        advanceUntilIdle()
+        assertTrue("echo 不匹配的响应必须丢弃", vm.state.value.groups.isEmpty())
+    }
+
+    @Test
+    fun `success response populates groups and pagination`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GlobalSearchViewModel(caller, debounceMillis = 300L)
+
+        vm.setKeyword("hello"); tick(300L)
+        assertTrue(vm.state.value.isLoading)
+
+        caller.completeAt(
+            0,
+            resp(
+                seq = 1L,
+                groups = listOf(bucket("g1", 12), bucket("g2", 3)),
+                hasMore = true,
+            ),
+        )
+        advanceUntilIdle()
+
+        val s = vm.state.value
+        assertFalse(s.isLoading)
+        assertEquals(2, s.groups.size)
+        assertEquals("g1", s.groups[0].channel_id)
+        assertEquals(2L, s.totalGroups)
+        assertTrue(s.totalGroupsApprox)
+        assertTrue(s.hasMore)
+        assertNull(s.errorCode)
+    }
+
+    @Test
+    fun `failure sets errorCode and clears groups`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GlobalSearchViewModel(caller, debounceMillis = 300L)
+
+        vm.setKeyword("hello"); tick(300L)
+        caller.completeAt(0, resp(seq = 1L, groups = listOf(bucket("g1"))))
+        advanceUntilIdle()
+        assertEquals(1, vm.state.value.groups.size)
+
+        vm.setKeyword("world"); tick(300L)
+        caller.failAt(1, errorCode = SearchErrorCode.UPSTREAM_UNAVAILABLE, httpStatus = 503)
+        advanceUntilIdle()
+
+        val s = vm.state.value
+        assertFalse(s.isLoading)
+        assertTrue("失败后 groups 应清空", s.groups.isEmpty())
+        assertEquals(SearchErrorCode.UPSTREAM_UNAVAILABLE, s.errorCode)
+        assertEquals(ChannelSearchUiAction.FALLBACK_TO_LOCAL, s.uiAction())
+    }
+
+    @Test
+    fun `rate limited failure carries retry_after`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GlobalSearchViewModel(caller, debounceMillis = 300L)
+
+        vm.setKeyword("hello"); tick(300L)
+        caller.failAt(
+            0,
+            errorCode = SearchErrorCode.RATE_LIMITED,
+            httpStatus = 429,
+            retryAfterSec = 5,
+        )
+        advanceUntilIdle()
+
+        val s = vm.state.value
+        assertEquals(SearchErrorCode.RATE_LIMITED, s.errorCode)
+        assertEquals(5, s.retryAfterSec)
+        assertEquals(ChannelSearchUiAction.RATE_LIMITED, s.uiAction())
+    }
+
+    @Test
+    fun `triggerNow skips debounce`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GlobalSearchViewModel(caller, debounceMillis = 300L)
+
+        vm.setKeyword("hello")
+        vm.triggerNow()
+        advanceUntilIdle()
+        assertEquals(1, caller.pending.size)
+        assertEquals("hello", caller.pending[0].req.keyword)
+    }
+
+    @Test
+    fun `triggerNow no-op when keyword empty`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GlobalSearchViewModel(caller, debounceMillis = 300L)
+        vm.triggerNow()
+        advanceUntilIdle()
+        assertTrue(caller.pending.isEmpty())
+    }
+
+    @Test
+    fun `reset cancels debounce and clears state`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GlobalSearchViewModel(caller, debounceMillis = 300L)
+
+        vm.setKeyword("hello")
+        vm.reset()
+        assertEquals("", vm.state.value.keyword)
+        tick(500L)
+        assertTrue("reset 后原 debounce 不应触发", caller.pending.isEmpty())
+    }
+
+    @Test
+    fun `response after keyword cleared is discarded`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GlobalSearchViewModel(caller, debounceMillis = 300L)
+
+        vm.setKeyword("hello"); tick(300L)   // seq=1 pending
+        vm.setKeyword("")                    // 用户清空
+        caller.completeAt(0, resp(seq = 1L, groups = listOf(bucket("g_late"))))
+        advanceUntilIdle()
+        assertTrue("keyword 已清空时迟到响应应丢弃", vm.state.value.groups.isEmpty())
+    }
+}

--- a/wkuikit/src/test/java/com/chat/uikit/search/remote/drill/GroupDrillViewModelTest.kt
+++ b/wkuikit/src/test/java/com/chat/uikit/search/remote/drill/GroupDrillViewModelTest.kt
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.search.remote.drill
+
+import com.chat.base.search.channel.ChannelSearchOutcome
+import com.chat.base.search.channel.ChannelSearchUiAction
+import com.chat.base.search.channel.dto.CombinedHit
+import com.chat.base.search.channel.dto.CursorList
+import com.chat.base.search.channel.dto.FileHit
+import com.chat.base.search.channel.dto.MessageHit
+import com.chat.base.search.channel.dto.Pagination
+import com.chat.base.search.channel.dto.SearchErrorCode
+import com.chat.base.search.global.dto.SearchGlobalMessagesReq
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GroupDrillViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun TestScope.tick(ms: Long) {
+        advanceTimeBy(ms)
+        runCurrent()
+    }
+
+    private class RecordingCaller : GroupDrillViewModel.SearchCaller {
+        data class Pending(
+            val req: SearchGlobalMessagesReq,
+            val callback: (ChannelSearchOutcome<CursorList<CombinedHit>>) -> Unit,
+        )
+
+        val pending = mutableListOf<Pending>()
+
+        override fun call(
+            req: SearchGlobalMessagesReq,
+            callback: (ChannelSearchOutcome<CursorList<CombinedHit>>) -> Unit,
+        ) {
+            pending += Pending(req, callback)
+        }
+
+        fun completeAt(index: Int, resp: CursorList<CombinedHit>) {
+            pending[index].callback(ChannelSearchOutcome.success(resp))
+        }
+
+        fun failAt(index: Int, code: String, httpStatus: Int = 500, retryAfterSec: Int = 0) {
+            pending[index].callback(
+                ChannelSearchOutcome.failure(
+                    httpStatus = httpStatus,
+                    errorCode = code,
+                    retryAfterSec = retryAfterSec,
+                ),
+            )
+        }
+    }
+
+    private fun messageHit(id: String): CombinedHit {
+        val m = MessageHit().apply {
+            message_id = id
+            message_seq = 1L
+            message_kind = "text"
+            snippet = "s"
+            sender_id = "u1"
+            sent_at = "2026-07-01T00:00:00Z"
+            channel_id = "g_xxx"
+            channel_type = 2
+        }
+        return CombinedHit().apply {
+            result_type = CombinedHit.TYPE_MESSAGE
+            sorted_at = "2026-07-01T00:00:00Z"
+            message = m
+        }
+    }
+
+    private fun fileHit(id: String): CombinedHit {
+        val f = FileHit().apply {
+            message_id = id
+            message_seq = 1L
+            file_name = "$id.pdf"
+            file_ext = "pdf"
+            sender_id = "u1"
+            sent_at = "2026-07-01T00:00:00Z"
+            channel_id = "g_xxx"
+            channel_type = 2
+        }
+        return CombinedHit().apply {
+            result_type = CombinedHit.TYPE_FILE
+            sorted_at = "2026-07-01T00:00:00Z"
+            file = f
+        }
+    }
+
+    private fun resp(
+        hits: List<CombinedHit>,
+        hasMore: Boolean = false,
+        nextCursor: String = "",
+    ): CursorList<CombinedHit> {
+        val cursor = CursorList<CombinedHit>()
+        cursor.data = hits
+        cursor.pagination = Pagination().apply {
+            has_more = hasMore
+            next_cursor = nextCursor
+        }
+        return cursor
+    }
+
+    @Test
+    fun `init with keyword triggers immediate first page (skip debounce)`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GroupDrillViewModel(caller, debounceMillis = 300L)
+
+        vm.init(channelId = "g_xxx", channelType = 2, initialKeyword = "hello")
+        advanceUntilIdle()
+        assertEquals("init 应立即触发首屏", 1, caller.pending.size)
+        assertEquals("hello", caller.pending[0].req.keyword)
+        assertEquals(1L, caller.pending[0].req.sequence)
+        assertNull("首屏 cursor 应为 null", caller.pending[0].req.cursor)
+
+        val body = caller.pending[0].req.filters.channelIds!![0]
+        assertEquals("g_xxx", body.channelId)
+        assertEquals(2, body.channelType.toInt())
+    }
+
+    @Test
+    fun `init with empty keyword does not fire`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GroupDrillViewModel(caller)
+        vm.init("g_xxx", 2, "")
+        advanceUntilIdle()
+        assertTrue(caller.pending.isEmpty())
+        assertEquals("", vm.state.value.keyword)
+    }
+
+    @Test
+    fun `success response replaces hits and stores cursor`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GroupDrillViewModel(caller)
+        vm.init("g_xxx", 2, "hello")
+
+        caller.completeAt(0, resp(listOf(messageHit("m1"), fileHit("f1")), hasMore = true, nextCursor = "cur1"))
+        advanceUntilIdle()
+
+        val s = vm.state.value
+        assertFalse(s.isLoading)
+        assertEquals(2, s.hits.size)
+        assertTrue(s.hasMore)
+        assertEquals("cur1", s.nextCursor)
+        assertNull(s.errorCode)
+    }
+
+    @Test
+    fun `loadMore appends hits and reuses sequence`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GroupDrillViewModel(caller)
+        vm.init("g_xxx", 2, "hello")
+
+        caller.completeAt(0, resp(listOf(messageHit("m1")), hasMore = true, nextCursor = "cur1"))
+        advanceUntilIdle()
+
+        vm.loadMore()
+        advanceUntilIdle()
+        assertEquals(2, caller.pending.size)
+        assertEquals("loadMore 应复用 sequence，不递增", 1L, caller.pending[1].req.sequence)
+        assertEquals("cur1", caller.pending[1].req.cursor)
+
+        caller.completeAt(1, resp(listOf(messageHit("m2"), messageHit("m3")), hasMore = false, nextCursor = ""))
+        advanceUntilIdle()
+
+        val s = vm.state.value
+        assertEquals("loadMore 应追加而不是替换", 3, s.hits.size)
+        assertFalse(s.hasMore)
+        assertNull(s.nextCursor)
+    }
+
+    @Test
+    fun `loadMore skipped when hasMore false`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GroupDrillViewModel(caller)
+        vm.init("g_xxx", 2, "hello")
+        caller.completeAt(0, resp(listOf(messageHit("m1")), hasMore = false))
+        advanceUntilIdle()
+
+        vm.loadMore()
+        advanceUntilIdle()
+        assertEquals("hasMore=false 时 loadMore 应 no-op", 1, caller.pending.size)
+    }
+
+    @Test
+    fun `keyword change resets cursor and increments sequence`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GroupDrillViewModel(caller, debounceMillis = 300L)
+        vm.init("g_xxx", 2, "hello")
+        caller.completeAt(0, resp(listOf(messageHit("m1")), hasMore = true, nextCursor = "cur1"))
+        advanceUntilIdle()
+
+        vm.setKeyword("world"); tick(300L)
+        assertEquals(2, caller.pending.size)
+        assertEquals("新 keyword 应递增 sequence", 2L, caller.pending[1].req.sequence)
+        assertNull("新 keyword 应重置 cursor", caller.pending[1].req.cursor)
+    }
+
+    @Test
+    fun `stale loadMore response after keyword change is discarded`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GroupDrillViewModel(caller, debounceMillis = 300L)
+        vm.init("g_xxx", 2, "hello")
+        caller.completeAt(0, resp(listOf(messageHit("m1")), hasMore = true, nextCursor = "cur1"))
+        advanceUntilIdle()
+
+        vm.loadMore()                            // seq=1 pending (loadMore)
+        assertEquals(2, caller.pending.size)
+
+        vm.setKeyword("world"); tick(300L)       // seq=2 pending (new search)
+        assertEquals(3, caller.pending.size)
+
+        // 迟到的 loadMore (seq=1) 到达 → 必须丢弃
+        caller.completeAt(1, resp(listOf(messageHit("m_stale"))))
+        advanceUntilIdle()
+        assertFalse(
+            "过期 loadMore 响应不应污染新 keyword 的 state",
+            vm.state.value.hits.any { it.message?.message_id == "m_stale" },
+        )
+
+        // 新的 reset (seq=2) 响应
+        caller.completeAt(2, resp(listOf(messageHit("m_new"))))
+        advanceUntilIdle()
+        assertEquals(1, vm.state.value.hits.size)
+        assertEquals("m_new", vm.state.value.hits[0].message?.message_id)
+    }
+
+    @Test
+    fun `empty keyword clears state and cancels debounce`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GroupDrillViewModel(caller, debounceMillis = 300L)
+        vm.init("g_xxx", 2, "hello")
+        caller.completeAt(0, resp(listOf(messageHit("m1"))))
+        advanceUntilIdle()
+        assertEquals(1, vm.state.value.hits.size)
+
+        vm.setKeyword("")
+        assertTrue(vm.state.value.hits.isEmpty())
+        assertEquals("", vm.state.value.keyword)
+    }
+
+    @Test
+    fun `reset request failure clears hits`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GroupDrillViewModel(caller, debounceMillis = 300L)
+        vm.init("g_xxx", 2, "hello")
+        caller.completeAt(0, resp(listOf(messageHit("m1"), messageHit("m2"))))
+        advanceUntilIdle()
+
+        vm.setKeyword("world"); tick(300L)
+        caller.failAt(1, SearchErrorCode.UPSTREAM_UNAVAILABLE, httpStatus = 503)
+        advanceUntilIdle()
+
+        val s = vm.state.value
+        assertTrue("reset 失败应清空旧 hits", s.hits.isEmpty())
+        assertEquals(SearchErrorCode.UPSTREAM_UNAVAILABLE, s.errorCode)
+        assertEquals(ChannelSearchUiAction.FALLBACK_TO_LOCAL, s.uiAction())
+    }
+
+    @Test
+    fun `loadMore failure preserves already-loaded hits`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GroupDrillViewModel(caller)
+        vm.init("g_xxx", 2, "hello")
+        caller.completeAt(0, resp(listOf(messageHit("m1")), hasMore = true, nextCursor = "cur1"))
+        advanceUntilIdle()
+
+        vm.loadMore()
+        advanceUntilIdle()
+        caller.failAt(1, SearchErrorCode.UPSTREAM_UNAVAILABLE, httpStatus = 503)
+        advanceUntilIdle()
+
+        val s = vm.state.value
+        assertEquals("loadMore 失败不应清空已加载", 1, s.hits.size)
+        assertEquals("m1", s.hits[0].message?.message_id)
+        assertEquals(SearchErrorCode.UPSTREAM_UNAVAILABLE, s.errorCode)
+    }
+
+    @Test
+    fun `rate limited surfaces retry_after in state`() = runTest {
+        val caller = RecordingCaller()
+        val vm = GroupDrillViewModel(caller)
+        vm.init("g_xxx", 2, "hello")
+        caller.failAt(0, SearchErrorCode.RATE_LIMITED, httpStatus = 429, retryAfterSec = 7)
+        advanceUntilIdle()
+        assertEquals(7, vm.state.value.retryAfterSec)
+        assertEquals(ChannelSearchUiAction.RATE_LIMITED, vm.state.value.uiAction())
+    }
+}

--- a/wkuikit/src/test/java/com/chat/uikit/search/remote/drill/GroupDrillViewModelTest.kt
+++ b/wkuikit/src/test/java/com/chat/uikit/search/remote/drill/GroupDrillViewModelTest.kt
@@ -328,4 +328,44 @@ class GroupDrillViewModelTest {
         assertEquals(7, vm.state.value.retryAfterSec)
         assertEquals(ChannelSearchUiAction.RATE_LIMITED, vm.state.value.uiAction())
     }
+
+    @Test
+    fun `response arriving in debounce window with mismatched keyword is discarded`() = runTest {
+        // 回归测试 PR #95 review 阻塞级 (Jerry-Xin)：debounce 窗口 stale response。
+        // GroupDrillViewModel 同样问题：setKeyword("foo") tick 300 → seq=1 pending；
+        // setKeyword("bar") state 立即改但 nextSequence 未递增；foo 响应到达时 requestKeyword
+        // 检查是唯一防线。同时验证 loadMore 在飞时用户改词的场景：loadMore 复用当前 sequence，
+        // reqSeq==nextSequence 会通过，此时也必须靠 requestKeyword 检查丢弃 stale loadMore 结果。
+        val caller = RecordingCaller()
+        val vm = GroupDrillViewModel(caller, debounceMillis = 300L)
+        vm.init("g_xxx", 2, "foo")
+        caller.completeAt(0, resp(listOf(messageHit("m_foo")), hasMore = true, nextCursor = "cur1"))
+        advanceUntilIdle()
+
+        // 场景 1: loadMore (seq=1) 在飞时用户改词
+        vm.loadMore()
+        assertEquals(2, caller.pending.size)
+        assertEquals(1L, caller.pending[1].req.sequence)
+
+        vm.setKeyword("bar")   // state.keyword=bar; nextSequence 仍是 1
+        assertEquals("bar", vm.state.value.keyword)
+
+        // loadMore 的 foo 响应到达 → 应被 requestKeyword 检查丢弃
+        caller.completeAt(1, resp(listOf(messageHit("m_foo_stale"))))
+        advanceUntilIdle()
+        assertFalse(
+            "stale loadMore 响应不能污染新 keyword state",
+            vm.state.value.hits.any { it.message?.message_id == "m_foo_stale" },
+        )
+        // 场景 2: debounce 触发 bar 的新请求
+        tick(300L)
+        assertEquals(3, caller.pending.size)
+        assertEquals("bar", caller.pending[2].req.keyword)
+        assertEquals(2L, caller.pending[2].req.sequence)
+
+        caller.completeAt(2, resp(listOf(messageHit("m_bar"))))
+        advanceUntilIdle()
+        assertEquals(1, vm.state.value.hits.size)
+        assertEquals("m_bar", vm.state.value.hits[0].message?.message_id)
+    }
 }


### PR DESCRIPTION
## Summary

- **L1 广度聚合**：会话列表页顶部搜索的"聊天记录"段从本地聚合切换到服务端 `POST /v1/messages/_search_global_groups`，覆盖跨群/跨 DM/跨子区的服务端可见消息；失败/离线/裸 404 自动 fallback 到本地 `WKIM.msgManager.search`
- **L2 深度浏览**：点某群/子区/DM 桶跳新的 `GroupDrillActivity` 走 `POST /v1/messages/_search_global_messages`，服务端 "传群 id 自动展开群+子区" 生效；message + file 单视图混排，cursor 分页
- **子区头像 fallback**：子区（channel_type=5）的 channel_id 是复合结构 AvatarView 无法直接加载，沿用父群头像；子区名展示 "父群名 · 子区名" 便于识别

对齐服务端契约 `04-aggregation-api-spec.md` §2/§3。

## 改动清单

**新增（wkbase/search/global/）**
- `SearchGlobalGroupsService/BodyBuilder/Model` + DTO（GroupBucket / GlobalSearchFilters / SearchGlobalGroupsReq/Resp）
- `SearchGlobalMessagesService/BodyBuilder/Model` + Req DTO（响应壳复用现有 CursorList<CombinedHit>）

**新增（wkuikit/search/remote/）**
- `GlobalSearchViewModel`：300ms debounce + 单调 sequence + 3 层乱序防护
- `drill/GroupDrillActivity/Adapter/ViewModel` + `act_group_drill_layout.xml`

**改现有**
- `wkbase/search/channel/dto/MessageHit.kt` / `FileHit.kt`：追加可选 `channel_type` / `channel_id`（服务端全局搜索场景回填 preview），向后兼容频道内搜索
- `wkuikit/search/remote/GlobalActivity.kt`：三段缓存 rebuild，聊天记录段接 L1；点 LOCAL_MSG 跳 GroupDrill；子区名 "父群 · 子区"
- `wkuikit/search/remote/GlobalAdapter.kt`：LOCAL_MSG 分支子区头像用父群加载
- `wkuikit/AndroidManifest.xml`：注册 GroupDrillActivity
- `wkuikit/build.gradle`：加 kotlinx-coroutines-test 测试依赖

## 策略确认

| 分段 | 策略 |
|---|---|
| 联系人段 | 老代码"本地 + `/search/global` 双源合并"保留 |
| 群段 | 同上 |
| 查找用户快捷 | 保留 |
| 聊天记录段 (L1) | **服务端优先 + 本地兜底**（`FALLBACK_TO_LOCAL` / 裸 404 → 老 `WKIM.msgManager.search`） |
| L2 深度页 | **只服务端**（本地无等价数据不做兜底，失败仅 toast） |

Space 隔离：`X-Space-Id` 自动注入，只搜当前 space 内可见消息（对齐飞书/钉钉惯例）。

## 单测

- wkbase 351 + wkuikit 219 = 100% pass
- 新增 30 用例：BodyBuilder 序列化 / Resp 反序列化 / Filters 触发门 / ViewModel debounce+sequence+乱序防护 / loadMore 追加 / 失败保留已加载 / rate_limited 场景

## Test plan

- [ ] 冷启动 → 会话列表页点顶部搜索 → 输入关键词 → 联系人/群/查找用户/聊天记录段全部展示
- [ ] 聊天记录段：单条命中直接展 snippet 紫色高亮；多条展"约 N 条相关聊天记录"
- [ ] 子区桶：显示"父群名 · 子区名"，头像沿用父群
- [ ] 快速输入多字符：只发一次 L1 请求（debounce 生效）
- [ ] 断网/prod 未部署接口场景：聊天记录段回退本地聚合，不空白
- [ ] 点聊天记录段某桶 → 跳 GroupDrillActivity（不是 MessageRecordActivity）
- [ ] L2 页：预填 keyword，混合 message + file 结果，`<mark>` 高亮
- [ ] L2 页：上滑触底 loadMore（若 hasMore=true）
- [ ] L2 页：修改 keyword 重搜（debounce + reset cursor）
- [ ] L2 页：点某条命中跳 ChatActivity（本地有消息则定位；无则空白 - 老问题）
- [ ] 频道内 "查找聊天记录"（MessageRecordActivity）无回归
- [ ] SearchUserActivity 联系人搜索无回归
- [ ] 会话列表/消息收发/上下文/我 tab 等其他模块无回归

## 已知残留（老代码历史行为，本 PR 不修，后续单独跟进）

- **服务端搜出 UI 隐藏的默认分组会话**：`is_default=true` category 三端 UI 一致故意不展示；服务端 messages_search 未同步该规则 → 建议服务端 filterVisible 增加一维过滤
- **点单条命中跳 ChatActivity 定位失败空白**：`chatView(orderSeq)` 定位机制依赖本地 IMSDK 消息记录，服务端搜出的历史消息本地不一定有；建议后续 PR 用 `_search_around` 端点补齐锚点前后消息