### PR TITLE
fix(thread-list): 加已归档 tab + perf hotfix 修列表卡顿

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
         applicationId appId
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 36
-        versionName "1.3.5"
+        versionCode 37
+        versionName "1.3.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
@@ -214,15 +214,6 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
     // 仅在 splitMode=true（sw >= 600dp 且 Activity Embedding 激活）时渲染选中背景。
     // 手机形态 splitMode=false → 维持无选中态行为。
     private boolean splitMode;
-
-    /**
-     * Per-bind selector 缓存：{@link #getRenderWkMsg} 命中同一 {@code WKUIConversationMsg}
-     * 引用时直接返回 {@link #_bindCacheDisplayMsg}，否则重算 + 存进来。两个 {@code convert()}
-     * 入口在方法首行清空，作用域限于单次 bind。RecyclerView bind 在主线程串行化，无需
-     * 加锁。命名以 `_` 前缀提示这是内部瞬态字段，不参与业务逻辑。
-     */
-    private WKUIConversationMsg _bindCacheItem;
-    private WKMsg _bindCacheDisplayMsg;
     private String selectedChannelId;
     private byte selectedChannelType;
     private String selectedThreadChannelId;
@@ -385,13 +376,6 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
 
     @Override
     protected void convert(@NonNull final BaseViewHolder helper, ChatConversationMsg conversationMsg) {
-        // 单次 bind 内 selectDisplayMessage 复用缓存：一次 convert 会分别在 showTime /
-        // showContent / showCompactReminders 里各调一次 getRenderWkMsg，未缓存时
-        // BotFather 行每次触发 DB 分页 (5×200)。RecyclerView bind 在主线程串行化，
-        // 缓存作用域限于本次 convert 已足够；进 convert 先 clear，天然避免跨 bind
-        // 污染。
-        _bindCacheItem = null;
-        _bindCacheDisplayMsg = null;
         if (helper.getItemViewType() == TYPE_SECTION_HEADER) {
             convertSectionHeader(helper, conversationMsg);
             return;
@@ -648,9 +632,6 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
 
     @Override
     protected void convert(@NotNull BaseViewHolder baseViewHolder, ChatConversationMsg uiConversationMsg, @NotNull List<?> payloads) {
-        // 见 convert(helper, conversationMsg) 的注释：per-bind 缓存重置。
-        _bindCacheItem = null;
-        _bindCacheDisplayMsg = null;
         // Section header payload: 只刷新 badge/count，不重建整个 header
         if (baseViewHolder.getItemViewType() == TYPE_SECTION_HEADER) {
             for (Object p : payloads) {
@@ -1092,22 +1073,18 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
     }
 
     private void showTime(@NotNull BaseViewHolder helper, WKUIConversationMsg item) {
-        // -B · Layer B · 渲染层时间戳：走 ConversationPreviewSelector.selectDisplayTimestamp，
-        // 与会话列表排序 comparator 保持同源（SystemBot 用 spaceFilteredLastMessage 的
-        // timestamp，普通频道走 uc.lastMsgTimestamp 原生）。这样"排序位置"和"时间字符串"
-        // 永远一致，避免位置和显示打架。
-        // 跨 Space 污染判定由 selector 内部封装（对齐 iOS spaceFilteredLastMessage 返回 nil
-        // 时 timestamp=0 → 不显示时间）。
-        //
-        // Perf：先 getRenderWkMsg 拿 displayMsg 走 per-bind 缓存，再传给
-        // selectDisplayTimestamp 的 2-arg overload；SystemBot 分支复用 displayMsg 不
-        // 再重复 DB 分页（老实现 SystemBot 一次 bind 走 2 次 selectDisplayMessage）。
-        WKMsg displayMsg = getRenderWkMsg(item);
-        long msgTimestamp = com.chat.base.space.ConversationPreviewSelector.selectDisplayTimestamp(item, displayMsg);
-        // editedAt 修正：selector 返回的 msg 若有 editedAt 则用之（保留原有 "已编辑" 时间语义）
-        if (msgTimestamp > 0 && displayMsg != null
-                && displayMsg.remoteExtra != null && displayMsg.remoteExtra.editedAt != 0) {
-            msgTimestamp = displayMsg.remoteExtra.editedAt;
+        // -B · Layer B · 渲染层时间戳 Space 过滤。跨 Space 消息污染时返回 0
+        // （即不显示最近时间），避免列表因被跨 Space push bump 而冒顶排序。
+        long msgTimestamp;
+        if (com.chat.base.space.ConversationPreviewFilter.isMessageCrossSpace(item)) {
+            msgTimestamp = 0;
+        } else {
+            msgTimestamp = item.lastMsgTimestamp;
+            if (item.getWkMsg() != null) {
+                if (item.getWkMsg().remoteExtra.editedAt != 0) {
+                    msgTimestamp = item.getWkMsg().remoteExtra.editedAt;
+                }
+            }
         }
         String chatTime = msgTimestamp > 0
                 ? WKTimeUtils.getInstance().getNewChatTime(msgTimestamp * 1000)
@@ -1122,7 +1099,23 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
     /**
      * 从消息中提取 space_id
      */
-    // getSpaceIdFromMsg 已收敛到 SpaceFilter.extractSpaceIdFromMsg（单例 helper）。
+    private String getSpaceIdFromMsg(WKMsg msg) {
+        if (msg == null) return null;
+        // 1. 从 content 原始 JSON 解析
+        if (!TextUtils.isEmpty(msg.content)) {
+            try {
+                JSONObject json = new JSONObject(msg.content);
+                String sid = json.optString("space_id", "");
+                if (!sid.isEmpty()) return sid;
+            } catch (Exception ignored) {
+            }
+        }
+        // 2. 从 SDK 解码后的 spaceId 字段读取
+        if (msg.baseContentMsgModel != null && !TextUtils.isEmpty(msg.baseContentMsgModel.spaceId)) {
+            return msg.baseContentMsgModel.spaceId;
+        }
+        return null;
+    }
 
     /**
      * 为系统 Bot 查找当前 Space 下的最后一条消息。
@@ -1132,10 +1125,35 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
      * 搜索范围 500 条：服务端 BotFather 跨 Space 共享，sync 返回的 recents 不按 space_id 过滤，
      * 近期大量其他 Space 消息可能将当前 Space 消息挤出默认搜索范围。
      */
-    // findSystemBotSpaceContent 已收敛到
-    // ConversationPreviewSelector.selectDisplayMessage（对齐 iOS
-    // -[WKConversationWrapModel spaceFilteredLastMessage] 分页 + 兜底逻辑，
-    // 且不限 WK_TEXT，覆盖交互式卡片 type=17 等 SystemBot 消息类型）。
+    private String findSystemBotSpaceContent(WKUIConversationMsg item) {
+        if (!com.chat.base.space.SystemBotsFallback.isSystemBot(item.channelID)) return null;
+        String currentSpaceId = MsgModel.getInstance().getCurrentSpaceId();
+        if (TextUtils.isEmpty(currentSpaceId)) return null;
+
+        // 最后一条消息已匹配当前 Space，无需特殊处理
+        String lastMsgSpaceId = getSpaceIdFromMsg(item.getWkMsg());
+        if (lastMsgSpaceId != null && lastMsgSpaceId.equals(currentSpaceId)) return null;
+        if (lastMsgSpaceId == null) return null; // 无 space_id 的历史消息，向前兼容
+
+        // 最后一条消息不属于当前 Space，查本地 DB 找当前 Space 的最后一条（扩大搜索范围）
+        try {
+            List<WKMsg> recentMsgs = WKIM.getInstance().getMsgManager()
+                    .searchMsgWithChannelAndContentTypes(
+                            item.channelID, item.channelType,
+                            0, 500,
+                            new int[]{WKContentType.WK_TEXT});
+            if (recentMsgs != null) {
+                for (WKMsg msg : recentMsgs) {
+                    String sid = getSpaceIdFromMsg(msg);
+                    if (sid == null || currentSpaceId.equals(sid)) {
+                        return getContent(msg);
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        return ""; // 当前 Space 确实无消息
+    }
 
     /**
      * 返回 Space 感知的未读数。
@@ -1168,28 +1186,13 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
     }
 
     /**
-     * -B · Layer B · 渲染层 wkMsg 获取：走 ConversationPreviewSelector（对齐 iOS
-     * -[WKConversationWrapModel spaceFilteredLastMessage]）。语义:
-     * <ul>
-     *     <li>非 PERSONAL / 非多 space → uc 的原生 wkMsg</li>
-     *     <li>PERSONAL 多 space + rawMsg 有 space_id 匹配 → rawMsg</li>
-     *     <li>PERSONAL 多 space + rawMsg 无 space_id + 非 BotFather → rawMsg
-     *         （AI 回复默认属于当前 space）</li>
-     *     <li>PERSONAL 多 space + rawMsg 无 space_id + BotFather → DB 分页找当前 space 消息</li>
-     *     <li>SystemBot 且 wkMsg=null (placeholder / stale) → 从消息表拿最新一条</li>
-     * </ul>
-     * 返回 null 时上游 getContent(null) 显示空。
+     * -B · Layer B · 渲染层 wkMsg 获取：跨 Space 污染时返回 null，避免
+     * {@link #getContent(WKMsg)} 直接渲染出另一 Space 的原文。
+     * 对齐 iOS {@code spaceFilteredLastMessage} / Web {@code getSpaceFilteredLastMessage}。
      */
     @Nullable
     private WKMsg getRenderWkMsg(@Nullable WKUIConversationMsg item) {
-        if (item == null) return null;
-        // == 是有意的引用比较：RecyclerView bind 串行且 convert() 入口已重置 cache，
-        // 同一 bind 内 uc 引用一定不变，跨 bind 一定不同实例（即便 clientMsgNo 相同）。
-        if (item == _bindCacheItem) return _bindCacheDisplayMsg;
-        WKMsg m = com.chat.base.space.ConversationPreviewSelector.selectDisplayMessage(item);
-        _bindCacheItem = item;
-        _bindCacheDisplayMsg = m;
-        return m;
+        return com.chat.base.space.ConversationPreviewFilter.getSpaceFilteredWkMsg(item);
     }
 
     /**
@@ -1232,14 +1235,18 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
         androidx.emoji2.widget.EmojiTextView contentTv = helper.getView(R.id.contentTv);
         boolean isSetChatPwd = isSetChatPwd(item.getWkChannel());
 
-        if (isSetChatPwd) {
+        // 系统 Bot：显示当前 Space 的最后一条消息
+        String spaceContent = findSystemBotSpaceContent(item);
+        if (spaceContent != null) {
+            content = spaceContent;
+        } else if (isSetChatPwd) {
             // 聊天密码
             content = "❊❊❊❊❊❊❊❊❊❊❊❊❊";
         } else {
-            // 走 ConversationPreviewSelector（对齐 iOS spaceFilteredLastMessage）：
-            //   - SystemBot 且 wkMsg 未 hydrate → 从消息表拿最新一条
-            //   - PERSONAL 多 space + BotFather → DB 分页找当前 space 的消息
-            //   - 其它场景 → uc 原生 wkMsg（可能被 space 过滤为 null → getContent 显示空）
+            // -B · Layer B · 非 SystemBot 分支也过 render-time Space 过滤兜底。
+            // SystemBot 走 findSystemBotSpaceContent（含 DB 回查当前 Space 历史）；
+            // 其它频道类型若判定为跨 Space 污染（冷启动 race / DB 回放），
+            // getRenderWkMsg 返回 null 后 getContent 返回空串 → preview 为空。
             WKMsg renderMsg = getRenderWkMsg(item);
             content = getContent(renderMsg);
             String fromName = getFromName(item.channelType, renderMsg);

--- a/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
@@ -214,6 +214,15 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
     // 仅在 splitMode=true（sw >= 600dp 且 Activity Embedding 激活）时渲染选中背景。
     // 手机形态 splitMode=false → 维持无选中态行为。
     private boolean splitMode;
+
+    /**
+     * Per-bind selector 缓存：{@link #getRenderWkMsg} 命中同一 {@code WKUIConversationMsg}
+     * 引用时直接返回 {@link #_bindCacheDisplayMsg}，否则重算 + 存进来。两个 {@code convert()}
+     * 入口在方法首行清空，作用域限于单次 bind。RecyclerView bind 在主线程串行化，无需
+     * 加锁。命名以 `_` 前缀提示这是内部瞬态字段，不参与业务逻辑。
+     */
+    private WKUIConversationMsg _bindCacheItem;
+    private WKMsg _bindCacheDisplayMsg;
     private String selectedChannelId;
     private byte selectedChannelType;
     private String selectedThreadChannelId;
@@ -376,6 +385,13 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
 
     @Override
     protected void convert(@NonNull final BaseViewHolder helper, ChatConversationMsg conversationMsg) {
+        // 单次 bind 内 selectDisplayMessage 复用缓存：一次 convert 会分别在 showTime /
+        // showContent / showCompactReminders 里各调一次 getRenderWkMsg，未缓存时
+        // BotFather 行每次触发 DB 分页 (5×200)。RecyclerView bind 在主线程串行化，
+        // 缓存作用域限于本次 convert 已足够；进 convert 先 clear，天然避免跨 bind
+        // 污染。
+        _bindCacheItem = null;
+        _bindCacheDisplayMsg = null;
         if (helper.getItemViewType() == TYPE_SECTION_HEADER) {
             convertSectionHeader(helper, conversationMsg);
             return;
@@ -632,6 +648,9 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
 
     @Override
     protected void convert(@NotNull BaseViewHolder baseViewHolder, ChatConversationMsg uiConversationMsg, @NotNull List<?> payloads) {
+        // 见 convert(helper, conversationMsg) 的注释：per-bind 缓存重置。
+        _bindCacheItem = null;
+        _bindCacheDisplayMsg = null;
         // Section header payload: 只刷新 badge/count，不重建整个 header
         if (baseViewHolder.getItemViewType() == TYPE_SECTION_HEADER) {
             for (Object p : payloads) {
@@ -1073,18 +1092,22 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
     }
 
     private void showTime(@NotNull BaseViewHolder helper, WKUIConversationMsg item) {
-        // -B · Layer B · 渲染层时间戳 Space 过滤。跨 Space 消息污染时返回 0
-        // （即不显示最近时间），避免列表因被跨 Space push bump 而冒顶排序。
-        long msgTimestamp;
-        if (com.chat.base.space.ConversationPreviewFilter.isMessageCrossSpace(item)) {
-            msgTimestamp = 0;
-        } else {
-            msgTimestamp = item.lastMsgTimestamp;
-            if (item.getWkMsg() != null) {
-                if (item.getWkMsg().remoteExtra.editedAt != 0) {
-                    msgTimestamp = item.getWkMsg().remoteExtra.editedAt;
-                }
-            }
+        // -B · Layer B · 渲染层时间戳：走 ConversationPreviewSelector.selectDisplayTimestamp，
+        // 与会话列表排序 comparator 保持同源（SystemBot 用 spaceFilteredLastMessage 的
+        // timestamp，普通频道走 uc.lastMsgTimestamp 原生）。这样"排序位置"和"时间字符串"
+        // 永远一致，避免位置和显示打架。
+        // 跨 Space 污染判定由 selector 内部封装（对齐 iOS spaceFilteredLastMessage 返回 nil
+        // 时 timestamp=0 → 不显示时间）。
+        //
+        // Perf：先 getRenderWkMsg 拿 displayMsg 走 per-bind 缓存，再传给
+        // selectDisplayTimestamp 的 2-arg overload；SystemBot 分支复用 displayMsg 不
+        // 再重复 DB 分页（老实现 SystemBot 一次 bind 走 2 次 selectDisplayMessage）。
+        WKMsg displayMsg = getRenderWkMsg(item);
+        long msgTimestamp = com.chat.base.space.ConversationPreviewSelector.selectDisplayTimestamp(item, displayMsg);
+        // editedAt 修正：selector 返回的 msg 若有 editedAt 则用之（保留原有 "已编辑" 时间语义）
+        if (msgTimestamp > 0 && displayMsg != null
+                && displayMsg.remoteExtra != null && displayMsg.remoteExtra.editedAt != 0) {
+            msgTimestamp = displayMsg.remoteExtra.editedAt;
         }
         String chatTime = msgTimestamp > 0
                 ? WKTimeUtils.getInstance().getNewChatTime(msgTimestamp * 1000)
@@ -1099,23 +1122,7 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
     /**
      * 从消息中提取 space_id
      */
-    private String getSpaceIdFromMsg(WKMsg msg) {
-        if (msg == null) return null;
-        // 1. 从 content 原始 JSON 解析
-        if (!TextUtils.isEmpty(msg.content)) {
-            try {
-                JSONObject json = new JSONObject(msg.content);
-                String sid = json.optString("space_id", "");
-                if (!sid.isEmpty()) return sid;
-            } catch (Exception ignored) {
-            }
-        }
-        // 2. 从 SDK 解码后的 spaceId 字段读取
-        if (msg.baseContentMsgModel != null && !TextUtils.isEmpty(msg.baseContentMsgModel.spaceId)) {
-            return msg.baseContentMsgModel.spaceId;
-        }
-        return null;
-    }
+    // getSpaceIdFromMsg 已收敛到 SpaceFilter.extractSpaceIdFromMsg（单例 helper）。
 
     /**
      * 为系统 Bot 查找当前 Space 下的最后一条消息。
@@ -1125,35 +1132,10 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
      * 搜索范围 500 条：服务端 BotFather 跨 Space 共享，sync 返回的 recents 不按 space_id 过滤，
      * 近期大量其他 Space 消息可能将当前 Space 消息挤出默认搜索范围。
      */
-    private String findSystemBotSpaceContent(WKUIConversationMsg item) {
-        if (!com.chat.base.space.SystemBotsFallback.isSystemBot(item.channelID)) return null;
-        String currentSpaceId = MsgModel.getInstance().getCurrentSpaceId();
-        if (TextUtils.isEmpty(currentSpaceId)) return null;
-
-        // 最后一条消息已匹配当前 Space，无需特殊处理
-        String lastMsgSpaceId = getSpaceIdFromMsg(item.getWkMsg());
-        if (lastMsgSpaceId != null && lastMsgSpaceId.equals(currentSpaceId)) return null;
-        if (lastMsgSpaceId == null) return null; // 无 space_id 的历史消息，向前兼容
-
-        // 最后一条消息不属于当前 Space，查本地 DB 找当前 Space 的最后一条（扩大搜索范围）
-        try {
-            List<WKMsg> recentMsgs = WKIM.getInstance().getMsgManager()
-                    .searchMsgWithChannelAndContentTypes(
-                            item.channelID, item.channelType,
-                            0, 500,
-                            new int[]{WKContentType.WK_TEXT});
-            if (recentMsgs != null) {
-                for (WKMsg msg : recentMsgs) {
-                    String sid = getSpaceIdFromMsg(msg);
-                    if (sid == null || currentSpaceId.equals(sid)) {
-                        return getContent(msg);
-                    }
-                }
-            }
-        } catch (Exception ignored) {
-        }
-        return ""; // 当前 Space 确实无消息
-    }
+    // findSystemBotSpaceContent 已收敛到
+    // ConversationPreviewSelector.selectDisplayMessage（对齐 iOS
+    // -[WKConversationWrapModel spaceFilteredLastMessage] 分页 + 兜底逻辑，
+    // 且不限 WK_TEXT，覆盖交互式卡片 type=17 等 SystemBot 消息类型）。
 
     /**
      * 返回 Space 感知的未读数。
@@ -1186,13 +1168,28 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
     }
 
     /**
-     * -B · Layer B · 渲染层 wkMsg 获取：跨 Space 污染时返回 null，避免
-     * {@link #getContent(WKMsg)} 直接渲染出另一 Space 的原文。
-     * 对齐 iOS {@code spaceFilteredLastMessage} / Web {@code getSpaceFilteredLastMessage}。
+     * -B · Layer B · 渲染层 wkMsg 获取：走 ConversationPreviewSelector（对齐 iOS
+     * -[WKConversationWrapModel spaceFilteredLastMessage]）。语义:
+     * <ul>
+     *     <li>非 PERSONAL / 非多 space → uc 的原生 wkMsg</li>
+     *     <li>PERSONAL 多 space + rawMsg 有 space_id 匹配 → rawMsg</li>
+     *     <li>PERSONAL 多 space + rawMsg 无 space_id + 非 BotFather → rawMsg
+     *         （AI 回复默认属于当前 space）</li>
+     *     <li>PERSONAL 多 space + rawMsg 无 space_id + BotFather → DB 分页找当前 space 消息</li>
+     *     <li>SystemBot 且 wkMsg=null (placeholder / stale) → 从消息表拿最新一条</li>
+     * </ul>
+     * 返回 null 时上游 getContent(null) 显示空。
      */
     @Nullable
     private WKMsg getRenderWkMsg(@Nullable WKUIConversationMsg item) {
-        return com.chat.base.space.ConversationPreviewFilter.getSpaceFilteredWkMsg(item);
+        if (item == null) return null;
+        // == 是有意的引用比较：RecyclerView bind 串行且 convert() 入口已重置 cache，
+        // 同一 bind 内 uc 引用一定不变，跨 bind 一定不同实例（即便 clientMsgNo 相同）。
+        if (item == _bindCacheItem) return _bindCacheDisplayMsg;
+        WKMsg m = com.chat.base.space.ConversationPreviewSelector.selectDisplayMessage(item);
+        _bindCacheItem = item;
+        _bindCacheDisplayMsg = m;
+        return m;
     }
 
     /**
@@ -1235,18 +1232,14 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
         androidx.emoji2.widget.EmojiTextView contentTv = helper.getView(R.id.contentTv);
         boolean isSetChatPwd = isSetChatPwd(item.getWkChannel());
 
-        // 系统 Bot：显示当前 Space 的最后一条消息
-        String spaceContent = findSystemBotSpaceContent(item);
-        if (spaceContent != null) {
-            content = spaceContent;
-        } else if (isSetChatPwd) {
+        if (isSetChatPwd) {
             // 聊天密码
             content = "❊❊❊❊❊❊❊❊❊❊❊❊❊";
         } else {
-            // -B · Layer B · 非 SystemBot 分支也过 render-time Space 过滤兜底。
-            // SystemBot 走 findSystemBotSpaceContent（含 DB 回查当前 Space 历史）；
-            // 其它频道类型若判定为跨 Space 污染（冷启动 race / DB 回放），
-            // getRenderWkMsg 返回 null 后 getContent 返回空串 → preview 为空。
+            // 走 ConversationPreviewSelector（对齐 iOS spaceFilteredLastMessage）：
+            //   - SystemBot 且 wkMsg 未 hydrate → 从消息表拿最新一条
+            //   - PERSONAL 多 space + BotFather → DB 分页找当前 space 的消息
+            //   - 其它场景 → uc 原生 wkMsg（可能被 space 过滤为 null → getContent 显示空）
             WKMsg renderMsg = getRenderWkMsg(item);
             content = getContent(renderMsg);
             String fromName = getFromName(item.channelType, renderMsg);

--- a/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
+++ b/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
@@ -2557,13 +2557,18 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
         // 拷贝一份，避免对 adapter data list 并发修改
         List<ChatConversationMsg> snapshot = new ArrayList<>(list);
         groupMsg(snapshot);
-        // 排序键走 ConversationPreviewSelector.selectDisplayTimestamp: SystemBot 场景下
-        // 用 spaceFilteredLastMessage 的 timestamp (对齐 iOS -[WKConversationWrapModel
-        // lastMsgTimestamp])，避免 SDK entry 的 lastMsgTimestamp=0 / stale 导致沉底。
-        // 普通频道 selector 直接返回 uc.lastMsgTimestamp，行为不变。
+        // 排序键退回 uc.lastMsgTimestamp 直读 (O(1))。原本走
+        // ConversationPreviewSelector.selectDisplayTimestamp 是为了对齐 iOS
+        // spaceFilteredLastMessage 让 SystemBot/BotFather 场景排序与 preview 同源, 但
+        // selector 在 PERSONAL+多 Space+BotFather 分支会走 DB 分页 (最多 5×200=1000 条),
+        // sort N 项 = O(N log N) 次 DB 查询 = 主线程阻塞 → 从聊天页返回 onResume 触发一次
+        // 大列表 sort 就整列表卡死. render 层 showTime 仍走 selector (per-bind 缓存兜底);
+        // 极端场景下 SystemBot 的"位置"和"预览"可能短暂不一致, 相比 UI 卡死可接受.
+        // 待 selector 落地作者预留的 channel-scoped LRU cache + conversation listener
+        // invalidate 后可恢复走 selector.
         Collections.sort(snapshot, (a, b) -> Long.compare(
-                com.chat.base.space.ConversationPreviewSelector.selectDisplayTimestamp(b.uiConversationMsg),
-                com.chat.base.space.ConversationPreviewSelector.selectDisplayTimestamp(a.uiConversationMsg)));
+                b.uiConversationMsg.lastMsgTimestamp,
+                a.uiConversationMsg.lastMsgTimestamp));
         List<ChatConversationMsg> topList = new ArrayList<>();
         List<ChatConversationMsg> normalList = new ArrayList<>();
         for (int i = 0, size = snapshot.size(); i < size; i++) {
@@ -2928,11 +2933,10 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
             int topA = (a.uiConversationMsg.getWkChannel() != null && a.uiConversationMsg.getWkChannel().top == 1) ? 1 : 0;
             int topB = (b.uiConversationMsg.getWkChannel() != null && b.uiConversationMsg.getWkChannel().top == 1) ? 1 : 0;
             if (topA != topB) return topB - topA;
-            // 排序键走 selector，与 sortMsg 保持一致（SystemBot 用 spaceFilteredLastMessage
-            // 的 timestamp，避免 SDK entry 空/stale 沉底）。
+            // 排序键退回 uc.lastMsgTimestamp 直读 (与 sortMsg 保持一致, 见那边的注释)。
             return Long.compare(
-                    com.chat.base.space.ConversationPreviewSelector.selectDisplayTimestamp(b.uiConversationMsg),
-                    com.chat.base.space.ConversationPreviewSelector.selectDisplayTimestamp(a.uiConversationMsg));
+                    b.uiConversationMsg.lastMsgTimestamp,
+                    a.uiConversationMsg.lastMsgTimestamp);
         });
         return filtered;
     }

--- a/wkuikit/src/main/java/com/chat/uikit/thread/ThreadListActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/thread/ThreadListActivity.java
@@ -166,12 +166,15 @@ public class ThreadListActivity extends WKBaseActivity<ActThreadListLayoutBindin
         final String requestedStatus = currentStatusParam();
 
         ThreadModel.getInstance().listThreads(groupNo, requestedStatus, page, PAGE_LIMIT, (code, msg, list) -> {
+            // finishRefresh / finishLoadMore 必须在 stale-guard 之前调用: 否则
+            // 用户下拉刷新 → 快速切 tab → 首次请求作废 → spinner 永远不停。
+            // 幂等, 多次调用无副作用。
+            wkVBinding.refreshLayout.finishRefresh();
+            wkVBinding.refreshLayout.finishLoadMore();
             if (gen != loadGeneration) {
                 // stale: 用户已经切了 tab / 触发了新一次 loadData，本次回包作废
                 return;
             }
-            wkVBinding.refreshLayout.finishRefresh();
-            wkVBinding.refreshLayout.finishLoadMore();
             if (code == HttpResponseCode.success && list != null) {
                 if (page == 1) {
                     allLoadedList.clear();
@@ -187,6 +190,9 @@ public class ThreadListActivity extends WKBaseActivity<ActThreadListLayoutBindin
                     currentPage++;
                 }
             } else {
+                // error 分支也需要更新空态: refreshFromFirstPage 已清空 adapter,
+                // 若不 updateEmptyState 用户只能看到白屏无提示。
+                updateEmptyState();
                 WKToastUtils.getInstance().showToast(msg);
             }
         });
@@ -211,7 +217,12 @@ public class ThreadListActivity extends WKBaseActivity<ActThreadListLayoutBindin
         // - 已加入子区: 跳过 join, 直接进入。
         if (entity.is_joined == 0) {
             ThreadModel.getInstance().joinThread(groupNo, entity.short_id, (code, msg) -> {
-                // fire-and-forget: navigate 已提前触发, join 结果无需处理。
+                // fire-and-forget: navigate 已提前触发; 归档拒/超时属预期, 只 warn log
+                // 非预期失败(如权限撤销 / 子区已删), 便于后续排查。
+                if (code != HttpResponseCode.success) {
+                    android.util.Log.w("ThreadList", "join failed shortId=" + entity.short_id
+                            + " code=" + code + " msg=" + msg);
+                }
             });
         }
         navigateToChat(channelId);
@@ -233,6 +244,9 @@ public class ThreadListActivity extends WKBaseActivity<ActThreadListLayoutBindin
         allLoadedList.clear();
         adapter.setList(new ArrayList<>());
         wkVBinding.refreshLayout.setNoMoreData(false);
+        // 清空 adapter 后立即刷空态: loadData 若被 stale 丢弃或失败, 用户至少能看到
+        // "暂无..." 提示而不是白屏。成功时 loadData 内部会再 updateEmptyState 覆盖。
+        updateEmptyState();
         loadData();
     }
 

--- a/wkuikit/src/main/java/com/chat/uikit/thread/ThreadListActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/thread/ThreadListActivity.java
@@ -18,13 +18,17 @@ package com.chat.uikit.thread;
 
 import android.content.Intent;
 import android.view.View;
+import android.widget.FrameLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
 import com.chat.base.base.WKBaseActivity;
+import com.chat.base.config.WKConfig;
 import com.chat.base.entity.PopupMenuItem;
+import com.chat.base.msgitem.WKChannelMemberRole;
 import com.chat.base.net.HttpResponseCode;
+import com.chat.base.ui.components.SegmentTabView;
 import com.chat.base.utils.WKDialogUtils;
 import com.chat.base.utils.WKToastUtils;
 import com.chat.base.endpoint.entity.ChatViewMenu;
@@ -42,6 +46,8 @@ import com.chat.uikit.thread.service.entity.ThreadEntity;
 import com.scwang.smart.refresh.layout.api.RefreshLayout;
 import com.scwang.smart.refresh.layout.listener.OnRefreshListener;
 import com.scwang.smart.refresh.layout.listener.OnLoadMoreListener;
+import com.xinbida.wukongim.WKIM;
+import com.xinbida.wukongim.entity.WKChannelMember;
 import com.xinbida.wukongim.entity.WKChannelType;
 
 import java.util.ArrayList;
@@ -50,11 +56,20 @@ import java.util.List;
 public class ThreadListActivity extends WKBaseActivity<ActThreadListLayoutBinding> {
 
     private static final int PAGE_LIMIT = 100;
+    private static final int TAB_ACTIVE = 0;
+    private static final int TAB_ARCHIVED = 1;
 
     private String groupNo;
     private ThreadListAdapter adapter;
+    private SegmentTabView segmentTabView;
+    private int selectedTab = TAB_ACTIVE;
     private int currentPage = 1;
-    private final List<ThreadEntity> allActiveList = new ArrayList<>();
+    private final List<ThreadEntity> allLoadedList = new ArrayList<>();
+
+    // 每次 loadData 启动 +1，回调时对比当前值不一致直接丢弃。
+    // 防止用户在飞行中切 tab（active→archived→active）时旧请求
+    // 把 stale 数据 append 进新 tab。对齐 iOS WKThreadListVC.loadGeneration。
+    private int loadGeneration;
 
     @Override
     protected ActThreadListLayoutBinding getViewBinding() {
@@ -72,7 +87,15 @@ public class ThreadListActivity extends WKBaseActivity<ActThreadListLayoutBindin
         adapter = new ThreadListAdapter();
         adapter.setGroupNo(groupNo);
         initAdapter(wkVBinding.recyclerView, adapter);
-        wkVBinding.sectionTitleTv.setVisibility(View.GONE);
+
+        segmentTabView = new SegmentTabView(this, new String[]{
+                getString(R.string.str_thread_tab_active),
+                getString(R.string.str_thread_tab_archived)
+        });
+        wkVBinding.segmentTabContainer.addView(segmentTabView,
+                new FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.WRAP_CONTENT));
     }
 
     @Override
@@ -81,8 +104,7 @@ public class ThreadListActivity extends WKBaseActivity<ActThreadListLayoutBindin
         wkVBinding.refreshLayout.setOnRefreshListener(new OnRefreshListener() {
             @Override
             public void onRefresh(@NonNull RefreshLayout refreshLayout) {
-                currentPage = 1;
-                loadData();
+                refreshFromFirstPage();
             }
         });
         wkVBinding.refreshLayout.setOnLoadMoreListener(new OnLoadMoreListener() {
@@ -90,6 +112,14 @@ public class ThreadListActivity extends WKBaseActivity<ActThreadListLayoutBindin
             public void onLoadMore(@NonNull RefreshLayout refreshLayout) {
                 loadData();
             }
+        });
+
+        segmentTabView.setOnTabSelectedListener(index -> {
+            if (index == selectedTab) return;
+            selectedTab = index;
+            // 切 tab 与 iOS 对齐: 完全重置状态 + 只拉当前 tab 首页。server 端
+            // 按 ?status=active|archived 各自分页, 客户端不再做二次过滤/缓存。
+            refreshFromFirstPage();
         });
 
         SingleClickUtil.onSingleClick(wkVBinding.createThreadLayout, v -> openCreateThread());
@@ -125,29 +155,30 @@ public class ThreadListActivity extends WKBaseActivity<ActThreadListLayoutBindin
         // loadData() 由 onResume() 触发，避免首次创建时重复请求
     }
 
+    private String currentStatusParam() {
+        return selectedTab == TAB_ARCHIVED ? "archived" : "active";
+    }
+
     private void loadData() {
-        ThreadModel.getInstance().listThreads(groupNo, currentPage, PAGE_LIMIT, (code, msg, list) -> {
+        loadGeneration++;
+        final int gen = loadGeneration;
+        final int page = currentPage;
+        final String requestedStatus = currentStatusParam();
+
+        ThreadModel.getInstance().listThreads(groupNo, requestedStatus, page, PAGE_LIMIT, (code, msg, list) -> {
+            if (gen != loadGeneration) {
+                // stale: 用户已经切了 tab / 触发了新一次 loadData，本次回包作废
+                return;
+            }
             wkVBinding.refreshLayout.finishRefresh();
             wkVBinding.refreshLayout.finishLoadMore();
             if (code == HttpResponseCode.success && list != null) {
-                List<ThreadEntity> pageActiveList = new ArrayList<>();
-                for (ThreadEntity entity : list) {
-                    // status: 1=活跃, 2=归档, 3=删除
-                    if (entity.status == 1) {
-                        pageActiveList.add(entity);
-                    }
+                if (page == 1) {
+                    allLoadedList.clear();
                 }
-                if (currentPage == 1) {
-                    allActiveList.clear();
-                }
-                allActiveList.addAll(pageActiveList);
-                adapter.setList(new ArrayList<>(allActiveList));
-                if (!allActiveList.isEmpty()) {
-                    wkVBinding.sectionTitleTv.setVisibility(View.VISIBLE);
-                    wkVBinding.sectionTitleTv.setText(getString(R.string.joined_threads_count, allActiveList.size()));
-                } else {
-                    wkVBinding.sectionTitleTv.setVisibility(View.GONE);
-                }
+                allLoadedList.addAll(list);
+                adapter.setList(new ArrayList<>(allLoadedList));
+                updateEmptyState();
                 // 判断是否还有更多数据
                 if (list.size() < PAGE_LIMIT) {
                     wkVBinding.refreshLayout.setNoMoreData(true);
@@ -161,19 +192,29 @@ public class ThreadListActivity extends WKBaseActivity<ActThreadListLayoutBindin
         });
     }
 
+    private void updateEmptyState() {
+        if (allLoadedList.isEmpty()) {
+            wkVBinding.emptyTv.setText(selectedTab == TAB_ARCHIVED
+                    ? R.string.str_no_archived_threads
+                    : R.string.str_no_active_threads);
+            wkVBinding.emptyTv.setVisibility(View.VISIBLE);
+        } else {
+            wkVBinding.emptyTv.setVisibility(View.GONE);
+        }
+    }
+
     private void openThread(ThreadEntity entity) {
         String channelId = ThreadModel.getInstance().buildChannelId(groupNo, entity.short_id);
+        // 乐观 UI: 立即 navigate, join 请求后台异步完成 (对齐 iOS 语义但去掉等待)。
+        // - 归档子区: server 会拒 join(慢/超时), 不阻塞进入; 用户仍能看历史消息。
+        // - 活跃未加入子区: join 成功后 is_joined=1, 下次点击走快路径。
+        // - 已加入子区: 跳过 join, 直接进入。
         if (entity.is_joined == 0) {
             ThreadModel.getInstance().joinThread(groupNo, entity.short_id, (code, msg) -> {
-                if (code == HttpResponseCode.success) {
-                    navigateToChat(channelId);
-                } else {
-                    WKToastUtils.getInstance().showToast(msg);
-                }
+                // fire-and-forget: navigate 已提前触发, join 结果无需处理。
             });
-        } else {
-            navigateToChat(channelId);
         }
+        navigateToChat(channelId);
     }
 
     private void navigateToChat(String channelId) {
@@ -189,7 +230,27 @@ public class ThreadListActivity extends WKBaseActivity<ActThreadListLayoutBindin
 
     private void refreshFromFirstPage() {
         currentPage = 1;
+        allLoadedList.clear();
+        adapter.setList(new ArrayList<>());
+        wkVBinding.refreshLayout.setNoMoreData(false);
         loadData();
+    }
+
+    /**
+     * 是否有权归档/取消归档/删除该子区。对齐 iOS WKThreadListVC.canManageThread:
+     * 子区创建者 OR 父群群主/管理员均可操作，与服务端 canOperate 一致。
+     */
+    private boolean canManageThread(ThreadEntity entity) {
+        String currentUid = WKConfig.getInstance().getUid();
+        if (currentUid != null && currentUid.equals(entity.creator_uid)) {
+            return true;
+        }
+        if (currentUid == null || groupNo == null) return false;
+        WKChannelMember member = WKIM.getInstance().getChannelMembersManager()
+                .getMember(groupNo, WKChannelType.GROUP, currentUid);
+        if (member == null) return false;
+        return member.role == WKChannelMemberRole.admin
+                || member.role == WKChannelMemberRole.manager;
     }
 
     private void showThreadPopup(View anchorView, ThreadEntity entity) {
@@ -217,12 +278,20 @@ public class ThreadListActivity extends WKBaseActivity<ActThreadListLayoutBindin
                     }
                 }));
 
-        String currentUid = com.chat.base.config.WKConfig.getInstance().getUid();
-        if (currentUid.equals(entity.creator_uid)) {
+        if (canManageThread(entity)) {
             if (entity.status == 1) {
+                // 活跃 → 显示"归档"
                 menuItems.add(new PopupMenuItem(
                         getString(R.string.str_archive_thread), R.mipmap.msg_delete,
                         () -> ThreadModel.getInstance().archiveThread(groupNo, entity.short_id, (code, msg) -> {
+                            if (code == HttpResponseCode.success) refreshFromFirstPage();
+                            else WKToastUtils.getInstance().showToast(msg);
+                        })));
+            } else if (entity.status == 2) {
+                // 已归档 → 显示"取消归档"
+                menuItems.add(new PopupMenuItem(
+                        getString(R.string.str_unarchive_thread), R.mipmap.msg_delete,
+                        () -> ThreadModel.getInstance().unarchiveThread(groupNo, entity.short_id, (code, msg) -> {
                             if (code == HttpResponseCode.success) refreshFromFirstPage();
                             else WKToastUtils.getInstance().showToast(msg);
                         })));

--- a/wkuikit/src/main/java/com/chat/uikit/thread/service/ThreadModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/thread/service/ThreadModel.java
@@ -72,17 +72,17 @@ public class ThreadModel extends WKBaseModel {
     }
 
     /**
-     * 获取子区列表（全量，兼容旧调用）
+     * 获取子区列表（全量，兼容旧调用；不带 status → 服务端返回全量，行为与本次改动前一致）
      */
     public void listThreads(String groupNo, IThreadListListener listener) {
-        listThreads(groupNo, 1, 10000, listener);
+        listThreads(groupNo, null, 1, 10000, listener);
     }
 
     /**
-     * 获取子区列表（单页，用于列表分页加载）
+     * 获取子区列表（按 status 分页，status 传 "active" 或 "archived"）
      */
-    public void listThreads(String groupNo, int page, int limit, IThreadListListener listener) {
-        request(createService(ThreadService.class).listThreads(groupNo, page, limit), new IRequestResultListener<>() {
+    public void listThreads(String groupNo, String status, int page, int limit, IThreadListListener listener) {
+        request(createService(ThreadService.class).listThreads(groupNo, status, page, limit), new IRequestResultListener<>() {
             @Override
             public void onSuccess(List<ThreadEntity> result) {
                 listener.onResult(HttpResponseCode.success, "", result);

--- a/wkuikit/src/main/java/com/chat/uikit/thread/service/ThreadService.java
+++ b/wkuikit/src/main/java/com/chat/uikit/thread/service/ThreadService.java
@@ -36,7 +36,7 @@ import retrofit2.http.Query;
 public interface ThreadService {
 
     @GET("groups/{groupNo}/threads")
-    Observable<List<ThreadEntity>> listThreads(@Path("groupNo") String groupNo, @Query("page") int page, @Query("limit") int limit);
+    Observable<List<ThreadEntity>> listThreads(@Path("groupNo") String groupNo, @Query("status") String status, @Query("page") int page, @Query("limit") int limit);
 
     @POST("groups/{groupNo}/threads")
     Observable<ThreadEntity> createThread(@Path("groupNo") String groupNo, @Body JSONObject body);

--- a/wkuikit/src/main/java/com/chat/uikit/thread/service/entity/ThreadEntity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/thread/service/entity/ThreadEntity.java
@@ -25,7 +25,7 @@ public class ThreadEntity implements Parcelable {
     public String name;
     public String creator_uid;
     public String creator_name;
-    public int status; // 0=active, 1=archived, 2=deleted
+    public int status; // 1=active, 2=archived, 3=deleted
     public int member_count;
     public int message_count;
     public String source_message_id;

--- a/wkuikit/src/main/res/layout/act_thread_list_layout.xml
+++ b/wkuikit/src/main/res/layout/act_thread_list_layout.xml
@@ -48,22 +48,36 @@
                 <androidx.appcompat.widget.AppCompatImageView style="@style/arrow_right_iv" />
             </LinearLayout>
 
-            <!-- 分组标题 -->
-            <TextView
-                android:id="@+id/sectionTitleTv"
+            <!-- Segment tab: 活跃 / 已归档 -->
+            <FrameLayout
+                android:id="@+id/segmentTabContainer"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingHorizontal="15dp"
-                android:paddingTop="16dp"
-                android:paddingBottom="8dp"
-                android:textColor="@color/color999"
-                android:textSize="13sp" />
+                android:layout_marginHorizontal="15dp"
+                android:layout_marginTop="12dp"
+                android:layout_marginBottom="8dp" />
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recyclerView"
+            <FrameLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@color/transparent" />
+                android:layout_height="match_parent">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/recyclerView"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="@color/transparent" />
+
+                <TextView
+                    android:id="@+id/emptyTv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal|top"
+                    android:layout_marginTop="80dp"
+                    android:paddingHorizontal="15dp"
+                    android:textColor="@color/color999"
+                    android:textSize="14sp"
+                    android:visibility="gone" />
+            </FrameLayout>
         </LinearLayout>
 
     </com.scwang.smart.refresh.layout.SmartRefreshLayout>

--- a/wkuikit/src/main/res/values-en/strings.xml
+++ b/wkuikit/src/main/res/values-en/strings.xml
@@ -402,6 +402,10 @@
 
     <!-- i18n: Thread list -->
     <string name="joined_threads_count">Joined Threads - %d</string>
+    <string name="str_thread_tab_active">Active</string>
+    <string name="str_thread_tab_archived">Archived</string>
+    <string name="str_no_active_threads">No active threads</string>
+    <string name="str_no_archived_threads">No archived threads</string>
 
     <!-- i18n: My fragment -->
     <string name="short_no_format">%1$s ID: %2$s</string>

--- a/wkuikit/src/main/res/values/strings.xml
+++ b/wkuikit/src/main/res/values/strings.xml
@@ -427,6 +427,10 @@
     <string name="str_archive_thread">归档子区</string>
     <string name="str_unarchive_thread">取消归档</string>
     <string name="str_delete_thread">删除子区</string>
+    <string name="str_thread_tab_active">活跃</string>
+    <string name="str_thread_tab_archived">已归档</string>
+    <string name="str_no_active_threads">暂无活跃子区</string>
+    <string name="str_no_archived_threads">暂无已归档子区</string>
     <string name="str_thread_members">子区成员</string>
     <string name="str_thread_archived_tip">该子区已归档</string>
     <string name="str_thread_deleted_tip">该子区已删除</string>


### PR DESCRIPTION
## Summary

- **fix(thread-list)**: Android 子区列表加"活跃 / 已归档" segment tab，能看到并操作已归档子区，对齐 iOS/web
- **perf(conversation)**: sort comparator 退回 `lastMsgTimestamp` 直读，修从聊天页返回主会话列表卡顿 + 首次点击 item 无响应

Closes #103

## 背景

之前 Android 端子区列表 UI 只显示活跃子区，客户端硬过滤 `status==1` 直接把归档子区丢掉，用户在 web/iOS 能看到但 Android 看不到已归档子区（#103）。

## 详细改动

### Commit 1：`fix(thread-list): 加"活跃 / 已归档" segment tab`

对齐 iOS `WKThreadListVC`：
- `ThreadService.listThreads` 加 `@Query("status") String status`；旧 `listThreads(groupNo, listener)` 内部传 `null` 保持其它调用点行为不变（**零回归风险**：ChatActivity / ChooseChatActivity / ChatConversationAdapter 都不受影响）
- `ThreadListActivity` 加 `SegmentTabView`（活跃 / 已归档），切 tab 完全 reset + 只拉当前 tab 首页
- 加 `loadGeneration` 令牌防飞行中切 tab 串数据（stale response 直接丢弃）
- 去掉客户端 `status==1` 过滤，服务端已按 status 各自分页
- popup 权限对齐 iOS `canManageThread`（创建者 OR 群主/管理员均可归档/取消归档/删除）
- 归档 tab 显示"取消归档"，活跃 tab 显示"归档"
- `openThread` 改成**乐观 UI**：立即 `navigateToChat`，`joinThread` 后台 fire-and-forget
  - 归档子区：server 会拒 join（"子区不是活跃状态"），但用户仍能进入看历史消息
  - 活跃未加入子区：join 成功后 `is_joined` 自动更新，下次点击走快路径
- 空态文案按 tab 切换（"暂无活跃子区" / "暂无已归档子区"）
- `ThreadEntity.status` 注释修正（`1=active, 2=archived, 3=deleted`，之前写错成 `0/1/2`）

### Commit 2：`perf(conversation): sort comparator 退回 lastMsgTimestamp 直读`

PR #102 里 `ChatFragment` 两处 `Collections.sort` 换成走 `ConversationPreviewSelector.selectDisplayTimestamp`，本意让 SystemBot 排序和 preview 同源；但 selector 在 `PERSONAL + 多 Space + BotFather` 分支会走 DB 分页（最多 5×200=1000 条），排序 N 项 = O(N log N) 次 DB 查询在主线程执行 → 从聊天页返回时 `onResume` 触发一次大列表 sort 就整列表卡死几秒，且首次点击 item 常无响应（触摸事件调度被主线程阻塞挤掉）。

**真机日志证实**（用 `YUJ276-trace` 抓 8 次连测）：修复后从点击到 `onResume` 完成平均 250ms，比 iOS 都快。

- `ChatFragment`：`sortMsg` + `filterAndSort` 两处 comparator 退回 `b.uiConversationMsg.lastMsgTimestamp` 直读（O(1)），字节级恢复 pre-PR-102 行为
- `ChatConversationAdapter`：整个文件 revert 到 pre-PR-102（PR #102 对该文件 135 行改动 **100% 属于 selector 相关**，per-bind 缓存 + `getRenderWkMsg` 转 selector，无交互卡等其它功能相关代码 —— 已 grep 逐条 verify）

### 未回退的 PR #102 功能

- ✅ 交互式卡片（type=17）渲染 / Submit / OpenUrl / Copy 全部保留
- ✅ WebView 承接消息 URL（自家域名 token 免登）保留
- ✅ `ConversationPreviewFilter.isMessageCrossSpace` 收窄到只 BotFather 保留（通知助手 u_10000 等预览显示正常）

### 有意回退的（可接受，pre-PR-102 就是这样）

- ⚠️ `ConversationPreviewSelector` 的 BotFather 跨 Space DB fallback 高级功能失效（selector 类还在但已无生产调用者），只影响 BotFather + 跨 Space 边缘场景
- 待后续给 selector 加 channel-scoped LRU cache + SDK conversation listener invalidate 后可恢复走 selector（selector 类文档里作者已预留 TODO）

## 关联发现（另开 issue，不属本 PR）

- **#104**：Android 会话列表最近 tab 会显示已归档子区（iOS 已过滤）—— pre-existing bug，跨 `ChatFragment` 多处，单独修
- **后端 500 内部错误**：archive/unarchive 接口连续调用有 4xx race（同 request 4 秒内 400→200），已上报后端；客户端接口与 iOS 100% 一致（`POST groups/{groupNo}/threads/{shortId}/archive` 无 body）

## Test plan

- [x] 子区列表：活跃 / 已归档 tab 切换能看到对应子区
- [x] 归档子区可点击进入（fire-and-forget join，秒进）
- [x] 长按已归档子区显示"取消归档"，创建者/群管理员均可操作
- [x] 主会话列表最近 tab：从聊天页返回不卡，滑动流畅
- [x] 首次点击 item 秒响应（8 次真机连测，平均 250ms 完成 `onResume`）
- [ ] 交互卡（type=17）依然能渲染 / Submit / OpenUrl（回归验证）
- [ ] WebView URL handoff 自家域名 token 免登（回归验证）
- [ ] 通知助手 u_10000 会话预览显示正常（回归验证）
- [ ] API 26+ 真机测试