### PR TITLE
fix(card): 支持 data URI 图片，修 Reasoning 卡折叠箭头不可见 (#117)

### DIFF
--- a/wkuikit/src/debug/assets/interactive_cards/ai.reasoning-process/goldens/answering.card.json
+++ b/wkuikit/src/debug/assets/interactive_cards/ai.reasoning-process/goldens/answering.card.json
@@ -1,696 +1,935 @@
 {
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-  "type": "AdaptiveCard",
-  "version": "1.5",
   "body": [
     {
-      "type": "Container",
-      "id": "octo-surface-accent-header-reasoning-active",
-      "style": "accent",
       "bleed": true,
-      "spacing": "None",
       "items": [
         {
-          "type": "ColumnSet",
-          "spacing": "None",
           "columns": [
             {
-              "type": "Column",
-              "width": "stretch",
-              "verticalContentAlignment": "Center",
               "items": [
                 {
-                  "type": "TextBlock",
-                  "text": "✦  已深度思考",
-                  "color": "Accent",
-                  "weight": "Bolder",
-                  "wrap": true,
-                  "spacing": "None"
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "深度思考",
+                          "type": "TextBlock",
+                          "weight": "Bolder",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "width": "auto"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开",
+                          "id": "reasoning_toggle_collapsed",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_toggle",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起",
+                          "id": "reasoning_toggle_expanded",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_toggle_expanded_action",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
                 },
                 {
-                  "type": "TextBlock",
-                  "text": "正在生成回答…",
+                  "color": "Accent",
                   "size": "Small",
-                  "isSubtle": true,
-                  "wrap": true,
-                  "spacing": "Small"
-                }
-              ]
-            },
-            {
-              "type": "Column",
-              "width": "auto",
-              "verticalContentAlignment": "Center",
-              "items": [
-                {
-                  "type": "TextBlock",
-                  "id": "octo-badge-reasoning-active-status",
+                  "spacing": "None",
                   "text": "回答中",
-                  "color": "Accent",
-                  "weight": "Bolder",
-                  "size": "Small",
-                  "wrap": true,
-                  "spacing": "None"
+                  "type": "TextBlock",
+                  "wrap": true
                 }
-              ]
+              ],
+              "type": "Column",
+              "width": "stretch"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "trace_panel",
-      "isVisible": true,
-      "spacing": "Large",
-      "items": [
-        {
-          "type": "Container",
+          ],
+          "id": "reasoning_header",
           "spacing": "None",
-          "separator": false,
-          "items": [
-            {
-              "type": "TextBlock",
-              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
-              "size": "Small",
-              "wrap": true,
-              "spacing": "None"
-            },
-            {
-              "type": "Container",
-              "style": "emphasis",
-              "spacing": "Small",
-              "items": [
-                {
-                  "type": "ColumnSet",
-                  "spacing": "None",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "query_metrics",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "channel=B · range=90d · group=stage",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "read_file",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "~/analytics/funnel_definition.sql · ×2",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "run_sql",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "按漏斗阶段汇总数量与转化率",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
+          "type": "ColumnSet"
         },
         {
-          "type": "Container",
-          "spacing": "Large",
-          "separator": true,
+          "id": "trace_panel",
+          "isVisible": true,
           "items": [
             {
-              "type": "TextBlock",
-              "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
-              "size": "Small",
-              "wrap": true,
-              "spacing": "None"
-            },
-            {
-              "type": "Container",
-              "style": "emphasis",
-              "spacing": "Small",
+              "id": "reasoning_phase_0",
               "items": [
                 {
-                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_0",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_0",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
                   "spacing": "None",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "query_metrics",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "按行业拆分激活率",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
+                  "type": "ColumnSet"
                 },
                 {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
+                  "id": "reasoning_tools_panel_0",
+                  "isVisible": false,
+                  "items": [
                     {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
+                      "columns": [
                         {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "channel=B · range=90d · group=stage",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
                         }
-                      ]
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
                     },
                     {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
+                      "columns": [
                         {
-                          "type": "TextBlock",
-                          "text": "search_tickets",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/analytics/funnel_definition.sql · ×2",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
                         }
-                      ]
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
                     },
                     {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
+                      "columns": [
                         {
-                          "type": "TextBlock",
-                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按漏斗阶段汇总数量与转化率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
                         }
-                      ]
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
                     }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
+                  ],
                   "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "read_file",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "~/nps/2026Q2_channelB.csv",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "query_metrics",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "叠加节假日与季节性校正",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
+                  "type": "Container"
                 }
-              ]
+              ],
+              "spacing": "None",
+              "type": "Container"
+            },
+            {
+              "id": "reasoning_phase_1",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_1",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_1",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_1",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按行业拆分激活率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "search_tickets",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/nps/2026Q2_channelB.csv",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "叠加节假日与季节性校正",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "Small",
+              "type": "Container"
+            },
+            {
+              "id": "reasoning_phase_2",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_2",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_2",
+                            "targetElements": [
+                              "reasoning_tools_panel_2",
+                              "reasoning_tools_toggle_collapsed_2",
+                              "reasoning_tools_toggle_expanded_2"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_2",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_2",
+                            "targetElements": [
+                              "reasoning_tools_panel_2",
+                              "reasoning_tools_toggle_collapsed_2",
+                              "reasoning_tools_toggle_expanded_2"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_2",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按行业汇总转化降幅贡献",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "edit_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/reports/channelB_rootcause.md · 已编辑",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Accent",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "think",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "正在组织结论、证据与下周建议…",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "Small",
+              "type": "Container"
+            },
+            {
+              "color": "Accent",
+              "size": "Small",
+              "spacing": "Medium",
+              "text": "◌  推理已完成，正在生成回答…",
+              "type": "TextBlock",
+              "wrap": true
             }
-          ]
+          ],
+          "spacing": "Medium",
+          "type": "Container"
         },
         {
-          "type": "Container",
-          "spacing": "Large",
-          "separator": true,
+          "id": "collapsed_panel",
+          "isVisible": false,
           "items": [
             {
-              "type": "TextBlock",
-              "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+              "isSubtle": true,
               "size": "Small",
-              "wrap": true,
-              "spacing": "None"
-            },
-            {
-              "type": "Container",
-              "style": "emphasis",
-              "spacing": "Small",
-              "items": [
-                {
-                  "type": "ColumnSet",
-                  "spacing": "None",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "run_sql",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "按行业汇总转化降幅贡献",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "edit_file",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "~/reports/channelB_rootcause.md · 已编辑",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Accent",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "think",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "正在组织结论、证据与下周建议…",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
+              "spacing": "None",
+              "text": "正在生成回答",
+              "type": "TextBlock",
+              "wrap": true
             }
-          ]
-        },
-        {
-          "type": "TextBlock",
-          "text": "◌  推理已完成，正在生成回答…",
-          "color": "Accent",
-          "size": "Small",
-          "wrap": true,
-          "spacing": "Large"
+          ],
+          "spacing": "Small",
+          "type": "Container"
         }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "collapsed_panel",
-      "isVisible": false,
-      "spacing": "Medium",
-      "items": [
-        {
-          "type": "TextBlock",
-          "text": "✓  推理已完成 · 回答正在生成",
-          "size": "Small",
-          "isSubtle": true,
-          "wrap": true,
-          "spacing": "None"
-        }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "octo-surface-default-footer-reasoning-active",
+      ],
+      "spacing": "None",
       "style": "emphasis",
-      "bleed": true,
-      "separator": true,
-      "spacing": "Large",
-      "items": [
-        {
-          "type": "ActionSet",
-          "horizontalAlignment": "Right",
-          "actions": [
-            {
-              "type": "Action.Submit",
-              "id": "reasoning_stop",
-              "title": "停止",
-              "style": "destructive",
-              "associatedInputs": "none",
-              "data": {
-                "action": "reasoning_stop",
-                "effect": "stop_reasoning",
-                "reasoning_id": "reasoning-channel-b-001",
-                "owner": "ai",
-                "action_type": "reasoning.control"
-              }
-            },
-            {
-              "type": "Action.ToggleVisibility",
-              "id": "reasoning_toggle",
-              "title": "显示 / 隐藏推理",
-              "targetElements": [
-                "trace_panel",
-                "collapsed_panel"
-              ]
-            }
-          ]
-        }
-      ]
+      "type": "Container"
     }
-  ]
+  ],
+  "type": "AdaptiveCard",
+  "version": "1.5"
 }

--- a/wkuikit/src/debug/assets/interactive_cards/ai.reasoning-process/goldens/completed.card.json
+++ b/wkuikit/src/debug/assets/interactive_cards/ai.reasoning-process/goldens/completed.card.json
@@ -1,784 +1,1095 @@
 {
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-  "type": "AdaptiveCard",
-  "version": "1.5",
   "body": [
     {
-      "type": "Container",
-      "id": "octo-surface-accent-header-reasoning-result",
-      "style": "accent",
       "bleed": true,
-      "spacing": "None",
       "items": [
         {
-          "type": "ColumnSet",
-          "spacing": "None",
           "columns": [
             {
-              "type": "Column",
-              "width": "stretch",
               "items": [
                 {
-                  "type": "TextBlock",
-                  "text": "✦  已深度思考",
-                  "color": "Accent",
-                  "weight": "Bolder",
-                  "wrap": true,
-                  "spacing": "None"
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "深度思考",
+                          "type": "TextBlock",
+                          "weight": "Bolder",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "width": "auto"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开",
+                          "id": "reasoning_toggle_collapsed",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_toggle",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起",
+                          "id": "reasoning_toggle_expanded",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_toggle_expanded_action",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
                 },
                 {
-                  "type": "TextBlock",
-                  "text": "用时 12 秒 · 3 段推理 · 13 次工具调用",
-                  "size": "Small",
-                  "isSubtle": true,
-                  "wrap": true,
-                  "spacing": "Small"
-                }
-              ]
-            },
-            {
-              "type": "Column",
-              "width": "auto",
-              "verticalContentAlignment": "Center",
-              "items": [
-                {
-                  "type": "TextBlock",
-                  "id": "octo-badge-reasoning-result-status",
-                  "text": "已完成",
                   "color": "Good",
-                  "weight": "Bolder",
                   "size": "Small",
-                  "wrap": true,
-                  "spacing": "None"
+                  "spacing": "None",
+                  "text": "已完成",
+                  "type": "TextBlock",
+                  "wrap": true
                 }
-              ]
+              ],
+              "type": "Column",
+              "width": "stretch"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "trace_panel",
-      "isVisible": false,
-      "spacing": "Large",
-      "items": [
-        {
-          "type": "Container",
+          ],
+          "id": "reasoning_header",
           "spacing": "None",
-          "separator": false,
-          "items": [
-            {
-              "type": "TextBlock",
-              "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
-              "size": "Small",
-              "wrap": true,
-              "spacing": "None"
-            },
-            {
-              "type": "Container",
-              "style": "emphasis",
-              "spacing": "Small",
-              "items": [
-                {
-                  "type": "ColumnSet",
-                  "spacing": "None",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "query_metrics",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "channel=B · range=90d · group=stage",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "read_file",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "~/analytics/funnel_definition.sql · ×2",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "run_sql",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "按漏斗阶段汇总数量与转化率",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
+          "type": "ColumnSet"
         },
         {
-          "type": "Container",
-          "spacing": "Large",
-          "separator": true,
+          "id": "trace_panel",
+          "isVisible": false,
           "items": [
             {
-              "type": "TextBlock",
-              "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
-              "size": "Small",
-              "wrap": true,
-              "spacing": "None"
-            },
-            {
-              "type": "Container",
-              "style": "emphasis",
-              "spacing": "Small",
+              "id": "reasoning_phase_0",
               "items": [
                 {
-                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_0",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_0",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
                   "spacing": "None",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "query_metrics",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "按行业拆分激活率",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
+                  "type": "ColumnSet"
                 },
                 {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
+                  "id": "reasoning_tools_panel_0",
+                  "isVisible": false,
+                  "items": [
                     {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
+                      "columns": [
                         {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "channel=B · range=90d · group=stage",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
                         }
-                      ]
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
                     },
                     {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
+                      "columns": [
                         {
-                          "type": "TextBlock",
-                          "text": "run_sql",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/analytics/funnel_definition.sql · ×2",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
                         }
-                      ]
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
                     },
                     {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
+                      "columns": [
                         {
-                          "type": "TextBlock",
-                          "text": "对比各行业激活与付费转化",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按漏斗阶段汇总数量与转化率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
                         }
-                      ]
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
                     }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
+                  ],
                   "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "search_tickets",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "read_file",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "~/nps/2026Q2_channelB.csv",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "query_metrics",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "叠加节假日与季节性校正",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "run_sql",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "逐周复核线索与激活数量",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "web_search",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "SaaS 行业 2026 试用政策调整",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
+                  "type": "Container"
                 }
-              ]
+              ],
+              "spacing": "None",
+              "type": "Container"
+            },
+            {
+              "id": "reasoning_phase_1",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "激活率的降幅高于线索量，交叉核验行业结构、客服工单、NPS 与季节性。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_1",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_1",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_1",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按行业拆分激活率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "对比各行业激活与付费转化",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "search_tickets",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/nps/2026Q2_channelB.csv",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "叠加节假日与季节性校正",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "逐周复核线索与激活数量",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "web_search",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "SaaS 行业 2026 试用政策调整",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "Small",
+              "type": "Container"
+            },
+            {
+              "id": "reasoning_phase_2",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_2",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_2",
+                            "targetElements": [
+                              "reasoning_tools_panel_2",
+                              "reasoning_tools_toggle_collapsed_2",
+                              "reasoning_tools_toggle_expanded_2"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_2",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_2",
+                            "targetElements": [
+                              "reasoning_tools_panel_2",
+                              "reasoning_tools_toggle_collapsed_2",
+                              "reasoning_tools_toggle_expanded_2"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_2",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按行业汇总转化降幅贡献",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "edit_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/reports/channelB_rootcause.md · 已编辑",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "think",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "拆分行业漏斗深挖与权益触达复盘",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "Small",
+              "type": "Container"
             }
-          ]
+          ],
+          "spacing": "Medium",
+          "type": "Container"
         },
         {
-          "type": "Container",
-          "spacing": "Large",
-          "separator": true,
+          "id": "collapsed_panel",
+          "isVisible": true,
           "items": [
             {
-              "type": "TextBlock",
-              "text": "主因确认：教育与专业服务合计贡献 63% 降幅，激活断点集中在试用权益触达。",
+              "isSubtle": true,
               "size": "Small",
-              "wrap": true,
-              "spacing": "None"
-            },
-            {
-              "type": "Container",
-              "style": "emphasis",
-              "spacing": "Small",
-              "items": [
-                {
-                  "type": "ColumnSet",
-                  "spacing": "None",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "run_sql",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "按行业汇总转化降幅贡献",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "edit_file",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "~/reports/channelB_rootcause.md · 已编辑",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "think",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "拆分行业漏斗深挖与权益触达复盘",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
+              "spacing": "None",
+              "text": "已思考 12 秒",
+              "type": "TextBlock",
+              "wrap": true
             }
-          ]
+          ],
+          "spacing": "Small",
+          "type": "Container"
         }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "collapsed_panel",
-      "isVisible": true,
-      "spacing": "Medium",
-      "items": [
-        {
-          "type": "TextBlock",
-          "text": "✓  已思考 12 秒 · 推理过程已收起",
-          "size": "Small",
-          "isSubtle": true,
-          "wrap": true,
-          "spacing": "None"
-        }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "octo-surface-default-footer-reasoning-result",
+      ],
+      "spacing": "None",
       "style": "emphasis",
-      "bleed": true,
-      "separator": true,
-      "spacing": "Large",
-      "items": [
-        {
-          "type": "ActionSet",
-          "horizontalAlignment": "Right",
-          "actions": [
-            {
-              "type": "Action.ToggleVisibility",
-              "id": "reasoning_toggle",
-              "title": "显示 / 隐藏推理",
-              "targetElements": [
-                "trace_panel",
-                "collapsed_panel"
-              ]
-            }
-          ]
-        }
-      ]
+      "type": "Container"
     }
-  ]
+  ],
+  "type": "AdaptiveCard",
+  "version": "1.5"
 }

--- a/wkuikit/src/debug/assets/interactive_cards/ai.reasoning-process/goldens/error.card.json
+++ b/wkuikit/src/debug/assets/interactive_cards/ai.reasoning-process/goldens/error.card.json
@@ -1,422 +1,588 @@
 {
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-  "type": "AdaptiveCard",
-  "version": "1.5",
   "body": [
     {
-      "type": "Container",
-      "id": "octo-surface-accent-header-reasoning-error",
-      "style": "accent",
       "bleed": true,
-      "spacing": "None",
       "items": [
         {
-          "type": "ColumnSet",
-          "spacing": "None",
           "columns": [
             {
-              "type": "Column",
-              "width": "stretch",
               "items": [
                 {
-                  "type": "TextBlock",
-                  "text": "✦  已深度思考",
-                  "color": "Accent",
-                  "weight": "Bolder",
-                  "wrap": true,
-                  "spacing": "None"
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "深度思考",
+                          "type": "TextBlock",
+                          "weight": "Bolder",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "width": "auto"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开",
+                          "id": "reasoning_toggle_collapsed",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_toggle",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起",
+                          "id": "reasoning_toggle_expanded",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_toggle_expanded_action",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
                 },
                 {
-                  "type": "TextBlock",
-                  "text": "已中断",
-                  "size": "Small",
-                  "isSubtle": true,
-                  "wrap": true,
-                  "spacing": "Small"
-                }
-              ]
-            },
-            {
-              "type": "Column",
-              "width": "auto",
-              "verticalContentAlignment": "Center",
-              "items": [
-                {
-                  "type": "TextBlock",
-                  "id": "octo-badge-reasoning-error-status",
-                  "text": "生成失败",
                   "color": "Attention",
-                  "weight": "Bolder",
                   "size": "Small",
-                  "wrap": true,
-                  "spacing": "None"
+                  "spacing": "None",
+                  "text": "生成失败",
+                  "type": "TextBlock",
+                  "wrap": true
                 }
-              ]
+              ],
+              "type": "Column",
+              "width": "stretch"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "trace_panel",
-      "isVisible": true,
-      "spacing": "Large",
-      "items": [
-        {
-          "type": "Container",
+          ],
+          "id": "reasoning_header",
           "spacing": "None",
-          "separator": false,
-          "items": [
-            {
-              "type": "TextBlock",
-              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
-              "size": "Small",
-              "wrap": true,
-              "spacing": "None"
-            },
-            {
-              "type": "Container",
-              "style": "emphasis",
-              "spacing": "Small",
-              "items": [
-                {
-                  "type": "ColumnSet",
-                  "spacing": "None",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "query_metrics",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "channel=B · range=90d · group=stage",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "read_file",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "~/analytics/funnel_definition.sql · ×2",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "run_sql",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "按漏斗阶段汇总数量与转化率",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
+          "type": "ColumnSet"
         },
         {
-          "type": "Container",
-          "spacing": "Large",
-          "separator": true,
+          "id": "trace_panel",
+          "isVisible": true,
           "items": [
             {
-              "type": "TextBlock",
-              "text": "准备交叉核验行业结构、客服工单与 NPS 时，推理服务连接中断。",
-              "size": "Small",
-              "wrap": true,
-              "spacing": "None"
-            },
-            {
-              "type": "Container",
-              "style": "emphasis",
-              "spacing": "Small",
+              "id": "reasoning_phase_0",
               "items": [
                 {
-                  "type": "ColumnSet",
-                  "spacing": "None",
                   "columns": [
                     {
-                      "type": "Column",
-                      "width": "auto",
                       "items": [
                         {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
                           "size": "Small",
-                          "spacing": "None"
+                          "spacing": "None",
+                          "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+                          "type": "TextBlock",
+                          "wrap": true
                         }
-                      ]
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
                     },
                     {
-                      "type": "Column",
-                      "width": "auto",
                       "items": [
                         {
-                          "type": "TextBlock",
-                          "text": "query_metrics",
-                          "weight": "Bolder",
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_0",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
                           "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
                         {
-                          "type": "TextBlock",
-                          "text": "按行业拆分激活率",
-                          "isSubtle": true,
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_0",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
                           "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
                         }
-                      ]
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
                     }
-                  ]
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
                 },
                 {
-                  "type": "ColumnSet",
+                  "id": "reasoning_tools_panel_0",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "channel=B · range=90d · group=stage",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/analytics/funnel_definition.sql · ×2",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按漏斗阶段汇总数量与转化率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
                   "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "None",
+              "type": "Container"
+            },
+            {
+              "id": "reasoning_phase_1",
+              "items": [
+                {
                   "columns": [
                     {
-                      "type": "Column",
-                      "width": "auto",
                       "items": [
                         {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Attention",
                           "size": "Small",
-                          "spacing": "None"
+                          "spacing": "None",
+                          "text": "准备交叉核验行业结构、客服工单与 NPS 时，推理服务连接中断。",
+                          "type": "TextBlock",
+                          "wrap": true
                         }
-                      ]
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
                     },
                     {
-                      "type": "Column",
-                      "width": "auto",
                       "items": [
                         {
-                          "type": "TextBlock",
-                          "text": "search_tickets",
-                          "weight": "Bolder",
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_1",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
                           "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
                         {
-                          "type": "TextBlock",
-                          "text": "连接超时，调用未完成",
-                          "isSubtle": true,
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_1",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
                           "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
                         }
-                      ]
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
                     }
-                  ]
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_1",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按行业拆分激活率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Attention",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "search_tickets",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "连接超时，调用未完成",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
                 }
-              ]
+              ],
+              "spacing": "Small",
+              "type": "Container"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "collapsed_panel",
-      "isVisible": false,
-      "spacing": "Medium",
-      "items": [
-        {
-          "type": "TextBlock",
-          "text": "生成已中断 · 点击可查看停止前的过程",
-          "size": "Small",
-          "isSubtle": true,
-          "wrap": true,
-          "spacing": "None"
-        }
-      ]
-    },
-    {
-      "type": "Container",
-      "style": "attention",
-      "spacing": "Large",
-      "items": [
-        {
-          "type": "TextBlock",
-          "text": "生成失败",
-          "color": "Attention",
-          "weight": "Bolder",
-          "wrap": true,
-          "spacing": "None"
+          ],
+          "spacing": "Medium",
+          "type": "Container"
         },
         {
-          "type": "TextBlock",
-          "text": "推理服务连接超时，已停止本次生成。可以重试，已完成的过程会保留。",
-          "wrap": true,
-          "spacing": "Small"
+          "id": "collapsed_panel",
+          "isVisible": false,
+          "items": [
+            {
+              "isSubtle": true,
+              "size": "Small",
+              "spacing": "None",
+              "text": "生成已中断",
+              "type": "TextBlock",
+              "wrap": true
+            }
+          ],
+          "spacing": "Small",
+          "type": "Container"
+        },
+        {
+          "items": [
+            {
+              "color": "Attention",
+              "spacing": "None",
+              "text": "生成失败",
+              "type": "TextBlock",
+              "weight": "Bolder",
+              "wrap": true
+            },
+            {
+              "spacing": "Small",
+              "text": "推理服务连接超时，本次生成已结束。已完成的过程会保留。",
+              "type": "TextBlock",
+              "wrap": true
+            }
+          ],
+          "spacing": "Medium",
+          "style": "attention",
+          "type": "Container"
         }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "octo-surface-default-footer-reasoning-error",
+      ],
+      "spacing": "None",
       "style": "emphasis",
-      "bleed": true,
-      "separator": true,
-      "spacing": "Large",
-      "items": [
-        {
-          "type": "ActionSet",
-          "horizontalAlignment": "Right",
-          "actions": [
-            {
-              "type": "Action.Submit",
-              "id": "reasoning_retry",
-              "title": "重试",
-              "style": "positive",
-              "associatedInputs": "none",
-              "data": {
-                "action": "reasoning_retry",
-                "effect": "retry_reasoning",
-                "reasoning_id": "reasoning-channel-b-003",
-                "owner": "ai",
-                "action_type": "reasoning.control"
-              }
-            },
-            {
-              "type": "Action.ToggleVisibility",
-              "id": "reasoning_toggle",
-              "title": "显示 / 隐藏推理",
-              "targetElements": [
-                "trace_panel",
-                "collapsed_panel"
-              ]
-            }
-          ]
-        }
-      ]
+      "type": "Container"
     }
-  ]
+  ],
+  "type": "AdaptiveCard",
+  "version": "1.5"
 }

--- a/wkuikit/src/debug/assets/interactive_cards/ai.reasoning-process/goldens/reasoning.card.json
+++ b/wkuikit/src/debug/assets/interactive_cards/ai.reasoning-process/goldens/reasoning.card.json
@@ -1,525 +1,687 @@
 {
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-  "type": "AdaptiveCard",
-  "version": "1.5",
   "body": [
     {
-      "type": "Container",
-      "id": "octo-surface-accent-header-reasoning-active",
-      "style": "accent",
       "bleed": true,
-      "spacing": "None",
       "items": [
         {
-          "type": "ColumnSet",
-          "spacing": "None",
           "columns": [
             {
-              "type": "Column",
-              "width": "stretch",
-              "verticalContentAlignment": "Center",
               "items": [
                 {
-                  "type": "TextBlock",
-                  "text": "✦  已深度思考",
-                  "color": "Accent",
-                  "weight": "Bolder",
-                  "wrap": true,
-                  "spacing": "None"
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "深度思考",
+                          "type": "TextBlock",
+                          "weight": "Bolder",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "width": "auto"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开",
+                          "id": "reasoning_toggle_collapsed",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_toggle",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起",
+                          "id": "reasoning_toggle_expanded",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_toggle_expanded_action",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
                 },
                 {
-                  "type": "TextBlock",
-                  "text": "正在深度思考…",
+                  "color": "Accent",
                   "size": "Small",
-                  "isSubtle": true,
-                  "wrap": true,
-                  "spacing": "Small"
-                }
-              ]
-            },
-            {
-              "type": "Column",
-              "width": "auto",
-              "verticalContentAlignment": "Center",
-              "items": [
-                {
-                  "type": "TextBlock",
-                  "id": "octo-badge-reasoning-active-status",
+                  "spacing": "None",
                   "text": "思考中",
-                  "color": "Accent",
-                  "weight": "Bolder",
-                  "size": "Small",
-                  "wrap": true,
-                  "spacing": "None"
+                  "type": "TextBlock",
+                  "wrap": true
                 }
-              ]
+              ],
+              "type": "Column",
+              "width": "stretch"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "trace_panel",
-      "isVisible": true,
-      "spacing": "Large",
-      "items": [
-        {
-          "type": "Container",
+          ],
+          "id": "reasoning_header",
           "spacing": "None",
-          "separator": false,
-          "items": [
-            {
-              "type": "TextBlock",
-              "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
-              "size": "Small",
-              "wrap": true,
-              "spacing": "None"
-            },
-            {
-              "type": "Container",
-              "style": "emphasis",
-              "spacing": "Small",
-              "items": [
-                {
-                  "type": "ColumnSet",
-                  "spacing": "None",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "query_metrics",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "channel=B · range=90d · group=stage",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "read_file",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "~/analytics/funnel_definition.sql · ×2",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "run_sql",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "按漏斗阶段汇总数量与转化率",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
+          "type": "ColumnSet"
         },
         {
-          "type": "Container",
-          "spacing": "Large",
-          "separator": true,
+          "id": "trace_panel",
+          "isVisible": true,
           "items": [
             {
-              "type": "TextBlock",
-              "text": "口径正常，但激活率掉得比线索量快；继续拉行业标签、客服工单和 NPS 交叉验证。",
-              "size": "Small",
-              "wrap": true,
-              "spacing": "None"
-            },
-            {
-              "type": "Container",
-              "style": "emphasis",
-              "spacing": "Small",
+              "id": "reasoning_phase_0",
               "items": [
                 {
-                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "先把渠道 B 转化下降的范围圈出来：拆成线索、试用激活、付费三段漏斗，取近 90 天数据。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_0",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_0",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
                   "spacing": "None",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "query_metrics",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "channel=B · dims=industry · metric=activation_rate",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
+                  "type": "ColumnSet"
                 },
                 {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
+                  "id": "reasoning_tools_panel_0",
+                  "isVisible": false,
+                  "items": [
                     {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
+                      "columns": [
                         {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "channel=B · range=90d · group=stage",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
                         }
-                      ]
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
                     },
                     {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
+                      "columns": [
                         {
-                          "type": "TextBlock",
-                          "text": "search_tickets",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/analytics/funnel_definition.sql · ×2",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
                         }
-                      ]
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
                     },
                     {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
+                      "columns": [
                         {
-                          "type": "TextBlock",
-                          "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按漏斗阶段汇总数量与转化率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
                         }
-                      ]
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
                     }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
+                  ],
                   "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "read_file",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "~/nps/2026Q2_channelB.csv",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Accent",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "query_metrics",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "verticalContentAlignment": "Center",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "正在叠加季节性校正…",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
+                  "type": "Container"
                 }
-              ]
+              ],
+              "spacing": "None",
+              "type": "Container"
+            },
+            {
+              "id": "reasoning_phase_1",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "口径正常，但激活率掉得比线索量快；继续拉行业标签、客服工单和 NPS 交叉验证。",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_1",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_1",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_1",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "channel=B · dims=industry · metric=activation_rate",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "search_tickets",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "渠道 B · 试用 / 激活失败 · 近 60 天",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/nps/2026Q2_channelB.csv",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Accent",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "正在叠加季节性校正…",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "Small",
+              "type": "Container"
+            },
+            {
+              "color": "Accent",
+              "size": "Small",
+              "spacing": "Medium",
+              "text": "◌  正在执行下一步…",
+              "type": "TextBlock",
+              "wrap": true
             }
-          ]
+          ],
+          "spacing": "Medium",
+          "type": "Container"
         },
         {
-          "type": "TextBlock",
-          "text": "◌  正在执行下一步…",
-          "color": "Accent",
-          "size": "Small",
-          "wrap": true,
-          "spacing": "Large"
+          "id": "collapsed_panel",
+          "isVisible": false,
+          "items": [
+            {
+              "isSubtle": true,
+              "size": "Small",
+              "spacing": "None",
+              "text": "正在思考",
+              "type": "TextBlock",
+              "wrap": true
+            }
+          ],
+          "spacing": "Small",
+          "type": "Container"
         }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "collapsed_panel",
-      "isVisible": false,
-      "spacing": "Medium",
-      "items": [
-        {
-          "type": "TextBlock",
-          "text": "✓  推理仍在进行 · 点击可查看当前过程",
-          "size": "Small",
-          "isSubtle": true,
-          "wrap": true,
-          "spacing": "None"
-        }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "octo-surface-default-footer-reasoning-active",
+      ],
+      "spacing": "None",
       "style": "emphasis",
-      "bleed": true,
-      "separator": true,
-      "spacing": "Large",
-      "items": [
-        {
-          "type": "ActionSet",
-          "horizontalAlignment": "Right",
-          "actions": [
-            {
-              "type": "Action.Submit",
-              "id": "reasoning_stop",
-              "title": "停止",
-              "style": "destructive",
-              "associatedInputs": "none",
-              "data": {
-                "action": "reasoning_stop",
-                "effect": "stop_reasoning",
-                "reasoning_id": "reasoning-channel-b-001",
-                "owner": "ai",
-                "action_type": "reasoning.control"
-              }
-            },
-            {
-              "type": "Action.ToggleVisibility",
-              "id": "reasoning_toggle",
-              "title": "显示 / 隐藏推理",
-              "targetElements": [
-                "trace_panel",
-                "collapsed_panel"
-              ]
-            }
-          ]
-        }
-      ]
+      "type": "Container"
     }
-  ]
+  ],
+  "type": "AdaptiveCard",
+  "version": "1.5"
 }

--- a/wkuikit/src/debug/assets/interactive_cards/ai.reasoning-process/goldens/stopped.card.json
+++ b/wkuikit/src/debug/assets/interactive_cards/ai.reasoning-process/goldens/stopped.card.json
@@ -1,387 +1,567 @@
 {
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-  "type": "AdaptiveCard",
-  "version": "1.5",
   "body": [
     {
-      "type": "Container",
-      "id": "octo-surface-accent-header-reasoning-result",
-      "style": "accent",
       "bleed": true,
-      "spacing": "None",
       "items": [
         {
-          "type": "ColumnSet",
-          "spacing": "None",
           "columns": [
             {
-              "type": "Column",
-              "width": "stretch",
               "items": [
                 {
-                  "type": "TextBlock",
-                  "text": "✦  已深度思考",
-                  "color": "Accent",
-                  "weight": "Bolder",
-                  "wrap": true,
-                  "spacing": "None"
-                },
-                {
-                  "type": "TextBlock",
-                  "text": "已思考 6 秒 · 已停止于第 2 段",
-                  "size": "Small",
-                  "isSubtle": true,
-                  "wrap": true,
-                  "spacing": "Small"
-                }
-              ]
-            },
-            {
-              "type": "Column",
-              "width": "auto",
-              "verticalContentAlignment": "Center",
-              "items": [
-                {
-                  "type": "TextBlock",
-                  "id": "octo-badge-reasoning-result-status",
-                  "text": "已停止",
-                  "color": "Warning",
-                  "weight": "Bolder",
-                  "size": "Small",
-                  "wrap": true,
-                  "spacing": "None"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "trace_panel",
-      "isVisible": false,
-      "spacing": "Large",
-      "items": [
-        {
-          "type": "Container",
-          "spacing": "None",
-          "separator": false,
-          "items": [
-            {
-              "type": "TextBlock",
-              "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
-              "size": "Small",
-              "wrap": true,
-              "spacing": "None"
-            },
-            {
-              "type": "Container",
-              "style": "emphasis",
-              "spacing": "Small",
-              "items": [
-                {
-                  "type": "ColumnSet",
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "深度思考",
+                          "type": "TextBlock",
+                          "weight": "Bolder",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "width": "auto"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开",
+                          "id": "reasoning_toggle_collapsed",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_toggle",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起",
+                          "id": "reasoning_toggle_expanded",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_toggle_expanded_action",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
                   "spacing": "None",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "query_metrics",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "channel=B · range=90d · group=stage",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
+                  "type": "ColumnSet"
                 },
                 {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "read_file",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "~/analytics/funnel_definition.sql · ×2",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "ColumnSet",
-                  "spacing": "Small",
-                  "columns": [
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
-                          "size": "Small",
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "auto",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "run_sql",
-                          "weight": "Bolder",
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
-                        {
-                          "type": "TextBlock",
-                          "text": "按漏斗阶段汇总数量与转化率",
-                          "isSubtle": true,
-                          "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    }
-                  ]
+                  "color": "Warning",
+                  "size": "Small",
+                  "spacing": "None",
+                  "text": "已停止",
+                  "type": "TextBlock",
+                  "wrap": true
                 }
-              ]
+              ],
+              "type": "Column",
+              "width": "stretch"
             }
-          ]
+          ],
+          "id": "reasoning_header",
+          "spacing": "None",
+          "type": "ColumnSet"
         },
         {
-          "type": "Container",
-          "spacing": "Large",
-          "separator": true,
+          "id": "trace_panel",
+          "isVisible": false,
           "items": [
             {
-              "type": "TextBlock",
-              "text": "激活率降幅高于线索量，开始按行业与试用权益触达交叉核验。",
-              "size": "Small",
-              "wrap": true,
-              "spacing": "None"
-            },
-            {
-              "type": "Container",
-              "style": "emphasis",
-              "spacing": "Small",
+              "id": "reasoning_phase_0",
               "items": [
                 {
-                  "type": "ColumnSet",
-                  "spacing": "None",
                   "columns": [
                     {
-                      "type": "Column",
-                      "width": "auto",
                       "items": [
                         {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Good",
                           "size": "Small",
-                          "spacing": "None"
+                          "spacing": "None",
+                          "text": "先拆分线索、试用激活与付费三段漏斗，核对近 90 天数据。",
+                          "type": "TextBlock",
+                          "wrap": true
                         }
-                      ]
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
                     },
                     {
-                      "type": "Column",
-                      "width": "auto",
                       "items": [
                         {
-                          "type": "TextBlock",
-                          "text": "query_metrics",
-                          "weight": "Bolder",
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_0",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
                           "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
                         {
-                          "type": "TextBlock",
-                          "text": "按行业拆分激活率",
-                          "isSubtle": true,
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_0",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
                           "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
                         }
-                      ]
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
                     }
-                  ]
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
                 },
                 {
-                  "type": "ColumnSet",
+                  "id": "reasoning_tools_panel_0",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "channel=B · range=90d · group=stage",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "read_file",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "~/analytics/funnel_definition.sql · ×2",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "run_sql",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按漏斗阶段汇总数量与转化率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
                   "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "None",
+              "type": "Container"
+            },
+            {
+              "id": "reasoning_phase_1",
+              "items": [
+                {
                   "columns": [
                     {
-                      "type": "Column",
-                      "width": "auto",
                       "items": [
                         {
-                          "type": "TextBlock",
-                          "text": "●",
-                          "color": "Accent",
                           "size": "Small",
-                          "spacing": "None"
+                          "spacing": "None",
+                          "text": "激活率降幅高于线索量，开始按行业与试用权益触达交叉核验。",
+                          "type": "TextBlock",
+                          "wrap": true
                         }
-                      ]
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
                     },
                     {
-                      "type": "Column",
-                      "width": "auto",
                       "items": [
                         {
-                          "type": "TextBlock",
-                          "text": "search_tickets",
-                          "weight": "Bolder",
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_1",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
                           "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Column",
-                      "width": "stretch",
-                      "items": [
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
                         {
-                          "type": "TextBlock",
-                          "text": "调用已由用户停止",
-                          "isSubtle": true,
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_1",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_1",
+                            "targetElements": [
+                              "reasoning_tools_panel_1",
+                              "reasoning_tools_toggle_collapsed_1",
+                              "reasoning_tools_toggle_expanded_1"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
                           "size": "Small",
-                          "wrap": true,
-                          "spacing": "None"
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
                         }
-                      ]
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
                     }
-                  ]
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_1",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Good",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "query_metrics",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "按行业拆分激活率",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    },
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Accent",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "search_tickets",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "调用已由用户停止",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "Small",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
                 }
-              ]
+              ],
+              "spacing": "Small",
+              "type": "Container"
             }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "collapsed_panel",
-      "isVisible": true,
-      "spacing": "Medium",
-      "items": [
+          ],
+          "spacing": "Medium",
+          "type": "Container"
+        },
         {
-          "type": "TextBlock",
-          "text": "✓  已保留停止前的 2 段推理过程",
-          "size": "Small",
-          "isSubtle": true,
-          "wrap": true,
-          "spacing": "None"
-        }
-      ]
-    },
-    {
-      "type": "Container",
-      "id": "octo-surface-default-footer-reasoning-result",
-      "style": "emphasis",
-      "bleed": true,
-      "separator": true,
-      "spacing": "Large",
-      "items": [
-        {
-          "type": "ActionSet",
-          "horizontalAlignment": "Right",
-          "actions": [
+          "id": "collapsed_panel",
+          "isVisible": true,
+          "items": [
             {
-              "type": "Action.ToggleVisibility",
-              "id": "reasoning_toggle",
-              "title": "显示 / 隐藏推理",
-              "targetElements": [
-                "trace_panel",
-                "collapsed_panel"
-              ]
+              "isSubtle": true,
+              "size": "Small",
+              "spacing": "None",
+              "text": "已停止 · 保留 2 段思考",
+              "type": "TextBlock",
+              "wrap": true
             }
-          ]
+          ],
+          "spacing": "Small",
+          "type": "Container"
         }
-      ]
+      ],
+      "spacing": "None",
+      "style": "emphasis",
+      "type": "Container"
     }
-  ]
+  ],
+  "type": "AdaptiveCard",
+  "version": "1.5"
 }

--- a/wkuikit/src/debug/assets/interactive_cards/ai.reasoning-process/manifest.json
+++ b/wkuikit/src/debug/assets/interactive_cards/ai.reasoning-process/manifest.json
@@ -2,15 +2,14 @@
   "schemaVersion": 2,
   "id": "ai.reasoning-process",
   "name": "推理过程卡",
-  "version": "0.1.0",
-  "contractVersion": "1.0.0",
+  "version": "0.4.1",
+  "contractVersion": "1.2.0",
   "protocol": "octo-card@1.0",
   "adaptiveCardVersion": "1.5",
-  "renderProfile": "octo-chat@1.2.0-rc.1",
+  "renderProfile": "octo-chat@1.2.0-rc.3",
   "renderProfileCompatibility": "octo-chat/v1",
   "defaultLocale": "zh-CN",
   "owner": "ai",
-  "actionType": "reasoning.control",
   "dataSchema": "contract/data.schema.json",
   "views": {
     "active": {

--- a/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/OctoAdaptiveImageLoader.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/OctoAdaptiveImageLoader.kt
@@ -82,17 +82,21 @@ object OctoAdaptiveImageLoader : IOnlineImageLoader {
         }
         return try {
             val bytes = fetchBytes(url)
-            val bitmap = if (looksLikeSvg(bytes)) {
-                decodeSvg(bytes)
-            } else {
-                decodeRasterDownsampled(bytes)
-            }
-            HttpRequestResult(bitmap)
+            HttpRequestResult(decodeImageBytes(bytes))
         } catch (t: Throwable) {
             Log.w(TAG, "load 失败 url=$url", t)
             HttpRequestResult(t as? Exception ?: RuntimeException(t))
         }
     }
+
+    /**
+     * 字节 → Bitmap。SVG 走 AndroidSVG，其余走降采样位图解码。
+     *
+     * 供 [OctoDataUriResolver] 复用——data URI 与 http 图片只在"取字节"这一步不同，
+     * 解码分支完全一样。
+     */
+    internal fun decodeImageBytes(bytes: ByteArray): Bitmap =
+        if (looksLikeSvg(bytes)) decodeSvg(bytes) else decodeRasterDownsampled(bytes)
 
     // ─────────────────────────────── Fetch ───────────────────────────────
 

--- a/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/OctoDataUriResolver.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/OctoDataUriResolver.kt
@@ -55,11 +55,31 @@ object OctoDataUriResolver : IResourceResolver {
     const val SCHEME = "data"
 
     /**
-     * 单张图 base64/percent-encoded 解码后的字节上限（2MB），与
-     * [OctoAdaptiveImageLoader] 的 MAX_BYTES 对齐。data URI 是内联的，畸形超长
-     * payload 会把整个 body 读进内存，加上限避免 OOM 掉会话页。
+     * 单张图解码后的字节上限（2MB），与 [OctoAdaptiveImageLoader] 的 MAX_BYTES 对齐。
+     *
+     * **两条分支都在解码前/解码中生效，不是事后校验** —— 事后校验挡不住任何东西：
+     * 畸形 payload 已经把内存吃完了才抛异常。见 [MAX_BASE64_CHARS] 与 [percentDecode]。
+     *
+     * `internal` 而非 `private`：让单测按真实上限构造越界用例，避免测试里复制一份常量后漂移。
      */
-    private const val MAX_BYTES = 2 * 1024 * 1024
+    internal const val MAX_BYTES = 2 * 1024 * 1024
+
+    /**
+     * base64 形态**解码前**的字符上限。
+     *
+     * `Base64.decode` 一次性分配完整结果数组，没有流式/带上限的入口，所以只能按输入
+     * 长度判。标准 base64 是 4 字符 → 3 字节，故 payload 长度超过 `MAX_BYTES/3*4`
+     * 时解码结果必然越界；换行等空白只会让结果更小，而"90% 是空白"的 payload 也不是
+     * 合法内联图，一并拒掉即可。
+     */
+    internal const val MAX_BASE64_CHARS = MAX_BYTES / 3 * 4
+
+    /**
+     * percent 形态缓冲区的初始容量（8KB）。折叠箭头 SVG 约 1KB，按 `payload.length`
+     * 预分配等于信任不可信长度；且它甚至不是解码结果的上界——多字节字符 1 char → 3 byte，
+     * 结果最多可达 3 倍长度，预分配后还要成倍扩容 + `toByteArray()` 再拷一份。
+     */
+    private const val PERCENT_BUF_INITIAL = 8 * 1024
 
     override fun resolveImageResource(
         url: String,
@@ -87,10 +107,14 @@ object OctoDataUriResolver : IResourceResolver {
      * 不用 `Uri.parse` 取 scheme-specific part：SVG payload 里带 `#`（如 fill="#333"）
      * 会被当 fragment 截断。这里按第一个逗号手工切分。
      *
-     * `internal` 供单测直接覆盖 percent-encoded 分支（base64 分支依赖
-     * `android.util.Base64`，host-side 单测拿不到真实实现）。
+     * @param base64Decode base64 解码器接缝。默认 `android.util.Base64`；host-side 单测
+     *   （`returnDefaultValues=true`）拿不到真实实现（返回 null），由测试注入 JVM 的
+     *   `java.util.Base64` 来覆盖这条分支。
      */
-    internal fun decodeDataUri(url: String): ByteArray {
+    internal fun decodeDataUri(
+        url: String,
+        base64Decode: (String) -> ByteArray? = { Base64.decode(it, Base64.DEFAULT) }
+    ): ByteArray {
         if (!url.startsWith("$SCHEME:", ignoreCase = true)) {
             throw IOException("not a data URI")
         }
@@ -103,12 +127,17 @@ object OctoDataUriResolver : IResourceResolver {
 
         val isBase64 = meta.split(';').any { it.trim().equals("base64", ignoreCase = true) }
         val bytes: ByteArray? = if (isBase64) {
+            if (payload.length > MAX_BASE64_CHARS) {
+                throw IOException("data URI base64 payload 超过 $MAX_BASE64_CHARS 字符上限")
+            }
             // DEFAULT 即标准字母表（+/），data URI 用的就是它；解码时本身容忍换行。
-            Base64.decode(payload, Base64.DEFAULT)
+            base64Decode(payload)
         } else {
             percentDecode(payload)
         }
         if (bytes == null || bytes.isEmpty()) throw IOException("data URI decoded to 0 byte")
+        // 兜底精确校验：base64 的字符上限是保守估计（空白字符会让实际结果更小），
+        // percent 分支边解边查最多溢出一个字符的字节数，都可能停在略超 MAX_BYTES 处。
         if (bytes.size > MAX_BYTES) throw IOException("data URI 超过 $MAX_BYTES 字节上限")
         return bytes
     }
@@ -122,9 +151,14 @@ object OctoDataUriResolver : IResourceResolver {
      * `%89PNG`）不是合法 UTF-8，转 String 会被替换成 U+FFFD，字节就毁了。
      */
     private fun percentDecode(payload: String): ByteArray {
-        val out = java.io.ByteArrayOutputStream(payload.length)
+        val out = java.io.ByteArrayOutputStream(minOf(payload.length, PERCENT_BUF_INITIAL))
         var i = 0
         while (i < payload.length) {
+            // 边解边查上限：缓冲区最多长到 MAX_BYTES + 一个字符的字节数就抛，
+            // 不会先把畸形 payload 吃满内存再判越界。
+            if (out.size() > MAX_BYTES) {
+                throw IOException("data URI percent payload 解码中超过 $MAX_BYTES 字节上限")
+            }
             val c = payload[i]
             if (c == '%' && i + 2 < payload.length) {
                 val hi = Character.digit(payload[i + 1], 16)

--- a/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/OctoDataUriResolver.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/msgmodel/OctoDataUriResolver.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.msgmodel
+
+import android.graphics.Bitmap
+import android.util.Base64
+import android.util.Log
+import io.adaptivecards.renderer.GenericImageLoaderAsync
+import io.adaptivecards.renderer.IResourceResolver
+import io.adaptivecards.renderer.http.HttpRequestResult
+import java.io.IOException
+
+/**
+ * `data:` URI 图片解析器（AC SDK 的 [IResourceResolver] 扩展点，按 scheme 注册）。
+ *
+ * ## 为什么需要
+ * 服务端的 `ai.reasoning-process` 模版把折叠箭头做成 **SVG data URI**
+ * （`data:image/svg+xml,%3Csvg...`），并在其上挂 `selectAction: Action.ToggleVisibility`。
+ *
+ * SDK 的 [GenericImageLoaderAsync.loadImage] 取图分三步：①按 scheme 查 ResourceResolver
+ * ②本地资源 ③在线 URL。我们此前只注册了 [OctoAdaptiveImageLoader]（`IOnlineImageLoader`），
+ * 它挂在第③步、且要先 `new URL(path)` 成功——而 `data:` 不是 Java `URL` 支持的协议，
+ * 直接 `MalformedURLException`，回退 imageBaseUrl（空）后抛 IOException。
+ *
+ * 结果是箭头图标渲染为空 → **没有可点区域** → 卡片无法展开/收起。web 正常是因为浏览器
+ * 原生支持 data URI。本 resolver 补上第①步这条通道。
+ *
+ * ## 支持的形态
+ * - `data:image/svg+xml,<percent-encoded>`（模版当前用法）
+ * - `data:image/png;base64,<base64>`
+ * - 省略 mediatype 的 `data:,xxx`（RFC 2397 允许）
+ *
+ * 解码沿用 [OctoAdaptiveImageLoader.decodeImageBytes]：SVG 走 AndroidSVG，位图走降采样。
+ * 与 http 图片只差"取字节"这一步。
+ */
+object OctoDataUriResolver : IResourceResolver {
+
+    private const val TAG = "OctoDataUriResolver"
+
+    /** scheme 名，注册与解析共用，避免两处写字符串漂移。 */
+    const val SCHEME = "data"
+
+    /**
+     * 单张图 base64/percent-encoded 解码后的字节上限（2MB），与
+     * [OctoAdaptiveImageLoader] 的 MAX_BYTES 对齐。data URI 是内联的，畸形超长
+     * payload 会把整个 body 读进内存，加上限避免 OOM 掉会话页。
+     */
+    private const val MAX_BYTES = 2 * 1024 * 1024
+
+    override fun resolveImageResource(
+        url: String,
+        loader: GenericImageLoaderAsync?
+    ): HttpRequestResult<Bitmap> = resolve(url)
+
+    override fun resolveImageResource(
+        url: String,
+        loader: GenericImageLoaderAsync?,
+        maxWidth: Int
+    ): HttpRequestResult<Bitmap> = resolve(url)
+
+    private fun resolve(url: String): HttpRequestResult<Bitmap> = try {
+        val bytes = decodeDataUri(url)
+        HttpRequestResult(OctoAdaptiveImageLoader.decodeImageBytes(bytes))
+    } catch (t: Throwable) {
+        // 失败即降级为空图，与"没有本 resolver"的 baseline 等价，不让单个坏图标毙掉整卡。
+        Log.w(TAG, "data URI 解码失败 (len=${url.length})", t)
+        HttpRequestResult(t as? Exception ?: RuntimeException(t))
+    }
+
+    /**
+     * `data:[<mediatype>][;base64],<data>` → 原始字节。
+     *
+     * 不用 `Uri.parse` 取 scheme-specific part：SVG payload 里带 `#`（如 fill="#333"）
+     * 会被当 fragment 截断。这里按第一个逗号手工切分。
+     *
+     * `internal` 供单测直接覆盖 percent-encoded 分支（base64 分支依赖
+     * `android.util.Base64`，host-side 单测拿不到真实实现）。
+     */
+    internal fun decodeDataUri(url: String): ByteArray {
+        if (!url.startsWith("$SCHEME:", ignoreCase = true)) {
+            throw IOException("not a data URI")
+        }
+        val comma = url.indexOf(',')
+        if (comma < 0) throw IOException("data URI missing comma")
+
+        val meta = url.substring("$SCHEME:".length, comma)
+        val payload = url.substring(comma + 1)
+        if (payload.isEmpty()) throw IOException("data URI empty payload")
+
+        val isBase64 = meta.split(';').any { it.trim().equals("base64", ignoreCase = true) }
+        val bytes: ByteArray? = if (isBase64) {
+            // DEFAULT 即标准字母表（+/），data URI 用的就是它；解码时本身容忍换行。
+            Base64.decode(payload, Base64.DEFAULT)
+        } else {
+            percentDecode(payload)
+        }
+        if (bytes == null || bytes.isEmpty()) throw IOException("data URI decoded to 0 byte")
+        if (bytes.size > MAX_BYTES) throw IOException("data URI 超过 $MAX_BYTES 字节上限")
+        return bytes
+    }
+
+    /**
+     * RFC 3986 percent-decoding，**按字节**解，不绕 String。
+     *
+     * 不用 `URLDecoder`：它实现的是 `application/x-www-form-urlencoded` 语义
+     * （`+` 解成空格），而 data URI 里 `+` 是字面量（SVG path 数据、`image/svg+xml`
+     * 都会出现）。而且它返回 String —— percent-encoded 的二进制载荷（如
+     * `%89PNG`）不是合法 UTF-8，转 String 会被替换成 U+FFFD，字节就毁了。
+     */
+    private fun percentDecode(payload: String): ByteArray {
+        val out = java.io.ByteArrayOutputStream(payload.length)
+        var i = 0
+        while (i < payload.length) {
+            val c = payload[i]
+            if (c == '%' && i + 2 < payload.length) {
+                val hi = Character.digit(payload[i + 1], 16)
+                val lo = Character.digit(payload[i + 2], 16)
+                if (hi >= 0 && lo >= 0) {
+                    out.write((hi shl 4) or lo)
+                    i += 3
+                    continue
+                }
+            }
+            // 非转义字符按 UTF-8 落字节（ASCII 走单字节，多字节字符也能正确编码）
+            out.write(c.toString().toByteArray(Charsets.UTF_8))
+            i++
+        }
+        return out.toByteArray()
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/card/InteractiveCardRenderer.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/card/InteractiveCardRenderer.kt
@@ -22,6 +22,7 @@ import com.chat.uikit.R
 import com.chat.uikit.chat.msgmodel.InteractiveCardDecision
 import com.chat.uikit.chat.msgmodel.InteractiveCardSanitizer
 import com.chat.uikit.chat.msgmodel.OctoAdaptiveImageLoader
+import com.chat.uikit.chat.msgmodel.OctoDataUriResolver
 import com.chat.uikit.chat.msgmodel.OctoHostConfig
 import io.adaptivecards.objectmodel.AdaptiveCard
 import io.adaptivecards.objectmodel.BaseActionElement
@@ -324,7 +325,12 @@ class InteractiveCardRenderer(
                 try {
                     CardRendererRegistration.getInstance()
                         .registerOnlineImageLoader(OctoAdaptiveImageLoader)
-                    Log.d(TAG, "OnlineImageLoader 已注册 (SVG-aware)")
+                    // data: URI 走 SDK 的 ResourceResolver 通道（按 scheme 查，优先于在线加载）。
+                    // 不注册的话 ai.reasoning-process 的 SVG data URI 折叠箭头渲染为空，
+                    // 卡片没有可点区域、无法展开。
+                    CardRendererRegistration.getInstance()
+                        .registerResourceResolver(OctoDataUriResolver.SCHEME, OctoDataUriResolver)
+                    Log.d(TAG, "OnlineImageLoader + data URI resolver 已注册 (SVG-aware)")
                 } catch (t: Throwable) {
                     // 注册失败最坏就是 SVG 不解，与"没本 loader"的 baseline 等价；不吞其它异常。
                     onlineImageLoaderRegistered.set(false)

--- a/wkuikit/src/test/java/com/chat/uikit/chat/msgmodel/OctoDataUriResolverTest.kt
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/msgmodel/OctoDataUriResolverTest.kt
@@ -16,17 +16,31 @@
 
 package com.chat.uikit.chat.msgmodel
 
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 import java.io.IOException
 
 /**
- * `data:` URI 解码单测。只覆盖 percent-encoded 分支 —— base64 分支依赖
- * `android.util.Base64`，host-side 单测（`returnDefaultValues=true`）拿不到真实实现。
+ * `data:` URI 解码单测。
+ *
+ * base64 分支通过 [decodeDataUri] 的解码器接缝注入 JVM 的 `java.util.Base64` 覆盖 ——
+ * host-side 单测（`returnDefaultValues=true`）拿不到 `android.util.Base64` 的真实实现。
+ * `getMimeDecoder()` 与 `android.util.Base64.DEFAULT` 语义一致（标准字母表 + 容忍换行）。
  */
 class OctoDataUriResolverTest {
+
+    /** 记录是否真的走到解码器 —— 越界用例要证明**解码前**就被拒了。 */
+    private class RecordingBase64 : (String) -> ByteArray? {
+        var invoked = false
+        override fun invoke(payload: String): ByteArray? {
+            invoked = true
+            return java.util.Base64.getMimeDecoder().decode(payload)
+        }
+    }
 
     private fun decode(url: String) = String(OctoDataUriResolver.decodeDataUri(url), Charsets.UTF_8)
 
@@ -96,6 +110,87 @@ class OctoDataUriResolverTest {
     @Test
     fun `empty payload is rejected`() {
         assertThrowsIO { decode("data:image/svg+xml,") }
+    }
+
+    // ---- base64 分支 ----
+
+    /** PNG 魔数 `89 50 4E 47 0D 0A 1A 0A` 的 base64 形态。 */
+    @Test
+    fun `base64 payload decodes to raw bytes`() {
+        val bytes = OctoDataUriResolver.decodeDataUri(
+            "data:image/png;base64,iVBORw0KGgo=",
+            RecordingBase64()
+        )
+        assertArrayEquals(
+            byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A),
+            bytes
+        )
+    }
+
+    /** `;base64` 标记大小写不敏感，且容忍参数间空格（`data:image/png; base64,...`）。 */
+    @Test
+    fun `base64 marker is case insensitive and space tolerant`() {
+        val expected = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+        assertArrayEquals(
+            expected,
+            OctoDataUriResolver.decodeDataUri("data:image/png;BASE64,iVBORw0KGgo=", RecordingBase64())
+        )
+        assertArrayEquals(
+            expected,
+            OctoDataUriResolver.decodeDataUri("data:image/png; base64,iVBORw0KGgo=", RecordingBase64())
+        )
+    }
+
+    /** base64 payload 里 `+` `/` 属标准字母表，必须交给解码器而不是被当 percent 语义处理。 */
+    @Test
+    fun `base64 standard alphabet is decoded not percent unescaped`() {
+        val bytes = OctoDataUriResolver.decodeDataUri("data:;base64,//79", RecordingBase64())
+        assertArrayEquals(byteArrayOf(0xFF.toByte(), 0xFE.toByte(), 0xFD.toByte()), bytes)
+    }
+
+    // ---- 内存上限（回归：上限必须在解码前/解码中生效，不能事后补刀）----
+
+    /**
+     * 超长 base64 payload 必须在**调用解码器之前**就被拒 —— `Base64.decode` 会一次性
+     * 分配完整结果数组，解码完再查上限等于让畸形 payload 先把内存吃掉。
+     */
+    @Test
+    fun `oversized base64 payload is rejected before decoding`() {
+        val recorder = RecordingBase64()
+        val payload = "A".repeat(OctoDataUriResolver.MAX_BASE64_CHARS + 1)
+        assertThrowsIO {
+            OctoDataUriResolver.decodeDataUri("data:image/png;base64,$payload", recorder)
+        }
+        assertFalse("解码器不应被调用：越界判定必须发生在解码前", recorder.invoked)
+    }
+
+    /** 刚好压线的 base64 payload 不应被上限误杀。 */
+    @Test
+    fun `base64 payload at the char limit is accepted`() {
+        val payload = "A".repeat(OctoDataUriResolver.MAX_BASE64_CHARS)
+        val bytes = OctoDataUriResolver.decodeDataUri("data:image/png;base64,$payload", RecordingBase64())
+        assertTrue(
+            "压线 payload 解码后应落在 MAX_BYTES 内，实际 ${bytes.size}",
+            bytes.isNotEmpty() && bytes.size <= OctoDataUriResolver.MAX_BYTES
+        )
+    }
+
+    /**
+     * percent 分支边解边查上限：必须**解码过程中**抛，而不是缓冲完整个 payload 再由
+     * 末尾的兜底校验补刀。靠异常消息区分这两条路径。
+     */
+    @Test
+    fun `oversized percent payload is rejected mid decode`() {
+        val payload = "A".repeat(OctoDataUriResolver.MAX_BYTES + 1024)
+        try {
+            decode("data:image/svg+xml,$payload")
+            fail("expected IOException")
+        } catch (e: IOException) {
+            assertTrue(
+                "应由解码中的增量上限拦截，实际消息：${e.message}",
+                e.message?.contains("解码中") == true
+            )
+        }
     }
 
     private fun assertThrowsIO(block: () -> Unit) {

--- a/wkuikit/src/test/java/com/chat/uikit/chat/msgmodel/OctoDataUriResolverTest.kt
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/msgmodel/OctoDataUriResolverTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat.msgmodel
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * `data:` URI 解码单测。只覆盖 percent-encoded 分支 —— base64 分支依赖
+ * `android.util.Base64`，host-side 单测（`returnDefaultValues=true`）拿不到真实实现。
+ */
+class OctoDataUriResolverTest {
+
+    private fun decode(url: String) = String(OctoDataUriResolver.decodeDataUri(url), Charsets.UTF_8)
+
+    @Test
+    fun `percent encoded svg decodes to markup`() {
+        val url = "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3C%2Fsvg%3E"
+        assertEquals("""<svg xmlns="http://www.w3.org/2000/svg"></svg>""", decode(url))
+    }
+
+    /** `#` 必须原样保留 —— 用 Uri.parse 取 SSP 会把它当 fragment 分隔符截断后半段。 */
+    @Test
+    fun `hash in fill color survives`() {
+        val url = "data:image/svg+xml,%3Cpath%20fill%3D%22%23333%22%2F%3E"
+        assertEquals("""<path fill="#333"/>""", decode(url))
+    }
+
+    /** `+` 是 path 数据的合法字符，按 RFC 3986 应保持字面量（不是表单编码的空格）。 */
+    @Test
+    fun `plus is not turned into space`() {
+        val url = "data:image/svg+xml,%3Cpath%20d%3D%22M1+2%22%2F%3E"
+        assertEquals("""<path d="M1+2"/>""", decode(url))
+    }
+
+    /**
+     * 非 UTF-8 的转义序列必须按字节保留 —— 走 String 中转会被替换成 U+FFFD，
+     * percent-encoded 的二进制图（PNG 魔数 89 50 4E 47）就毁了。
+     */
+    @Test
+    fun `non utf8 escapes survive as raw bytes`() {
+        // %89PNG → 89 50 4E 47，正是 PNG 魔数
+        val bytes = OctoDataUriResolver.decodeDataUri("data:image/png,%89PNG")
+        assertEquals(4, bytes.size)
+        assertEquals(0x89.toByte(), bytes[0])
+        assertEquals('P'.code.toByte(), bytes[1])
+        assertEquals('N'.code.toByte(), bytes[2])
+        assertEquals('G'.code.toByte(), bytes[3])
+    }
+
+    /** 畸形转义（`%` 后不是两位 hex）按字面量处理，不抛异常。 */
+    @Test
+    fun `malformed escape is kept literal`() {
+        assertEquals("100%25", decode("data:,100%2525"))
+        assertEquals("a%zz", decode("data:,a%zz"))
+    }
+
+    /** RFC 2397 允许省略 mediatype。 */
+    @Test
+    fun `omitted mediatype is accepted`() {
+        assertEquals("<svg/>", decode("data:,%3Csvg%2F%3E"))
+    }
+
+    @Test
+    fun `scheme is case insensitive`() {
+        assertEquals("<svg/>", decode("DATA:image/svg+xml,%3Csvg%2F%3E"))
+    }
+
+    @Test
+    fun `non data uri is rejected`() {
+        assertThrowsIO { decode("https://example.com/a.svg") }
+    }
+
+    @Test
+    fun `missing comma is rejected`() {
+        assertThrowsIO { decode("data:image/svg+xml") }
+    }
+
+    @Test
+    fun `empty payload is rejected`() {
+        assertThrowsIO { decode("data:image/svg+xml,") }
+    }
+
+    private fun assertThrowsIO(block: () -> Unit) {
+        try {
+            block()
+            fail("expected IOException")
+        } catch (e: IOException) {
+            assertTrue(true)
+        }
+    }
+}


### PR DESCRIPTION
Closes #117

## 现象与根因

Reasoning 卡（`ai.reasoning-process`，服务端默认模版 0.4.1）的折叠箭头在 Android 上**渲染为空 → 没有可点区域 → 卡片无法展开/收起**。

箭头是 6~8 个 `Image`，url 全是 **SVG data URI**：

```
data:image/svg+xml,%3Csvg%20xmlns%3D...   ← 挂 selectAction: Action.ToggleVisibility
```

AC SDK 的 `GenericImageLoaderAsync.loadImage` 取图分三步：

| 通道 | 用途 | 此前 |
|---|---|---|
| ① 按 scheme 查 `IResourceResolver` | 自定义协议 | **未注册** |
| ② 本地资源 | app 内资源 | — |
| ③ 在线 URL | 网络图片 | 已接（`OctoAdaptiveImageLoader`） |

我们只接了通道③，而它挂在 `new URL(path)` 之后 —— `data:` 不是 Java `URL` 支持的协议，直接 `MalformedURLException`，回退 `imageBaseUrl`（空）后抛 `IOException`。**通道①从未注册**。

web 正常是因为浏览器原生支持 data URI。

## 排除过程（这些都不是原因）

| 怀疑点 | 结论 |
|---|---|
| 元素/action 白名单拒卡 | 卡片只用 Column/TextBlock/ColumnSet/Container/Image/`Action.ToggleVisibility`/AdaptiveCard，全在 `ELEMENTS_V1` / `ACTIONS_ALL` 内 |
| octo/v1 不给交互 | `ToggleVisibility` 无条件放行（`InteractiveCardDecision.kt:237-243`），`allowInteractive` 只管 `Action.Submit` |
| SDK 不支持 Image 上的 selectAction | 支持，`ImageRenderer.java:399` → `ContainerRenderer.setSelectAction` |
| sanitizer 改写 ColumnSet 破坏 toggle 目标 | `COLUMN_CARRY_PROPS` 已保留 `isVisible`/`id`/`selectAction` |
| 我们的 action handler 没处理 ToggleVisibility | 无需处理，SDK 内部翻转 `isVisible`（`InteractiveCardRenderer.kt:368`） |

**折叠功能本身一直是好的，坏的只是"点不到那个按钮"。** 所以补上图片通道后，交互立刻可用，没有第二轮修复。

## 改动

产品代码 3 个文件、约 135 行（逻辑约 40 行，其余注释）：

- **新增 `OctoDataUriResolver`** —— `data` scheme 的 `IResourceResolver`，支持 percent-encoded 与 base64 两种形态
- **`OctoAdaptiveImageLoader`** 抽出 `decodeImageBytes()` 供复用（SVG 走 AndroidSVG / 位图走降采样）；data URI 与 http 只差"取字节"这一步
- **`InteractiveCardRenderer`** 注册该 resolver

percent-decoding **按字节实现**而非走 `URLDecoder`，两个理由：
1. `URLDecoder` 是 `application/x-www-form-urlencoded` 语义（`+` 解成空格），而 data URI 按 RFC 3986，`+` 是字面量（`image/svg+xml`、SVG path 数据里都会出现）
2. 它返回 `String` —— percent-encoded 的二进制载荷（如 `%89PNG`）不是合法 UTF-8，转 String 会被替换成 U+FFFD，字节就毁了

另外同步了 debug 预览夹具（第二笔提交）：Android 侧 golden 停在 **0.1.0**，服务端已是 **0.4.1**。0.1.0 里一个 `Image` 都没有、根本没折叠 UI —— **这也是本缺陷长期没被发现的原因**。

## 验证

- **单测 10 例**：`#` 不被截断（用 `Uri.parse` 会当 fragment 截断）、`+` 保持字面量、非 UTF-8 转义按字节保留、畸形转义不抛异常、mediatype 可省略、scheme 大小写不敏感
- **wkuikit 全模块 366 例通过**
- **真机 vivo V2464A / Android 16**：预览页 5 个状态箭头全部渲染；点击后面板展开 + 箭头翻转 + 摘要收起（`targetElements` 四个 id 全生效）
- **真实群聊 reasoning 消息经反馈人验证可正常展开**

## 风险

只在 URL 以 `data:` 开头时介入，**http/https 图片走原路径完全不变**。resolver 内部失败降级为空图，与"没有本 resolver"的现状等价，不会毙掉整卡。

未碰：消息收发 / 存储 / 同步、卡片校验层（`InteractiveCardDecision`）、sanitizer、UI 布局。唯一改到的既有代码是把 3 行 if/else 抽成函数，行为不变。

第二笔提交是 `wkuikit/src/debug/assets`，**不进 release 包**。

## 已知残留（本次不改）

流式刷新时用户手动展开的状态会在**终态帧**到达时被重置。

实测数据（一条消息 36 秒生命周期）：**9 次 bind、仅 3 次全量重建**（初始帧 / 中间 transient 帧 / 终态帧），缓存命中率 67% —— **性能不是问题**，不需要做类似 iOS `ACRView 复用池` 的优化。状态重置为一次性影响，发生在内容刚更新完的时刻。

`Action.ToggleVisibility` 完全在 SDK 内部处理，**客户端拿不到用户的 toggle 动作**，硬修需触碰 SDK 内部 view 树或改自编 AAR 源码，性价比低。若产品要求保持展开态，**最低成本修法在服务端**（终态帧下发展开态）。

## 给 iOS 的提示

issue 里提到 iOS 同样存在此问题。根因很可能不同但相关 —— iOS 侧 `ACRSVGImageView.mm` 已 stub 为栅格兜底（裁掉了 SVGKit 依赖），所以 iOS 可能**连 https 的 SVG 图标都渲染不了**，不只是 data URI。建议 iOS 单先确认这一层。

## 建议的后续（未包含在本 PR）

模版演进时 Android 无同步机制，只能等用户反馈。建议加 CI 检查：比对 octo-server `pkg/cardtmpl/*/handoff/` 与本地 manifest 的版本号，不一致即告警。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
