### PR TITLE
feat(rename): 群/子区改名入口放开给普通成员 (WS-25)

### DIFF
--- a/wkuikit/src/main/java/com/chat/uikit/group/GroupDetailActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/group/GroupDetailActivity.java
@@ -367,11 +367,11 @@ public class GroupDetailActivity extends WKBaseActivity<ActGroupDetailLayoutBind
         });
         SingleClickUtil.onSingleClick(wkVBinding.groupNameLayout, view1 -> {
             if (!groupIsEnable()) return;
-            if (memberRole != WKChannelMemberRole.normal) {
-                Intent intent = new Intent(this, UpdateGroupNameActivity.class);
-                intent.putExtra("groupNo", groupNo);
-                startActivity(intent);
-            } else showSingleBtnDialog(getString(R.string.edit_group_notice));
+            // 放开：所有活跃人类成员都能进入改名页；龙虾做粗过滤，服务端最终裁决龙虾/外部/黑名单。
+            if (isCurrentUserRobot()) return;
+            Intent intent = new Intent(this, UpdateGroupNameActivity.class);
+            intent.putExtra("groupNo", groupNo);
+            startActivity(intent);
         });
         //监听频道改变通知
         WKIM.getInstance().getChannelManager().addOnRefreshChannelInfo("group_detail_refresh_channel", (channel, isEnd) -> {
@@ -763,6 +763,13 @@ public class GroupDetailActivity extends WKBaseActivity<ActGroupDetailLayoutBind
 
     private boolean groupIsEnable() {
         return groupChannel != null && groupChannel.status != Const.GroupStatusDisband;
+    }
+
+    // 当前登录用户是否为龙虾（机器人）。改名入口只做粗过滤，服务端 fail-closed 兜底。
+    private boolean isCurrentUserRobot() {
+        WKChannelMember me = WKIM.getInstance().getChannelMembersManager()
+                .getMember(groupNo, WKChannelType.GROUP, WKConfig.getInstance().getUid());
+        return me != null && me.robot == 1;
     }
 
     private void initGroupAvatar() {

--- a/wkuikit/src/main/java/com/chat/uikit/thread/ThreadDetailActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/thread/ThreadDetailActivity.java
@@ -78,10 +78,9 @@ public class ThreadDetailActivity extends WKBaseActivity<ActThreadDetailLayoutBi
     @Override
     protected void initListener() {
         SingleClickUtil.onSingleClick(wkVBinding.threadNameLayout, v -> {
-            if (!isCreator && !isGroupAdmin) {
-                WKToastUtils.getInstance().showToastNormal(getString(R.string.str_rename_thread_no_permission));
-                return;
-            }
+            // 放开：父群活跃成员即可改名（能进入本页即已是父群活跃成员）。
+            // 龙虾做粗过滤，服务端 fail-closed 最终裁决龙虾/外部/黑名单。
+            if (isCurrentUserRobot()) return;
             showRenameDialog();
         });
 
@@ -201,6 +200,13 @@ public class ThreadDetailActivity extends WKBaseActivity<ActThreadDetailLayoutBi
     protected void onDestroy() {
         super.onDestroy();
         WKIM.getInstance().getChannelManager().removeRefreshChannelInfo("thread_detail_channel");
+    }
+
+    // 当前登录用户是否为龙虾（机器人）。改名入口只做粗过滤，服务端 fail-closed 兜底。
+    private boolean isCurrentUserRobot() {
+        WKChannelMember me = WKIM.getInstance().getChannelMembersManager()
+                .getMember(groupNo, WKChannelType.GROUP, WKConfig.getInstance().getUid());
+        return me != null && me.robot == 1;
     }
 
     private void showRenameDialog() {

--- a/wkuikit/src/main/res/values-en/strings.xml
+++ b/wkuikit/src/main/res/values-en/strings.xml
@@ -559,7 +559,6 @@
     <string name="str_close_thread_confirm">Close this thread? All members will lose access.</string>
     <string name="str_rename_thread">Rename Thread</string>
     <string name="str_rename_thread_hint">Enter thread name</string>
-    <string name="str_rename_thread_no_permission">Only the creator or group admin can rename</string>
     <string name="str_thread_closed_tip">This thread has been closed</string>
     <string name="str_thread_name_empty">Thread name cannot be empty</string>
     <string name="group_md">GROUP.md</string>

--- a/wkuikit/src/main/res/values/strings.xml
+++ b/wkuikit/src/main/res/values/strings.xml
@@ -421,7 +421,6 @@
     <string name="str_rename_thread">修改子区名称</string>
     <string name="str_rename_thread_hint">请输入子区名称</string>
     <string name="str_thread_name_empty">子区名称不能为空</string>
-    <string name="str_rename_thread_no_permission">仅子区创建者或群管理员可修改名称</string>
     <string name="str_join_thread">加入子区</string>
     <string name="str_leave_thread">离开子区</string>
     <string name="str_archive_thread">归档子区</string>


### PR DESCRIPTION
## WS-25 群/子区改名入口解锁（放开给普通成员）

Closes #97

放开 octo-android 的「群改名」和「子区改名」入口，让任何活跃人类成员都能改名。对齐服务端 PR Mininglamp-OSS/octo-server#542 的口径（robot / 外部 / 黑名单除外，由服务端 fail-closed 兜底）。

### 改动

**1. 群改名 `GroupDetailActivity.java`**

原逻辑仅 `memberRole != normal`（群主/管理员）可进入改名页，普通成员被弹 `edit_group_notice` dialog。现放开给所有活跃人类成员，仅对龙虾做前端粗过滤（`isCurrentUserRobot()`）。`UpdateGroupNameActivity.java` 无二次 role 校验，无需改动。

**2. 子区改名 `ThreadDetailActivity.java`**

原逻辑 `!isCreator && !isGroupAdmin` 时提示「无权限」。现移除该门禁：能进入本页即已是父群活跃成员，直接放行，同样仅对龙虾粗过滤。`threadNameLayout` 无 `setEnabled(false)` 动态禁用逻辑。

**3. 清理**：删除门禁移除后残留的 `str_rename_thread_no_permission` 死资源（zh + en）。

粗过滤统一走新增的 `isCurrentUserRobot()`：从群成员缓存取当前用户的 `robot` 字段判断，与仓库既有 `member.robot == 1` 用法一致。

### 三端一致

对齐 Web `threadPermission.ts` 修改后的口径（父群活跃成员 → 放行）与服务端 fail-closed 兜底。

### 构建 / 测试验证

- `./gradlew :app:assembleDebug` → **BUILD SUCCESSFUL**，dev/prod 两 flavor 均出包（`octoim-{dev,prod}-debug-v1.3.5.apk`），无 error。
- `./gradlew :wkuikit:testDebugUnitTest` → **BUILD SUCCESSFUL**，221 tests，0 failures / 0 errors。

### 待补（需测试环境 / 部署确认，非代码侧可自足）

- 非管理员普通成员真机/模拟器走查：改群名、改子区名保存成功 + 系统 tip「XXX 修改群名为 YYY」渲染正确。需可登录的后端 + 非管理员测试账号 + 已加入的群/子区。
- octo-server#542 线上强制鉴权部署时序确认（#542 已合并，线上是否已强制鉴权由 deploy owner 确认）。

### 关联

- 父任务：WS-22
- 服务端 PR：Mininglamp-OSS/octo-server#542
- 本 PR 只做 octo-android；Web / iOS 各自 WS 跟进。
