### PR TITLE
fix(db): Bugly ANR/OOM 批次 —— WAL 连接池、缺失索引、同步内存峰值

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ build/
 # Release output
 app/release/
 
+# Bugly 符号表上传工具的产物（buglySymbolAndroid.jar 的工作目录，不是模块）
+/buglybin/
+
 # Local configuration file (sdk path, etc)
 local.properties
 /local.properties

--- a/wkbase/src/main/java/com/chat/base/net/BaseObserver.java
+++ b/wkbase/src/main/java/com/chat/base/net/BaseObserver.java
@@ -23,9 +23,12 @@ import com.chat.base.WKBaseApplication;
 import com.chat.base.config.WKConfig;
 import com.chat.base.endpoint.EndpointManager;
 import com.chat.base.utils.ActManagerUtils;
+import com.tencent.bugly.crashreport.CrashReport;
 import com.xinbida.wukongim.WKIM;
 
 import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava3.core.Observer;
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -36,6 +39,14 @@ import io.reactivex.rxjava3.disposables.Disposable;
  * 服务器返回的状态是在http的状态码上
  */
 public abstract class BaseObserver<T> implements Observer<T> {
+
+    /**
+     * 本进程内最多上报几条被 Rx 吞掉的 {@link Error}。堆已经耗尽时上报本身也要分配内存，
+     * 不能因为要报告 OOM 反而把进程推下去；而且同一次事故通常连着抛好几条，报 3 条足够定性。
+     */
+    private static final int MAX_SWALLOWED_ERROR_REPORTS = 3;
+    private static final AtomicInteger swallowedErrorReports = new AtomicInteger(0);
+
     @Override
     public void onComplete() {
     }
@@ -48,6 +59,7 @@ public abstract class BaseObserver<T> implements Observer<T> {
 
     @Override
     public void onError(@NotNull Throwable e) {
+        reportIfSwallowedError(e);
         ResponseThrowable throwable = ResponseExceptionHandle.getInstance().handleException(e);
         if (throwable != null) {
             String msg = throwable.getMessage();
@@ -70,6 +82,48 @@ public abstract class BaseObserver<T> implements Observer<T> {
                 onFail(throwable.getCode(), msg, errJson);
             }
         }
+    }
+
+    /**
+     * 把落到 Rx 错误管道里的 {@link Error}（主要是 {@link OutOfMemoryError}）补一条 Bugly 上报。
+     *
+     * <p><b>为什么需要</b>：{@link ResponseExceptionHandle#handleException} 的兜底分支
+     * 把任何非 {@code HttpException} 一律转成 {@code code=-1} 的普通请求失败，业务层只看到
+     * 「这次请求没成功」。OOM 走到这里就彻底消失了——**不崩溃、不上报**，线上表现是
+     * 「会话列表突然空了」而 Bugly 里一条记录都没有，等于把排查线索掐断。
+     *
+     * <p>2026-08-14 真机实测：压舱到只剩 3.84MB 可用堆时，会话同步的 OOM 正是这样被吞掉的
+     * （logcat 只有一行 {@code Throwing OutOfMemoryError}，无 FATAL EXCEPTION、无崩溃记录）。
+     * 而同一个 OOM 若抛在 {@code Retrofit.parseResponse} 里则会被原样重抛 → 崩溃 → Bugly 收到
+     * ——同一类事故，能不能被发现全看它恰好抛在哪一帧，不可接受。
+     *
+     * <p><b>刻意不改崩溃语义</b>：这里只补一条 {@code postCatchedException}，然后让流程照常往下走。
+     * 该崩的路径（Retrofit / OkHttp 对 VirtualMachineError 的重抛）不受影响，行为与 main 一致。
+     *
+     * <p>release 也执行 —— 这是线上诊断通道，不是开发期日志。
+     */
+    private static void reportIfSwallowedError(Throwable e) {
+        if (!containsError(e)) return;
+        if (swallowedErrorReports.incrementAndGet() > MAX_SWALLOWED_ERROR_REPORTS) return;
+        try {
+            CrashReport.postCatchedException(e);
+        } catch (Throwable ignored) {
+            // 上报失败不能反过来影响业务的错误处理
+        }
+    }
+
+    /** 顺着 cause 链和第一层 suppressed 找 {@link Error}；OkHttp 会把原始 Throwable 挂在 suppressed 上。 */
+    private static boolean containsError(Throwable e) {
+        Throwable t = e;
+        for (int depth = 0; t != null && depth < 5; depth++) {
+            if (t instanceof Error) return true;
+            for (Throwable s : t.getSuppressed()) {
+                if (s instanceof Error) return true;
+            }
+            if (t.getCause() == t) break;
+            t = t.getCause();
+        }
+        return false;
     }
 
     @Override

--- a/wkbase/src/main/java/com/chat/base/net/FastJsonResponseBodyConverter.kt
+++ b/wkbase/src/main/java/com/chat/base/net/FastJsonResponseBodyConverter.kt
@@ -49,15 +49,21 @@ class FastJsonResponseBodyConverter<T>(
     override fun convert(value: ResponseBody): T? {
         return value.use { body ->
             val reader = body.charStream()
-            val head = CharArray(STREAM_THRESHOLD_CHARS)
+            // 探测缓冲按需翻倍，不要一上来就按阈值分配：那样每个响应（99% 是几 KB 的小接口）
+            // 都要白拿 512KB，超过 TLAB、每次走慢路径分配，在一个「降内存峰值」的改动里
+            // 反而制造出固定的 per-request 垃圾。
+            var head = CharArray(INITIAL_PROBE_CHARS)
             var headLen = 0
-            while (headLen < head.size) {
+            while (headLen < STREAM_THRESHOLD_CHARS) {
+                if (headLen == head.size) {
+                    head = head.copyOf(minOf(head.size * 2, STREAM_THRESHOLD_CHARS))
+                }
                 val read = reader.read(head, headLen, head.size - headLen)
                 if (read == -1) break
                 headLen += read
             }
 
-            if (headLen < head.size) {
+            if (headLen < STREAM_THRESHOLD_CHARS) {
                 // 小响应：整包已在手上，保持原路径
                 if (headLen == 0) null else JSON.parseObject(String(head, 0, headLen), type)
             } else {
@@ -67,7 +73,7 @@ class FastJsonResponseBodyConverter<T>(
                     JSONReader(pushback).use { it.readObject<T>(type) }
                 }
                 WKHeapProbe.span(
-                    "http JSONReader(stream)", ">${head.size}chars", before, WKHeapProbe.usedNow()
+                    "http JSONReader(stream)", ">${headLen}chars", before, WKHeapProbe.usedNow()
                 )
                 result
             }
@@ -77,5 +83,12 @@ class FastJsonResponseBodyConverter<T>(
     private companion object {
         /** 超过这个长度才值得流式。256K 字符 ≈ 512KB，远小于会话同步那种 350 万字符的响应。 */
         const val STREAM_THRESHOLD_CHARS = 256 * 1024
+
+        /**
+         * 探测缓冲的起始容量，按需翻倍到 [STREAM_THRESHOLD_CHARS] 为止。
+         * 16K 字符（32KB）覆盖绝大多数接口，一次扩容都不用；越过阈值的大包最多 4 次
+         * arraycopy（总拷贝量 < 2× 阈值），相对后面的解析可以忽略。
+         */
+        const val INITIAL_PROBE_CHARS = 16 * 1024
     }
 }

--- a/wkbase/src/main/java/com/chat/base/net/FastJsonResponseBodyConverter.kt
+++ b/wkbase/src/main/java/com/chat/base/net/FastJsonResponseBodyConverter.kt
@@ -15,18 +15,67 @@
  */
 
 package com.chat.base.net
+
 import com.alibaba.fastjson.JSON
+import com.alibaba.fastjson.JSONReader
+import com.xinbida.wukongim.utils.WKHeapProbe
 import okhttp3.ResponseBody
 import retrofit2.Converter
+import java.io.PushbackReader
 import java.lang.reflect.Type
 
+/**
+ * 大响应体走流式解析，避免整包物化。
+ *
+ * 改动前是 `JSON.parseObject(value.string(), type)`：`ResponseBody.string()` 内部先
+ * `Buffer.writeAll(source)` 把整个响应解压进 okio Segment 链，再整体转成一个 UTF-16 String，
+ * 然后才建对象树——同一时刻内存里有三份。线上 OOM 有一条就死在第一步
+ * （`okio.Segment.<init>`，栈退时释放 231MB），FastJson 还没跑到。
+ *
+ * 现在按大小分流：
+ * - 响应 ≤ [STREAM_THRESHOLD_CHARS]：一次读完，走原来的 `JSON.parseObject(String, Type)`，
+ *   行为与改动前完全一致（绝大多数接口走这条，不引入回归面）。
+ * - 超过阈值：把已读的头部推回去，交给 [JSONReader] 增量解析。okio 不再缓冲整包，
+ *   也不再产生整包 String，峰值只剩对象树本身。
+ *
+ * 注意 fastjson 1.2.83 的 `JSON.parseObject(InputStream, ...)` **不是流式**
+ * （`JSON.java:569` 起先 `allocateBytes(64KB)` 再按 1.5 倍扩容 + arraycopy 读完整包），
+ * 用它没有意义，必须走 `JSONReader(Reader)`。
+ */
 class FastJsonResponseBodyConverter<T>(
     private val type: Type
 ) : Converter<ResponseBody, T> {
 
     override fun convert(value: ResponseBody): T? {
-        return value.use {
-            JSON.parseObject(value.string(), type)
+        return value.use { body ->
+            val reader = body.charStream()
+            val head = CharArray(STREAM_THRESHOLD_CHARS)
+            var headLen = 0
+            while (headLen < head.size) {
+                val read = reader.read(head, headLen, head.size - headLen)
+                if (read == -1) break
+                headLen += read
+            }
+
+            if (headLen < head.size) {
+                // 小响应：整包已在手上，保持原路径
+                if (headLen == 0) null else JSON.parseObject(String(head, 0, headLen), type)
+            } else {
+                val before = WKHeapProbe.usedNow()
+                val result = PushbackReader(reader, headLen).use { pushback ->
+                    pushback.unread(head, 0, headLen)
+                    JSONReader(pushback).use { it.readObject<T>(type) }
+                }
+                WKHeapProbe.span(
+                    "http JSONReader(stream)", ">${head.size}chars", before, WKHeapProbe.usedNow()
+                )
+                result
+            }
         }
+    }
+
+    private companion object {
+        /** 超过这个长度才值得流式。256K 字符 ≈ 512KB，远小于会话同步那种 350 万字符的响应。 */
+        const val STREAM_THRESHOLD_CHARS = 256 * 1024
     }
 }

--- a/wkbase/src/main/java/com/chat/base/net/FastJsonResponseBodyConverter.kt
+++ b/wkbase/src/main/java/com/chat/base/net/FastJsonResponseBodyConverter.kt
@@ -70,6 +70,9 @@ class FastJsonResponseBodyConverter<T>(
                 val before = WKHeapProbe.usedNow()
                 val result = PushbackReader(reader, headLen).use { pushback ->
                     pushback.unread(head, 0, headLen)
+                    // unread 已把探测缓冲拷进 PushbackReader 自己的 buf，这里必须放掉本地引用：
+                    // 否则两份 512KB 在整个 readObject 期间同时强可达，正好抵掉这条路径省下的量。
+                    head = CharArray(0)
                     JSONReader(pushback).use { it.readObject<T>(type) }
                 }
                 WKHeapProbe.span(

--- a/wkbase/src/main/java/com/chat/base/net/LogInterceptor.java
+++ b/wkbase/src/main/java/com/chat/base/net/LogInterceptor.java
@@ -95,9 +95,12 @@ public class LogInterceptor implements Interceptor {
 
             if (requestBody != null && !requestBody.isOneShot()) {
                 long reqLen = requestBody.contentLength();
-                if (reqLen > MAX_LOG_BODY_BYTES) {
-                    // 文件上传这类：writeTo 会把整包灌进内存，不能为了打一条日志付这个代价
-                    requestParams = "body 过大，已跳过打印（" + reqLen + " bytes）";
+                if (reqLen < 0 || reqLen > MAX_LOG_BODY_BYTES) {
+                    // 文件上传这类：writeTo 会把整包灌进内存，不能为了打一条日志付这个代价。
+                    // 长度未知（-1，流式 body）同样跳过：写完才知道多大，等于没有上界。
+                    requestParams = reqLen < 0
+                            ? "body 长度未知，已跳过打印"
+                            : "body 过大，已跳过打印（" + reqLen + " bytes）";
                 } else if (freeHeapBytes() < LOW_HEAP_SKIP_BYTES) {
                     requestParams = "堆吃紧，跳过 body 打印";
                 } else {

--- a/wkbase/src/main/java/com/chat/base/net/LogInterceptor.java
+++ b/wkbase/src/main/java/com/chat/base/net/LogInterceptor.java
@@ -37,6 +37,7 @@ import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import okio.Buffer;
 import okio.BufferedSource;
 import okio.ByteString;
@@ -47,6 +48,40 @@ import okio.ByteString;
  */
 public class LogInterceptor implements Interceptor {
 
+    /**
+     * 只打印小于这个字节数的 body，超过的只打一行大小提示。
+     *
+     * <p>为什么要有上界：会话同步这类响应有 350 万字符，原实现 {@code body().string()} 整包物化 →
+     * {@code formatJson} 再建一遍 JSON DOM 并缩进美化 → StringBuilder 再拼一份 → 最后用整包
+     * String 重建 body 回写，同一份数据五六份，debug 包凭空多吃 80MB+，堆水位测量完全失真。
+     *
+     * <p>而且 {@link WKLogUtils} 按 3900 字符分片输出，350 万字符 = 900+ 条独立 logcat 记录：
+     * 人根本拼不回来，还会把 logcat 环形缓冲区冲爆，ANR 堆栈 / 堆探针那些真正要看的日志全被挤掉。
+     * 也就是说大 body 这样打等于没打，代价却是实打实的——所以直接不打，只留大小和 URL。
+     *
+     * <p>小 body（99% 的接口）行为与改动前一致，该看的都还在。
+     */
+    private static final long MAX_LOG_BODY_BYTES = 256L * 1024L;
+
+    /**
+     * 可用堆低于这个数就整段跳过 body 打印。
+     *
+     * <p>日志工具绝不能是压死进程的最后一根稻草。2026-08-14 压舱实测：堆只剩 9MB 时，
+     * 下面那句 {@code peekBody(256KB+1)} 自己 OOM 了，崩溃栈停在
+     * {@code LogInterceptor.intercept → PeekSource.read → InflaterSource → okio.Segment.<init>}
+     * ——被测代码没问题，是量具把进程压垮了。
+     *
+     * <p>注意 peek 的开销不止 256KB：gzip 响应要边解压边填 okio Segment，
+     * 真实占用是解压后的字节数 + 段链开销。
+     */
+    private static final long LOW_HEAP_SKIP_BYTES = 32L * 1024L * 1024L;
+
+    /** 当前可用堆（max - used）。 */
+    private static long freeHeapBytes() {
+        Runtime rt = Runtime.getRuntime();
+        return rt.maxMemory() - (rt.totalMemory() - rt.freeMemory());
+    }
+
     @NotNull
     @Override
     public Response intercept(@NotNull Chain chain) throws IOException {
@@ -54,27 +89,31 @@ public class LogInterceptor implements Interceptor {
         if (WKBinder.isDebug) {
             Request request = chain.request();
             //获取request内容
-            RequestBody requestBody = request.body();
+            // 已格式化、可直接打印的请求体；body 过大时是一行提示
             String requestParams = "";
+            RequestBody requestBody = request.body();
 
             if (requestBody != null && !requestBody.isOneShot()) {
-                boolean oneShort = requestBody.isOneShot();
-                WKLogUtils.e("判断执行次数"+oneShort);
-                MediaType type = requestBody.contentType();
-                Buffer source = new Buffer();
-                requestBody.writeTo(source);
-                try {
-                    Charset charset = type == null ? Charset.defaultCharset() : type.charset(Charset.defaultCharset());
-                    readBomAsCharset(source, charset);
-//                    Util.readBomAsCharset(source, charset);
-//                    Util.readBomAsCharset()
-                    requestParams = source.readString(charset);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                } finally {
-                    closeQuietly(source);
+                long reqLen = requestBody.contentLength();
+                if (reqLen > MAX_LOG_BODY_BYTES) {
+                    // 文件上传这类：writeTo 会把整包灌进内存，不能为了打一条日志付这个代价
+                    requestParams = "body 过大，已跳过打印（" + reqLen + " bytes）";
+                } else if (freeHeapBytes() < LOW_HEAP_SKIP_BYTES) {
+                    requestParams = "堆吃紧，跳过 body 打印";
+                } else {
+                    MediaType type = requestBody.contentType();
+                    Buffer source = new Buffer();
+                    requestBody.writeTo(source);
+                    try {
+                        Charset charset = type == null ? Charset.defaultCharset() : type.charset(Charset.defaultCharset());
+                        readBomAsCharset(source, charset);
+                        requestParams = formatJson(source.readString(charset));
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    } finally {
+                        closeQuietly(source);
+                    }
                 }
-                // request = request.newBuilder().post(requestBody).build();
             }
             // 请求日志
             StringBuilder reqSb = new StringBuilder();
@@ -86,7 +125,7 @@ public class LogInterceptor implements Interceptor {
                     .append(request.headers());
             if (!TextUtils.isEmpty(requestParams)) {
                 reqSb.append("==============Body==============\n")
-                        .append(formatJson(requestParams)).append("\n");
+                        .append(requestParams).append("\n");
             }
             reqSb.append("**************Request***************").append("\n");
             WKLogUtils.d("wkHttpLog", reqSb.toString());
@@ -99,26 +138,38 @@ public class LogInterceptor implements Interceptor {
 
             if (!TextUtils.isEmpty(requestParams)) {
                 sb.append(" \n").append("============Request Body============\n")
-                        .append(formatJson(requestParams)).append("\n");
+                        .append(requestParams).append("\n");
             }
             sb.append("*************Response**************\n")
                     .append(response.request().url()).append("\n")
                     .append(String.format(Locale.getDefault(), "本次请求响应时间: %.1f ms", (t2 - t1) / 1e6d)).append("\n")
                     .append("=============Headers=============\n")
                     .append(response.headers()).append("\n");
-            String content = response.body().string();
             sb.append("==============Body==============\n");
-            if (response.isSuccessful()) {
-                sb.append(formatJson(content)).append("\n");
-            } else {
+            if (!response.isSuccessful()) {
                 sb.append("http请求失败，").append(response.networkResponse()).append("\n");
+            } else if (freeHeapBytes() < LOW_HEAP_SKIP_BYTES) {
+                // 堆已经吃紧，peek 本身就可能 OOM（实测过）。这条日志的价值远不如进程活着。
+                sb.append("堆吃紧（剩 ").append(freeHeapBytes() / (1024 * 1024))
+                        .append("MB），跳过 body 打印\n");
+            } else {
+                // peekBody 只缓冲最多 MAX+1 字节，且不消费原 body：小 body 拿到的就是全文，
+                // 大 body 拿到 MAX+1 字节即可判定超限。原实现的 body().string() +
+                // ResponseBody.create(content) 回写整段删掉了——那一步会把流式解析
+                // (FastJsonResponseBodyConverter) 在 debug 包里彻底抵消，因为转换器拿到的
+                // body 已经是内存里的整包 String，白流式了。
+                ResponseBody peeked = response.peekBody(MAX_LOG_BODY_BYTES + 1);
+                if (peeked.contentLength() > MAX_LOG_BODY_BYTES) {
+                    sb.append("body 过大，已跳过打印（>")
+                            .append(MAX_LOG_BODY_BYTES / 1024).append("KB）\n");
+                } else {
+                    sb.append(formatJson(peeked.string())).append("\n");
+                }
             }
             sb.append("*************Response**************");
             WKLogUtils.d("wkHttpLog", "   " + sb);
-            MediaType mediaType = response.body().contentType();
-            return response.newBuilder()
-                    .body(okhttp3.ResponseBody.create(content, mediaType))
-                    .build();
+            // 原 body 未被消费，原样返回，不再重建
+            return response;
         } else {
             return chain.proceed(chain.request());
         }

--- a/wkbase/src/main/java/com/chat/base/net/OkHttpUtils.java
+++ b/wkbase/src/main/java/com/chat/base/net/OkHttpUtils.java
@@ -86,6 +86,10 @@ public class OkHttpUtils {
                             .addInterceptor(mRewriteCacheControlInterceptor)
                             .addInterceptor(new CommonRequestParamInterceptor())
                             .addNetworkInterceptor(mRewriteCacheControlInterceptor)
+                            // LogInterceptor 只在 debug 生效（内部 WKBinder.isDebug 判定，release 走
+                            // chain.proceed 直通）。它对 body 有 256KB 上界：小 body 照旧全打，大 body
+                            // 只打大小——原实现会把整个响应体物化五六份，debug 包凭空多吃 80MB+，
+                            // 既带偏堆测量，又把 logcat 缓冲区冲爆。详见 LogInterceptor.MAX_LOG_BODY_BYTES。
                             .addInterceptor(new LogInterceptor())
                             // Emoji manifest 端点公开无鉴权，parse 前先做 raw body 字节上限
                             // 检查，防 hostile / MITM 推巨大 body → FastJson buffer 后 OOM。
@@ -93,9 +97,9 @@ public class OkHttpUtils {
                             //
                             // ⚠️ 必须放在 LogInterceptor 之后（即 list 末尾，最内层）：
                             // application interceptor 按 list order 由外到内包装，list 末尾的
-                            // interceptor 最先看到 response。LogInterceptor 会 body().string()
-                            // 全量读 body 后再打日志，若 BodyLimit 在 Log 之前（更外层），
-                            // Log 已经 OOM 了 BodyLimit 才拿到 response——检查太晚。
+                            // interceptor 最先看到 response，能在任何人读 body 之前先做大小检查。
+                            // （LogInterceptor 现在只 peek 最多 256KB，不再整包读，但这个顺序仍是
+                            // 正确的：让上限检查处在最内层，谁都别想先碰到超大 body。）
                             // 参考 PR #94 Jerry-Xin round-3 review B2。
                             .addInterceptor(new EmojiManifestBodyLimitInterceptor())
                             // 全局搜索 L1/L2 端点也做 body 大小上限（同 Emoji 拦截器语义），

--- a/wkbase/src/main/java/com/chat/base/utils/ANRWatchdog.java
+++ b/wkbase/src/main/java/com/chat/base/utils/ANRWatchdog.java
@@ -4,12 +4,15 @@ import android.content.Context;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.SystemClock;
 import android.util.Log;
 
 import com.tencent.bugly.crashreport.CrashReport;
 
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -21,10 +24,20 @@ public final class ANRWatchdog extends Thread {
 
     private static final String TAG = "ANRWatchdog";
     private static final int CHECK_INTERVAL_MS = 5000;
+    /**
+     * 实际睡眠超过这个时长说明看门狗线程自己被冻结/挂起（cached-app freezer、Doze 深睡），
+     * 此时 responded=false 不代表主线程卡住，本轮判定作废。
+     */
+    private static final long FREEZE_THRESHOLD_MS = CHECK_INTERVAL_MS * 2L;
+    /** 从日志文本还原堆栈时最多取多少帧，够 Bugly 分组即可。 */
+    private static final int MAX_PARSED_FRAMES = 32;
 
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private volatile boolean responded = true;
     private volatile boolean stopped = false;
+    /** 因冻结跳过的轮数，随下一次真实 ANR 一起上报，不静默丢弃。 */
+    private volatile int freezeSkipCount = 0;
+    private volatile String lastFreezeSkipDetail = null;
     private static volatile ANRWatchdog instance;
     private static Context appContext;
 
@@ -65,21 +78,40 @@ public final class ANRWatchdog extends Thread {
             responded = false;
             mainHandler.post(() -> responded = true);
 
+            long startRealtime = SystemClock.elapsedRealtime();
+            long startUptime = SystemClock.uptimeMillis();
             try {
                 Thread.sleep(CHECK_INTERVAL_MS);
             } catch (InterruptedException e) {
                 break;
             }
+            long elapsedRealtime = SystemClock.elapsedRealtime() - startRealtime;
+            long elapsedUptime = SystemClock.uptimeMillis() - startUptime;
 
             if (!responded && !stopped) {
-                String fullReport = buildReport();
-                String briefReport = buildBriefReport();
+                if (elapsedRealtime > FREEZE_THRESHOLD_MS) {
+                    freezeSkipCount++;
+                    lastFreezeSkipDetail = "realtime=" + elapsedRealtime + "ms uptime=" + elapsedUptime
+                            + "ms (expected " + CHECK_INTERVAL_MS + "ms)";
+                    Log.w(TAG, "Skip round #" + freezeSkipCount + ", watchdog itself was frozen: "
+                            + lastFreezeSkipDetail);
+                    continue;
+                }
+
+                StackTraceElement[] mainStack = Looper.getMainLooper().getThread().getStackTrace();
+                String fullReport = buildReport(mainStack, freezeSkipCount, lastFreezeSkipDetail);
+                String briefReport = buildBriefReport(mainStack, freezeSkipCount, lastFreezeSkipDetail);
                 Log.e(TAG, briefReport);
 
                 DiagnosticLogFile.append(appContext, fullReport);
 
                 try {
-                    CrashReport.postCatchedException(new ANRError(briefReport));
+                    ANRError error = new ANRError(briefReport);
+                    // 让 Bugly 按主线程真实堆栈聚合，否则所有 ANR 都折叠到 ANRWatchdog.run 一个 issue 里
+                    if (mainStack.length > 0) {
+                        error.setStackTrace(mainStack);
+                    }
+                    CrashReport.postCatchedException(error);
                     Log.w(TAG, "ANR report posted to Bugly successfully");
                 } catch (Throwable e) {
                     Log.e(TAG, "Failed to post to Bugly: " + e.getMessage());
@@ -94,7 +126,8 @@ public final class ANRWatchdog extends Thread {
         }
     }
 
-    private static String buildBriefReport() {
+    private static String buildBriefReport(StackTraceElement[] mainStack,
+                                           int freezeSkipCount, String lastFreezeSkipDetail) {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US);
         StringBuilder sb = new StringBuilder(2048);
 
@@ -102,23 +135,26 @@ public final class ANRWatchdog extends Thread {
         sb.append("Device: ").append(Build.MANUFACTURER).append(' ').append(Build.MODEL).append('\n');
         sb.append("Android: ").append(Build.VERSION.RELEASE).append(" (API ").append(Build.VERSION.SDK_INT).append(")\n");
         sb.append("Main thread state: ").append(Looper.getMainLooper().getThread().getState()).append('\n');
+        appendFreezeSkips(sb, freezeSkipCount, lastFreezeSkipDetail);
 
-        sb.append("\n--- Main Thread Stack ---\n");
-        StackTraceElement[] mainStack = Looper.getMainLooper().getThread().getStackTrace();
-        for (StackTraceElement e : mainStack) {
-            sb.append("  at ").append(e.toString()).append('\n');
-        }
-
+        // Memory 放在堆栈之前: Bugly 的异常信息字段有长度上限, 超了从尾部截断。堆栈在「堆栈」页签里
+        // 有完整一份(setStackTrace), 这里被截无所谓; 内存数据只有这一处, 不能被截掉。
         Runtime rt = Runtime.getRuntime();
         long usedMB = (rt.totalMemory() - rt.freeMemory()) / (1024 * 1024);
         long maxMB = rt.maxMemory() / (1024 * 1024);
         sb.append("\n--- Memory ---\n");
         sb.append("Used: ").append(usedMB).append("MB / Max: ").append(maxMB).append("MB\n");
 
+        sb.append("\n--- Main Thread Stack ---\n");
+        for (StackTraceElement e : mainStack) {
+            sb.append("  at ").append(e.toString()).append('\n');
+        }
+
         return sb.toString();
     }
 
-    private static String buildReport() {
+    private static String buildReport(StackTraceElement[] mainStack,
+                                      int freezeSkipCount, String lastFreezeSkipDetail) {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US);
         StringBuilder sb = new StringBuilder(4096);
 
@@ -127,9 +163,9 @@ public final class ANRWatchdog extends Thread {
         sb.append("Device: ").append(Build.MANUFACTURER).append(' ').append(Build.MODEL).append('\n');
         sb.append("Android: ").append(Build.VERSION.RELEASE).append(" (API ").append(Build.VERSION.SDK_INT).append(")\n");
         sb.append("Main thread state: ").append(Looper.getMainLooper().getThread().getState()).append('\n');
+        appendFreezeSkips(sb, freezeSkipCount, lastFreezeSkipDetail);
 
         sb.append("\n--- Main Thread Stack ---\n");
-        StackTraceElement[] mainStack = Looper.getMainLooper().getThread().getStackTrace();
         for (StackTraceElement e : mainStack) {
             sb.append("  at ").append(e.toString()).append('\n');
         }
@@ -161,6 +197,15 @@ public final class ANRWatchdog extends Thread {
         return sb.toString();
     }
 
+    private static void appendFreezeSkips(StringBuilder sb, int freezeSkipCount, String lastFreezeSkipDetail) {
+        if (freezeSkipCount <= 0) return;
+        sb.append("Watchdog freeze-skipped rounds: ").append(freezeSkipCount);
+        if (lastFreezeSkipDetail != null) {
+            sb.append(" (last: ").append(lastFreezeSkipDetail).append(')');
+        }
+        sb.append('\n');
+    }
+
     private static void uploadPendingLogs() {
         if (appContext == null) return;
         AppExecutors.io().execute(() -> {
@@ -170,11 +215,69 @@ public final class ANRWatchdog extends Thread {
                 Log.w(TAG, "Uploading pending diagnostic logs");
                 // 只截取主线程堆栈部分上报，避免全线程快照超出 Bugly 消息限制
                 String toUpload = extractMainThreadSection(logs);
-                CrashReport.postCatchedException(new ANRError(toUpload));
+                ANRError error = new ANRError(toUpload);
+                // 与实时上报一致：把文本里的主线程堆栈还原成真实栈，避免全部折叠到 uploadPendingLogs 一个 issue
+                StackTraceElement[] parsed = parseMainThreadStack(toUpload);
+                if (parsed.length > 0) {
+                    error.setStackTrace(parsed);
+                }
+                CrashReport.postCatchedException(error);
                 DiagnosticLogFile.clear(appContext);
             } catch (Throwable ignored) {
             }
         });
+    }
+
+    /** 把 "--- Main Thread Stack ---" 段落里的 "  at cls.method(File.java:12)" 还原成 StackTraceElement。 */
+    private static StackTraceElement[] parseMainThreadStack(String block) {
+        List<StackTraceElement> frames = new ArrayList<>();
+        try {
+            int start = block.indexOf("--- Main Thread Stack ---");
+            if (start < 0) return new StackTraceElement[0];
+            String[] lines = block.substring(start).split("\n");
+            for (String raw : lines) {
+                String line = raw.trim();
+                if (!line.startsWith("at ")) {
+                    // 堆栈段结束（遇到下一个 "--- xxx ---" 或空行之后的非 at 行）就停
+                    if (frames.isEmpty()) continue;
+                    if (line.isEmpty()) continue;
+                    break;
+                }
+                StackTraceElement e = parseFrame(line.substring(3));
+                if (e != null) frames.add(e);
+                if (frames.size() >= MAX_PARSED_FRAMES) break;
+            }
+        } catch (Throwable ignored) {
+            return new StackTraceElement[0];
+        }
+        return frames.toArray(new StackTraceElement[0]);
+    }
+
+    private static StackTraceElement parseFrame(String s) {
+        int paren = s.indexOf('(');
+        if (paren <= 0 || !s.endsWith(")")) return null;
+        String qualified = s.substring(0, paren);
+        int lastDot = qualified.lastIndexOf('.');
+        if (lastDot <= 0 || lastDot == qualified.length() - 1) return null;
+        String className = qualified.substring(0, lastDot);
+        String methodName = qualified.substring(lastDot + 1);
+
+        String location = s.substring(paren + 1, s.length() - 1);
+        String fileName = null;
+        // -2 是 StackTraceElement 对 native 帧的约定编码，保证还原后 toString 仍打印 "(Native Method)"
+        int lineNumber = "Native Method".equals(location) ? -2 : -1;
+        int colon = location.lastIndexOf(':');
+        if (colon > 0) {
+            fileName = location.substring(0, colon);
+            try {
+                lineNumber = Integer.parseInt(location.substring(colon + 1));
+            } catch (NumberFormatException ignored) {
+                fileName = location;
+            }
+        } else if (!location.isEmpty() && location.indexOf(' ') < 0) {
+            fileName = location;
+        }
+        return new StackTraceElement(className, methodName, fileName, lineNumber);
     }
 
     private static String extractMainThreadSection(String logs) {

--- a/wkbase/src/test/java/com/chat/base/net/FastJsonStreamConverterTest.java
+++ b/wkbase/src/test/java/com/chat/base/net/FastJsonStreamConverterTest.java
@@ -1,0 +1,153 @@
+package com.chat.base.net;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.alibaba.fastjson.JSON;
+
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * OOM 改动的回归网：{@link FastJsonResponseBodyConverter} 超过阈值会改走 JSONReader 流式解析，
+ * 会话同步那个 350 万字符的响应必然走这条路。这里用同一份 JSON 分别跑「流式路径」和
+ * 「改动前的 parseObject(String)」，逐字段比对——少一个元素、少一个字段都要在这里挂掉。
+ */
+public class FastJsonStreamConverterTest {
+
+    private static final MediaType JSON_TYPE = MediaType.parse("application/json; charset=utf-8");
+
+    public static class Recent {
+        public String message_id;
+        public String content;
+        public long message_seq;
+    }
+
+    public static class Conversation {
+        public String channel_id;
+        public byte channel_type;
+        public long timestamp;
+        public int unread;
+        public List<Recent> recents;
+    }
+
+    public static class SyncChat {
+        public List<Conversation> conversations;
+        public String cursor;
+    }
+
+    /** 造一个字符数 >= targetChars 的响应，结构与 conv sync 同形。 */
+    private static String buildPayload(int convCount, int recentsPerConv, int contentChars) {
+        SyncChat chat = new SyncChat();
+        chat.cursor = "cursor-end";
+        chat.conversations = new ArrayList<>();
+        StringBuilder filler = new StringBuilder(contentChars);
+        for (int i = 0; i < contentChars; i++) {
+            // 混入需要转义的字符和多字节字符，覆盖 lexer 的边界处理
+            filler.append(i % 37 == 0 ? '"' : (i % 53 == 0 ? '\\' : (i % 11 == 0 ? '中' : 'a')));
+        }
+        String content = filler.toString();
+        for (int c = 0; c < convCount; c++) {
+            Conversation conv = new Conversation();
+            conv.channel_id = "channel_" + c;
+            conv.channel_type = (byte) (c % 3);
+            conv.timestamp = 1_700_000_000L + c;
+            conv.unread = c;
+            conv.recents = new ArrayList<>();
+            for (int r = 0; r < recentsPerConv; r++) {
+                Recent recent = new Recent();
+                recent.message_id = "msg_" + c + "_" + r;
+                recent.message_seq = r;
+                recent.content = content;
+                conv.recents.add(recent);
+            }
+            chat.conversations.add(conv);
+        }
+        return JSON.toJSONString(chat);
+    }
+
+    private static SyncChat convert(String payload) throws Exception {
+        FastJsonResponseBodyConverter<SyncChat> converter =
+                new FastJsonResponseBodyConverter<>(SyncChat.class);
+        return converter.convert(ResponseBody.create(payload, JSON_TYPE));
+    }
+
+    private static void assertSameAsLegacy(String payload) throws Exception {
+        SyncChat expected = JSON.parseObject(payload, SyncChat.class);
+        SyncChat actual = convert(payload);
+
+        assertNotNull("converter 返回 null", actual);
+        assertEquals("cursor 丢失", expected.cursor, actual.cursor);
+        assertEquals("会话数量对不上", expected.conversations.size(), actual.conversations.size());
+        for (int i = 0; i < expected.conversations.size(); i++) {
+            Conversation e = expected.conversations.get(i);
+            Conversation a = actual.conversations.get(i);
+            assertEquals("channel_id[" + i + "]", e.channel_id, a.channel_id);
+            assertEquals("channel_type[" + i + "]", e.channel_type, a.channel_type);
+            assertEquals("timestamp[" + i + "]", e.timestamp, a.timestamp);
+            assertEquals("unread[" + i + "]", e.unread, a.unread);
+            assertEquals("recents 条数[" + i + "]", e.recents.size(), a.recents.size());
+            for (int r = 0; r < e.recents.size(); r++) {
+                assertEquals("message_id[" + i + "][" + r + "]",
+                        e.recents.get(r).message_id, a.recents.get(r).message_id);
+                assertEquals("content[" + i + "][" + r + "]",
+                        e.recents.get(r).content, a.recents.get(r).content);
+                assertEquals("message_seq[" + i + "][" + r + "]",
+                        e.recents.get(r).message_seq, a.recents.get(r).message_seq);
+            }
+        }
+    }
+
+    /** 小于阈值：走原路径，必须与改动前逐字段一致。 */
+    @Test
+    public void smallPayloadMatchesLegacy() throws Exception {
+        String payload = buildPayload(3, 2, 100);
+        assertSameAsLegacy(payload);
+    }
+
+    /** 刚好越过 256K 字符阈值：流式路径的入口边界。 */
+    @Test
+    public void justOverThresholdMatchesLegacy() throws Exception {
+        String payload = buildPayload(40, 4, 2_000);
+        assertSameAsLegacy(payload);
+    }
+
+    /** 会话同步量级（数百会话 × 多条 recent，百万级字符）：真实场景。 */
+    @Test
+    public void syncChatSizedPayloadMatchesLegacy() throws Exception {
+        String payload = buildPayload(300, 5, 2_000);
+        assertSameAsLegacy(payload);
+    }
+
+    /** 单个超大字段跨多次 buffer 填充：lexer 跨块拼接的经典出错点。 */
+    @Test
+    public void hugeSingleFieldMatchesLegacy() throws Exception {
+        String payload = buildPayload(2, 1, 900_000);
+        assertSameAsLegacy(payload);
+    }
+
+    /** 恰好落在阈值附近的多个长度，逐个扫一遍边界。 */
+    @Test
+    public void lengthsAroundThresholdMatchLegacy() throws Exception {
+        for (int extra = -3; extra <= 3; extra++) {
+            String base = buildPayload(1, 1, 256 * 1024);
+            int target = 256 * 1024 + extra;
+            StringBuilder sb = new StringBuilder(base);
+            while (sb.length() < target) sb.insert(sb.length() - 1, ' ');
+            String payload = sb.toString();
+            SyncChat actual = convert(payload);
+            assertNotNull("len=" + payload.length() + " 返回 null", actual);
+            assertEquals("len=" + payload.length() + " 会话数对不上",
+                    1, actual.conversations.size());
+            assertEquals("len=" + payload.length() + " content 长度对不上",
+                    JSON.parseObject(payload, SyncChat.class)
+                            .conversations.get(0).recents.get(0).content.length(),
+                    actual.conversations.get(0).recents.get(0).content.length());
+        }
+    }
+}

--- a/wkbase/src/test/java/com/chat/base/net/FastJsonStreamConverterTest.java
+++ b/wkbase/src/test/java/com/chat/base/net/FastJsonStreamConverterTest.java
@@ -2,6 +2,7 @@ package com.chat.base.net;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import com.alibaba.fastjson.JSON;
 
@@ -149,5 +150,49 @@ public class FastJsonStreamConverterTest {
                             .conversations.get(0).recents.get(0).content.length(),
                     actual.conversations.get(0).recents.get(0).content.length());
         }
+    }
+
+    /**
+     * 空 body：{@code headLen == 0 -> null} 是这个转换器里唯一一处由我们手写、而非 fastjson
+     * 决定的分支，所以必须有测试钉住。改动前 {@code JSON.parseObject("")} 也是 null。
+     */
+    @Test
+    public void emptyBodyReturnsNull() throws Exception {
+        assertNull("空 body 应返回 null", convert(""));
+        assertNull("改动前的路径同样返回 null", JSON.parseObject("", SyncChat.class));
+    }
+
+    /**
+     * 截断 JSON。按大小分流最容易出的洞是两条路径抛不同类型的异常 —— 上层
+     * {@code ResponseExceptionHandle} 就会因为响应多大而走不同分支。这里钉住「同一类异常」，
+     * 小包（原路径）和越过阈值的大包（流式路径）各测一次。
+     */
+    @Test
+    public void malformedPayloadThrowsSameTypeAsLegacy() {
+        assertSameThrowAsLegacy(truncate(buildPayload(3, 2, 100)));
+        assertSameThrowAsLegacy(truncate(buildPayload(300, 5, 2_000)));
+    }
+
+    /** 砍掉尾部让结构不闭合。 */
+    private static String truncate(String payload) {
+        return payload.substring(0, payload.length() - 20);
+    }
+
+    private static void assertSameThrowAsLegacy(String payload) {
+        Class<?> legacy = null;
+        Class<?> actual = null;
+        try {
+            JSON.parseObject(payload, SyncChat.class);
+        } catch (Throwable t) {
+            legacy = t.getClass();
+        }
+        try {
+            convert(payload);
+        } catch (Throwable t) {
+            actual = t.getClass();
+        }
+        assertNotNull("改动前的路径没有抛异常，这个用例失去意义（截断得不够狠）", legacy);
+        assertEquals("两条路径抛的异常类型不一致，上层会因响应大小走不同分支",
+                legacy, actual);
     }
 }

--- a/wkim/src/main/assets/wk_sql/202608131400.sql
+++ b/wkim/src/main/assets/wk_sql/202608131400.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_reminders_undone ON reminders(type, channel_id) WHERE done=0;

--- a/wkim/src/main/assets/wk_sql/202608131600.sql
+++ b/wkim/src/main/assets/wk_sql/202608131600.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_message_flame ON message(is_deleted) WHERE flame=1;

--- a/wkim/src/main/assets/wk_sql/202608132100.sql
+++ b/wkim/src/main/assets/wk_sql/202608132100.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_message_channel_order_seq ON message(channel_id, channel_type, order_seq);
+CREATE INDEX IF NOT EXISTS idx_message_channel_msg_seq ON message(channel_id, channel_type, message_seq);

--- a/wkim/src/main/java/com/xinbida/wukongim/db/ChannelDBManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/ChannelDBManager.java
@@ -10,6 +10,7 @@ import android.text.TextUtils;
 import com.xinbida.wukongim.WKIMApplication;
 import com.xinbida.wukongim.entity.WKChannel;
 import com.xinbida.wukongim.entity.WKChannelSearchResult;
+import com.xinbida.wukongim.entity.WKChannelType;
 import com.xinbida.wukongim.utils.WKCommonUtils;
 import com.xinbida.wukongim.utils.WKLoggerUtils;
 
@@ -161,6 +162,9 @@ public class ChannelDBManager {
         } finally {
             helper.endTransaction();
         }
+        for (WKChannel wkChannel : list) {
+            invalidateMemberCacheIfPersonal(wkChannel);
+        }
     }
 
     public synchronized void insertOrUpdate(WKChannel channel) {
@@ -183,6 +187,7 @@ public class ChannelDBManager {
         }
         WKIMApplication.getInstance().getDbHelper()
                 .insert(channel, cv);
+        invalidateMemberCacheIfPersonal(wkChannel);
     }
 
     public synchronized void update(WKChannel wkChannel) {
@@ -200,7 +205,21 @@ public class ChannelDBManager {
         }
         WKIMApplication.getInstance().getDbHelper()
                 .update(channel, cv, WKDBColumns.WKChannelColumns.channel_id + "=? and " + WKDBColumns.WKChannelColumns.channel_type + "=?", update);
+        invalidateMemberCacheIfPersonal(wkChannel);
+    }
 
+    /**
+     * PERSONAL 频道行变更后，让 {@link ChannelMembersDbManager} 里以该 uid 为成员的缓存失效。
+     *
+     * <p>原因：{@code ChannelMembersDbManager.query(channelId, channelType, uid)} 的 SQL 是
+     * {@code channel_members LEFT JOIN channel ON member_uid = channel_id AND channel_type=1}，
+     * 序列化时 memberName / remark / memberAvatar / avatarCacheKey 会被 channel 表的列覆写。
+     * 所以成员缓存同时依赖 channel 表，个人频道改名/改备注/换头像后必须失效，
+     * 否则消息列表里的发送者昵称会停在旧值。
+     */
+    private void invalidateMemberCacheIfPersonal(WKChannel wkChannel) {
+        if (wkChannel == null || wkChannel.channelType != WKChannelType.PERSONAL) return;
+        ChannelMembersDbManager.getInstance().invalidateMemberUid(wkChannel.channelID);
     }
 
     /**
@@ -373,6 +392,9 @@ public class ChannelDBManager {
         whereValue[1] = String.valueOf(channelType);
         WKIMApplication.getInstance().getDbHelper()
                 .update(channel, updateKey, updateValue, where, whereValue);
+        if (channelType == WKChannelType.PERSONAL) {
+            ChannelMembersDbManager.getInstance().invalidateMemberUid(channelID);
+        }
     }
 
     public WKChannel serializableChannel(Cursor cursor) {

--- a/wkim/src/main/java/com/xinbida/wukongim/db/ChannelMembersDbManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/ChannelMembersDbManager.java
@@ -7,6 +7,7 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.text.TextUtils;
 
+import com.xinbida.wukongim.BuildConfig;
 import com.xinbida.wukongim.WKIMApplication;
 import com.xinbida.wukongim.entity.WKChannelMember;
 import com.xinbida.wukongim.manager.ChannelMembersManager;
@@ -20,6 +21,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * 2019-11-10 14:06
@@ -28,6 +32,48 @@ import java.util.List;
 public class ChannelMembersDbManager {
     private static final String TAG = "ChannelMembersDbManager";
     final String channelCols = channel + ".channel_remark," + channel + ".channel_name," + channel + ".avatar," + channel + ".avatar_cache_key";
+
+    /**
+     * 单成员缓存（对照 {@link com.xinbida.wukongim.manager.ChannelManager} 的 channelInfoCache）。
+     *
+     * <p>动机：Bugly 上 19 份 ANR 里有 7 份卡在 {@code getMember} —— RecyclerView 每 bind 一行
+     * （会话列表 {@code ChatConversationAdapter} 与聊天页 {@code WKChatBaseProvider} 两处）
+     * 都会经 {@code WKMsg.getMemberOfFrom()} 打一次本表。{@code WKMsg.memberOfFrom} 只是实例级
+     * 懒缓存，列表 rebuild / 新消息对象即作废，且**只缓存非 null**，所以「发送者不在
+     * channel_members 里」的消息每次 bind 都要重查一次 —— 故这里必须连负结果一起缓存。
+     *
+     * <p>Key：{@code channelId|channelType|memberUid}。
+     *
+     * <p>失效面（{@link #query(String, byte, String)} 的 SQL 是 channel_members LEFT JOIN channel，
+     * 见 {@link #serializableChannelMember} 里 memberName/remark/avatar 被 channel 列覆写，
+     * 所以缓存同时依赖两张表）：
+     * <ul>
+     *     <li>channel_members：本类是全仓库唯一写者（已核），所有写方法就地失效；</li>
+     *     <li>channel：{@link ChannelDBManager} 只有 4 个写方法，其中 PERSONAL 频道的写入
+     *         会回调 {@link #invalidateMemberUid(String)}。</li>
+     * </ul>
+     *
+     * <p>与 channelInfoCache 一致，命中时返回**共享实例**而非副本，调用方不得就地改字段。
+     */
+    private static final int MAX_CACHE_SIZE = 2000;
+    /** 负缓存哨兵：DB 里查不到该成员时也要记住，否则每次 bind 都重查。 */
+    private static final WKChannelMember NULL_MEMBER = new WKChannelMember();
+    private final ConcurrentHashMap<String, WKChannelMember> memberCache = new ConcurrentHashMap<>();
+    /** memberUid -> 该成员出现过的 cache key，供 channel 侧按 uid 精确失效，避免整表清空。 */
+    private final ConcurrentHashMap<String, Set<String>> keysByMemberUid = new ConcurrentHashMap<>();
+    /**
+     * 失效代际。用于堵住读穿透缓存的经典竞态：
+     * <pre>
+     * 线程B: querySlowPath 读到旧值 ──────────────┐
+     * 线程A:            写 DB + 失效（无可删）    │
+     * 线程B:                        回填旧值 ← 脏 ┘
+     * </pre>
+     * {@code insert}/{@code update}/{@code querySlowPath} 互为 synchronized 不会交错，
+     * 但 {@code insertMembers}（两个重载）与 {@code deleteWithChannel} 没有加锁，会。
+     * 故读路径在发起 DB 查询前记下代际，回填时若代际已变就丢弃本次结果
+     * （退化为不缓存，与改动前行为一致，是 fail-safe 方向）。
+     */
+    private final AtomicLong cacheGeneration = new AtomicLong();
 
     private ChannelMembersDbManager() {
     }
@@ -38,6 +84,76 @@ public class ChannelMembersDbManager {
 
     public static ChannelMembersDbManager getInstance() {
         return ChannelMembersManagerBinder.channelMembersManager;
+    }
+
+    private static String cacheKey(String channelId, byte channelType, String uid) {
+        return channelId + "|" + (int) channelType + "|" + uid;
+    }
+
+    private void putCache(String key, String memberUid, WKChannelMember member, long generation) {
+        // 代际已变说明读期间发生过写，本次结果可能已过期，直接丢弃不缓存
+        if (cacheGeneration.get() != generation) return;
+        // 惰性上限：只在超限时整清，不做 LRU —— 实际 key 数受「可见消息的发送者」约束，
+        // 正常量级在几百，2000 是防御性护栏而非常态路径。
+        if (memberCache.size() >= MAX_CACHE_SIZE) {
+            clearCache();
+            return;
+        }
+        memberCache.put(key, member == null ? NULL_MEMBER : member);
+        keysByMemberUid.computeIfAbsent(memberUid, k -> ConcurrentHashMap.newKeySet()).add(key);
+    }
+
+    private void invalidate(String channelId, byte channelType, String uid) {
+        if (TextUtils.isEmpty(channelId) || TextUtils.isEmpty(uid)) return;
+        cacheGeneration.incrementAndGet();
+        String key = cacheKey(channelId, channelType, uid);
+        memberCache.remove(key);
+        Set<String> keys = keysByMemberUid.get(uid);
+        if (keys != null) keys.remove(key);
+    }
+
+    private void invalidate(WKChannelMember member) {
+        if (member == null) return;
+        invalidate(member.channelID, member.channelType, member.memberUID);
+    }
+
+    private void invalidate(List<WKChannelMember> list) {
+        if (WKCommonUtils.isEmpty(list)) return;
+        for (WKChannelMember member : list) {
+            invalidate(member);
+        }
+    }
+
+    /**
+     * 某个频道整体失效（{@link #deleteWithChannel} 用）。调用频率极低，扫全表可接受。
+     */
+    private void invalidateChannel(String channelId, byte channelType) {
+        if (TextUtils.isEmpty(channelId)) return;
+        cacheGeneration.incrementAndGet();
+        String prefix = channelId + "|" + (int) channelType + "|";
+        for (String key : memberCache.keySet()) {
+            if (key.startsWith(prefix)) memberCache.remove(key);
+        }
+    }
+
+    /**
+     * PERSONAL 频道行变更时由 {@link ChannelDBManager} 回调：该 uid 作为成员出现过的所有
+     * 缓存条目全部失效（因为 memberName / remark / avatar 是从 channel 表 join 出来的）。
+     */
+    public void invalidateMemberUid(String memberUid) {
+        if (TextUtils.isEmpty(memberUid)) return;
+        cacheGeneration.incrementAndGet();
+        Set<String> keys = keysByMemberUid.remove(memberUid);
+        if (keys == null) return;
+        for (String key : keys) {
+            memberCache.remove(key);
+        }
+    }
+
+    public void clearCache() {
+        cacheGeneration.incrementAndGet();
+        memberCache.clear();
+        keysByMemberUid.clear();
     }
 
     public synchronized List<WKChannelMember> search(String channelId, byte channelType, String keyword, int page, int size) {
@@ -169,10 +285,59 @@ public class ChannelMembersDbManager {
     /**
      * 查询单个频道成员
      *
+     * <p>快路径：ConcurrentHashMap 无锁命中直接返回，**不进 synchronized 慢路径**。
+     * 这点和 {@code ChannelManager.getChannel} 同构，同时解掉线上实测的
+     * {@code Long monitor contention with owner main ... for 677ms} —— 原实现整个方法
+     * synchronized，主线程在锁内等 SQLCipher 连接时会把所有后台线程的成员查询一并堵死。
+     *
      * @param channelId 频道ID
      * @param uid       用户ID
      */
-    public synchronized WKChannelMember query(String channelId, byte channelType, String uid) {
+    public WKChannelMember query(String channelId, byte channelType, String uid) {
+        if (TextUtils.isEmpty(channelId) || TextUtils.isEmpty(uid)) return null;
+        WKChannelMember cached = memberCache.get(cacheKey(channelId, channelType, uid));
+        if (cached != null) {
+            if (BuildConfig.DEBUG) debugCountHit();
+            return cached == NULL_MEMBER ? null : cached;
+        }
+        if (BuildConfig.DEBUG) debugCountMiss();
+        return querySlowPath(channelId, channelType, uid);
+    }
+
+    // ---- debug-only 命中率埋点（release 由 BuildConfig.DEBUG 短路，字段也不会被读）----
+    private static final String CACHE_TAG = "ANRFix-MemberCache";
+    private long debugHit;
+    private long debugMiss;
+    private long debugLastLogAt;
+
+    private void debugCountHit() {
+        debugHit++;
+        debugMaybeLog();
+    }
+
+    private void debugCountMiss() {
+        debugMiss++;
+        debugMaybeLog();
+    }
+
+    /** 每 5 秒最多打一行，避免 bind 路径上刷屏反过来影响测量。计数存在良性竞争，只用于看量级。 */
+    private void debugMaybeLog() {
+        long now = android.os.SystemClock.elapsedRealtime();
+        if (now - debugLastLogAt < 5000) return;
+        debugLastLogAt = now;
+        long total = debugHit + debugMiss;
+        android.util.Log.d(CACHE_TAG, "hit=" + debugHit + " miss=" + debugMiss
+                + " hitRate=" + (total == 0 ? 0 : debugHit * 100 / total) + "%"
+                + " size=" + memberCache.size());
+    }
+
+    private synchronized WKChannelMember querySlowPath(String channelId, byte channelType, String uid) {
+        String key = cacheKey(channelId, channelType, uid);
+        // double-check：进 synchronized 之前可能另一线程已经回填
+        WKChannelMember cached = memberCache.get(key);
+        if (cached != null) return cached == NULL_MEMBER ? null : cached;
+
+        long generation = cacheGeneration.get();
         WKChannelMember wkChannelMember = null;
         Object[] args = new Object[3];
         args[0] = channelId;
@@ -183,12 +348,14 @@ public class ChannelMembersDbManager {
                 .getInstance()
                 .getDbHelper().rawQuery(sql, args)) {
             if (cursor == null) {
+                // DB 不可用属于瞬时态，不进缓存，否则会把「库还没开」固化成负结果
                 return null;
             }
             if (cursor.moveToLast()) {
                 wkChannelMember = serializableChannelMember(cursor);
             }
         }
+        putCache(key, uid, wkChannelMember, generation);
         return wkChannelMember;
     }
 
@@ -203,6 +370,7 @@ public class ChannelMembersDbManager {
         }
         WKIMApplication.getInstance().getDbHelper()
                 .insert(channelMembers, cv);
+        invalidate(channelMember);
     }
 
     /**
@@ -232,6 +400,7 @@ public class ChannelMembersDbManager {
         } finally {
             helper.endTransaction();
         }
+        invalidate(list);
     }
 
     public void insertMembers(List<WKChannelMember> allMemberList, List<WKChannelMember> existList) {
@@ -265,6 +434,7 @@ public class ChannelMembersDbManager {
         } finally {
             helper.endTransaction();
         }
+        invalidate(allMemberList);
     }
 
     public void insertOrUpdate(WKChannelMember channelMember) {
@@ -294,6 +464,7 @@ public class ChannelMembersDbManager {
         }
         WKIMApplication.getInstance().getDbHelper()
                 .update(channelMembers, cv, WKDBColumns.WKChannelMembersColumns.channel_id + "=? and " + WKDBColumns.WKChannelMembersColumns.channel_type + "=? and " + WKDBColumns.WKChannelMembersColumns.member_uid + "=?", update);
+        invalidate(channelMember);
     }
 
     /**
@@ -316,6 +487,8 @@ public class ChannelMembersDbManager {
         int row = WKIMApplication.getInstance().getDbHelper()
                 .update(channelMembers, updateKey, updateValue, where, whereValue);
         if (row > 0) {
+            // 必须在下面 query 之前失效，否则会把改前的旧值重新读回来并回填缓存
+            invalidate(channelID, channelType, uid);
             WKChannelMember channelMember = query(channelID, channelType, uid);
             if (channelMember != null)
                 //刷新频道成员信息
@@ -330,6 +503,7 @@ public class ChannelMembersDbManager {
         selectionArgs[0] = channelID;
         selectionArgs[1] = String.valueOf(channelType);
         WKIMApplication.getInstance().getDbHelper().delete(channelMembers, selection, selectionArgs);
+        invalidateChannel(channelID, channelType);
     }
 
     /**

--- a/wkim/src/main/java/com/xinbida/wukongim/db/ChannelMembersDbManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/ChannelMembersDbManager.java
@@ -53,7 +53,10 @@ public class ChannelMembersDbManager {
      *         会回调 {@link #invalidateMemberUid(String)}。</li>
      * </ul>
      *
-     * <p>与 channelInfoCache 一致，命中时返回**共享实例**而非副本，调用方不得就地改字段。
+     * <p>命中时返回**副本**：缓存条目是进程级共享的，若把实例交出去，调用方就地改字段
+     * （如 ChatActivity 收到 PERSONAL 频道刷新后改 memberName/memberRemark）会污染所有
+     * 引用它的消息，且写入的语义可能不同（channel.channelRemark 是个人频道备注，
+     * member_remark 是群内备注）。副本是一次浅拷贝，比它替掉的那次 DB 查询便宜得多。
      */
     private static final int MAX_CACHE_SIZE = 2000;
     /** 负缓存哨兵：DB 里查不到该成员时也要记住，否则每次 bind 都重查。 */
@@ -72,6 +75,10 @@ public class ChannelMembersDbManager {
      * 但 {@code insertMembers}（两个重载）与 {@code deleteWithChannel} 没有加锁，会。
      * 故读路径在发起 DB 查询前记下代际，回填时若代际已变就丢弃本次结果
      * （退化为不缓存，与改动前行为一致，是 fail-safe 方向）。
+     *
+     * <p>回填做**两次**代际检查：put 之前一次是快速退出，put 之后再一次才是真正关窗口 ——
+     * 只查 put 之前的话，失效落在 check 与 put 之间时脏值会被写在删除之后，而这份缓存没有
+     * TTL，错的昵称/头像会一直钉到下次该成员被写或切账号。见 {@link #putCache}。
      */
     private final AtomicLong cacheGeneration = new AtomicLong();
 
@@ -99,8 +106,42 @@ public class ChannelMembersDbManager {
             clearCache();
             return;
         }
-        memberCache.put(key, member == null ? NULL_MEMBER : member);
+        memberCache.put(key, member == null ? NULL_MEMBER : copyOf(member));
+        // put 之后复查：失效可能落在上面那次 check 与这次 put 之间（insertMembers /
+        // deleteWithChannel 不与本方法互斥），那样 remove 先发生、脏值后写入就永久留下。
+        // 两种交错都安全：失效方的 remove 与这里的 remove 至少有一个在 put 之后执行。
+        if (cacheGeneration.get() != generation) {
+            memberCache.remove(key);
+            return;
+        }
         keysByMemberUid.computeIfAbsent(memberUid, k -> ConcurrentHashMap.newKeySet()).add(key);
+    }
+
+    /**
+     * 浅拷贝。{@code extraMap} 也复制一层，否则调用方改 map 内容照样穿透到缓存条目。
+     */
+    private static WKChannelMember copyOf(WKChannelMember src) {
+        WKChannelMember copy = new WKChannelMember();
+        copy.id = src.id;
+        copy.channelID = src.channelID;
+        copy.channelType = src.channelType;
+        copy.memberUID = src.memberUID;
+        copy.memberName = src.memberName;
+        copy.memberRemark = src.memberRemark;
+        copy.memberAvatar = src.memberAvatar;
+        copy.memberAvatarCacheKey = src.memberAvatarCacheKey;
+        copy.role = src.role;
+        copy.status = src.status;
+        copy.isDeleted = src.isDeleted;
+        copy.createdAt = src.createdAt;
+        copy.updatedAt = src.updatedAt;
+        copy.version = src.version;
+        copy.robot = src.robot;
+        copy.remark = src.remark;
+        copy.memberInviteUID = src.memberInviteUID;
+        copy.forbiddenExpirationTime = src.forbiddenExpirationTime;
+        copy.extraMap = src.extraMap == null ? null : new HashMap<>(src.extraMap);
+        return copy;
     }
 
     private void invalidate(String channelId, byte channelType, String uid) {
@@ -132,7 +173,13 @@ public class ChannelMembersDbManager {
         cacheGeneration.incrementAndGet();
         String prefix = channelId + "|" + (int) channelType + "|";
         for (String key : memberCache.keySet()) {
-            if (key.startsWith(prefix)) memberCache.remove(key);
+            if (!key.startsWith(prefix)) continue;
+            memberCache.remove(key);
+            // 反向索引同步剪掉，否则频道反复删除时它只增不减：上限只看 memberCache.size()，
+            // 拦不住这里的孤儿 key。空 Set 留着不删 —— 删它有「删除瞬间另一线程刚 add」的
+            // 竞态，代价是漏一次失效（脏名字），比留一个空 Set 的代价大。
+            Set<String> keys = keysByMemberUid.get(key.substring(prefix.length()));
+            if (keys != null) keys.remove(key);
         }
     }
 
@@ -298,7 +345,7 @@ public class ChannelMembersDbManager {
         WKChannelMember cached = memberCache.get(cacheKey(channelId, channelType, uid));
         if (cached != null) {
             if (BuildConfig.DEBUG) debugCountHit();
-            return cached == NULL_MEMBER ? null : cached;
+            return cached == NULL_MEMBER ? null : copyOf(cached);
         }
         if (BuildConfig.DEBUG) debugCountMiss();
         return querySlowPath(channelId, channelType, uid);
@@ -335,7 +382,7 @@ public class ChannelMembersDbManager {
         String key = cacheKey(channelId, channelType, uid);
         // double-check：进 synchronized 之前可能另一线程已经回填
         WKChannelMember cached = memberCache.get(key);
-        if (cached != null) return cached == NULL_MEMBER ? null : cached;
+        if (cached != null) return cached == NULL_MEMBER ? null : copyOf(cached);
 
         long generation = cacheGeneration.get();
         WKChannelMember wkChannelMember = null;

--- a/wkim/src/main/java/com/xinbida/wukongim/db/ConversationDbManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/ConversationDbManager.java
@@ -345,6 +345,41 @@ public class ConversationDbManager {
         return conversationMsg;
     }
 
+    /**
+     * 批量版 {@link #queryWithChannel(String, byte)}：同一 channelType 下一次查回多个会话。
+     *
+     * <p>用于子区预览卡这类「一次 bind 要读 K 个子区会话」的场景，把 K 次带两个 left join 的
+     * 查询压成 1 次。SQL、join 与 is_deleted 过滤跟单条版逐字一致，返回的行用同一个
+     * {@code serializeMsg} 反序列化，保证与逐条查询结果等价。
+     *
+     * <p>分片 500 规避 SQLite 999 变量上限（同 {@link #queryWithExtraChannelIds}）。
+     */
+    public List<WKConversationMsg> queryWithChannelIds(List<String> channelIDs, byte channelType) {
+        List<WKConversationMsg> list = new ArrayList<>();
+        if (channelIDs == null || channelIDs.isEmpty()) return list;
+        int chunkSize = 500;
+        for (int start = 0; start < channelIDs.size(); start += chunkSize) {
+            int end = Math.min(start + chunkSize, channelIDs.size());
+            List<String> chunk = channelIDs.subList(start, end);
+            String sql = "select " + conversation + ".*," + channelCols + "," + extraCols + " from " + conversation + " left join " + channel + " on " + conversation + ".channel_id=" + channel + ".channel_id and " + conversation + ".channel_type=" + channel + ".channel_type left join " + conversationExtra + " on " + conversation + ".channel_id=" + conversationExtra + ".channel_id and " + conversation + ".channel_type=" + conversationExtra + ".channel_type where " + conversation + ".channel_id in (" + WKCursor.getPlaceholders(chunk.size()) + ") and " + conversation + ".channel_type=? and " + conversation + ".is_deleted=0";
+            Object[] args = new Object[chunk.size() + 1];
+            for (int i = 0; i < chunk.size(); i++) {
+                args[i] = chunk.get(i);
+            }
+            args[chunk.size()] = channelType;
+            try (Cursor cursor = WKIMApplication.getInstance().getDbHelper().rawQuery(sql, args)) {
+                if (cursor == null) continue;
+                for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext()) {
+                    WKConversationMsg msg = serializeMsg(cursor);
+                    if (msg != null) list.add(msg);
+                }
+            } catch (Exception e) {
+                WKLoggerUtils.getInstance().e(TAG, "queryWithChannelIds chunk error");
+            }
+        }
+        return list;
+    }
+
     public synchronized boolean deleteWithChannel(String channelID, byte channelType, int isDeleted) {
         String[] update = new String[2];
         update[0] = channelID;

--- a/wkim/src/main/java/com/xinbida/wukongim/db/ConversationDbManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/ConversationDbManager.java
@@ -257,9 +257,29 @@ public class ConversationDbManager {
         helper.insertSql(conversation, cv);
     }
 
+    /**
+     * 构造 sync 用的 lastMsgSeq 串（每次 WebSocket 连上都会跑一次）。
+     *
+     * <p>线上实测过 54.7 秒（Bugly #89，占着唯一连接把主线程堵死）。三个问题叠加：
+     * <ol>
+     *     <li>相关子查询：每个 conversation 行跑一次 {@code max(message_seq)}；</li>
+     *     <li><b>过滤条件写在外层</b>：内层派生表是裸的 {@code select * from conversation}，
+     *         已删除 / 空 channel_id 的会话也要完整跑一遍子查询，算完再被外层丢掉；</li>
+     *     <li>{@code message_seq} 没有覆盖索引，求 max 要把命中行逐条回表。</li>
+     * </ol>
+     *
+     * <p>本次改 2（把 {@code is_deleted=0 AND channel_id<>''} 下推进派生表）+
+     * 3（{@code 202608132100.sql} 加 {@code idx_message_channel_msg_seq}）。
+     * 1 是语义本身要求的，不动。
+     *
+     * <p>结果集等价：下推的两个条件都是 {@code conversation} 自己的列，
+     * {@code select *} 原样透传，先过滤后计算与先计算后过滤的存活行集合完全相同，
+     * 只是不再为注定被丢弃的行付子查询的代价。
+     */
     public synchronized String queryLastMsgSeqs() {
         String lastMsgSeqs = "";
-        String sql = "select GROUP_CONCAT(channel_id||':'||channel_type||':'|| last_seq,'|') synckey from (select *,(select max(message_seq) from " + message + " where " + message + ".channel_id=" + conversation + ".channel_id and " + message + ".channel_type=" + conversation + ".channel_type limit 1) last_seq from " + conversation + ") cn where channel_id<>'' AND is_deleted=0";
+        String sql = "select GROUP_CONCAT(channel_id||':'||channel_type||':'|| last_seq,'|') synckey from (select *,(select max(message_seq) from " + message + " where " + message + ".channel_id=" + conversation + ".channel_id and " + message + ".channel_type=" + conversation + ".channel_type limit 1) last_seq from " + conversation + " where " + conversation + ".channel_id<>'' AND " + conversation + ".is_deleted=0) cn";
+
         WKDBHelper helper = WKIMApplication.getInstance().getDbHelper();
         if (helper == null || helper.isClosed()) return lastMsgSeqs;
         Cursor cursor = helper.rawQuery(sql);

--- a/wkim/src/main/java/com/xinbida/wukongim/db/ConversationDbManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/ConversationDbManager.java
@@ -374,7 +374,10 @@ public class ConversationDbManager {
                     if (msg != null) list.add(msg);
                 }
             } catch (Exception e) {
-                WKLoggerUtils.getInstance().e(TAG, "queryWithChannelIds chunk error");
+                // WKLoggerUtils 走 WKIM.isDebug()，本仓库 setDebug(true) 写死 → 不包 DEBUG 会进 release
+                if (com.xinbida.wukongim.BuildConfig.DEBUG) {
+                    WKLoggerUtils.getInstance().e(TAG, "queryWithChannelIds chunk error");
+                }
             }
         }
         return list;

--- a/wkim/src/main/java/com/xinbida/wukongim/db/MsgDbManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/MsgDbManager.java
@@ -1034,6 +1034,18 @@ public class MsgDbManager {
     }
 
     public List<WKMsg> insertOrReplaceExtra(List<WKMsgExtra> list) {
+        return insertOrReplaceExtra(list, true);
+    }
+
+    /**
+     * @param needUpdatedMsgs 是否需要返回「更新后的消息列表」。
+     *                        <p>false 时跳过末尾的 {@link #queryWithMsgIds(List)} —— 那一步会把刚写入
+     *                        extra 的每条消息重新查回来并 {@code serializeMsg}，其中包含把每条 content
+     *                        解析成 {@code org.json.JSONObject} DOM（交互卡这类深层嵌套结构尤其重）。
+     *                        冷启动会话同步一次几千条时，这批临时对象是几百 MB 级别，线上 OOM 的崩溃栈
+     *                        就停在这里。调用方不用返回值时必须传 false。
+     */
+    public List<WKMsg> insertOrReplaceExtra(List<WKMsgExtra> list, boolean needUpdatedMsgs) {
         List<String> msgIds = new ArrayList<>();
         List<ContentValues> cvList = new ArrayList<>();
         for (int i = 0, size = list.size(); i < size; i++) {
@@ -1058,6 +1070,9 @@ public class MsgDbManager {
             WKLoggerUtils.getInstance().e(TAG, "insertOrReplace error");
         } finally {
             helper.endTransaction();
+        }
+        if (!needUpdatedMsgs) {
+            return new ArrayList<>();
         }
         List<WKMsg> msgList = queryWithMsgIds(msgIds);
         return msgList;
@@ -1462,6 +1477,12 @@ public class MsgDbManager {
     }
 
     public List<WKMsg> queryWithMsgIds(List<String> messageIds) {
+        // OOM 诊断：这是线上崩溃栈停住的函数。批量大时（同步路径）打一条水位，
+        // 小批量（单条编辑/撤回）不打，避免刷屏。问题闭环后删。
+        final boolean probe = com.xinbida.wukongim.BuildConfig.DEBUG && messageIds.size() > 200;
+        if (probe) {
+            com.xinbida.wukongim.utils.WKHeapProbe.mark("queryWithMsgIds enter", "ids=" + messageIds.size());
+        }
 
         String sql = "select " + messageCols + "," + extraCols + " from " + message + " left join " + messageExtra + " on " + message + ".message_id=" + messageExtra + ".message_id where " + message + ".message_id in (" + WKCursor.getPlaceholders(messageIds.size()) + ")";
         List<WKMsg> list = new ArrayList<>();
@@ -1558,6 +1579,14 @@ public class MsgDbManager {
                     }
                 }
             }
+        }
+        if (probe) {
+            long chars = 0;
+            for (int i = 0, size = list.size(); i < size; i++) {
+                if (list.get(i).content != null) chars += list.get(i).content.length();
+            }
+            com.xinbida.wukongim.utils.WKHeapProbe.mark("queryWithMsgIds exit",
+                    "rows=" + list.size() + " contentChars=" + chars);
         }
         return list;
     }

--- a/wkim/src/main/java/com/xinbida/wukongim/db/MsgDbManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/MsgDbManager.java
@@ -62,7 +62,6 @@ public class MsgDbManager {
         return MsgDbManagerBinder.db;
     }
 
-    private int requestCount;
     //    private int more = 1;
     private final HashMap<String, Long> channelMinMsgSeqs = new HashMap<>();
     //  P1-1: per-channel preview gate. Without this, a channel-level
@@ -72,6 +71,48 @@ public class MsgDbManager {
     // Keyed by channelId + channelType + oldestOrderSeq so every distinct
     // load (first-open / paging) gets its own one-shot gate.
     private final ConcurrentHashMap<String, Boolean> previewPosted = new ConcurrentHashMap<>();
+    /**
+     * 同步轮次计数，key 与 {@link #previewPosted} 同为
+     * {@code channelId_channelType_oldestOrderSeq}。
+     *
+     * <p>原先是单例字段 {@code private int requestCount}，是上一轮修 {@code previewPosted}
+     * 时漏掉的同一类坑：它跨频道、跨分页位置共享，于是
+     * <ul>
+     *     <li>A 频道把它顶到 5（服务端某轮返回不足一页）后，</li>
+     *     <li>B 频道（或同频道的下一个 oldestOrderSeq）进来时 {@code requestCount < 5}
+     *         直接不成立 → 跳过同步分支 → 把本地查询结果原样上报；</li>
+     *     <li>若本地那一段恰好是空洞，上报的就是空 list，
+     *         而 UI 侧把空 list 当成「到头了」永久关掉加载开关。</li>
+     * </ul>
+     * 改为按 key 隔离后，每次独立的加载各自计数，互不污染。递归调用沿用同一个
+     * {@code oldestOrderSeq}，所以 key 在递归过程中稳定。
+     */
+    private final ConcurrentHashMap<String, Integer> requestCounts = new ConcurrentHashMap<>();
+
+    private int getRequestCount(String key) {
+        Integer count = requestCounts.get(key);
+        return count == null ? 0 : count;
+    }
+
+    /**
+     * 两个闸门 map 都只在终止分支清理，若某次加载的同步回调始终不回来（进程被冻结、
+     * 请求被丢弃等），条目会留下。加个上限阀：超了整清。清空是 fail-open ——
+     * 在途加载的计数归零，最坏结果是多同步一轮 / 多 post 一次 preview
+     * （{@code ChatActivity.applyDataToAdapter} 本来就能处理重复回调），
+     * 比让泄漏条目把某个分页位置永久闸死安全。
+     */
+    private void guardLoadGateSize() {
+        if (requestCounts.size() > 256 || previewPosted.size() > 256) {
+            requestCounts.clear();
+            previewPosted.clear();
+        }
+    }
+
+    /** 终止分支统一收口：同步轮次与 preview 闸门一起清，避免其中一个泄漏。 */
+    private void clearLoadGates(String key) {
+        requestCounts.remove(key);
+        previewPosted.remove(key);
+    }
 
     public void queryOrSyncHistoryMessages(String channelId, byte channelType, long oldestOrderSeq, boolean contain, int pullMode, int limit, final IGetOrSyncHistoryMsgBack iGetOrSyncHistoryMsgBack) {
         //获取原始数据
@@ -205,10 +246,8 @@ public class MsgDbManager {
                 }
             }
             if (minMessageSeq == minSeq) {
-                requestCount = 0;
-//                more = 1;
                 //  P1-1: clear the preview gate on terminal callback
-                previewPosted.remove(previewKey);
+                clearLoadGates(previewKey);
                 new Handler(Looper.getMainLooper()).post(() -> iGetOrSyncHistoryMsgBack.onResult(list));
                 return;
             }
@@ -232,31 +271,29 @@ public class MsgDbManager {
             endMsgSeq = oldestMsgSeq;
             startMsgSeq = 0;
         }
+        int requestCount = getRequestCount(previewKey);
         if (isSyncMsg && requestCount < 5) {
             if (requestCount == 0) {
                 new Handler(Looper.getMainLooper()).post(iGetOrSyncHistoryMsgBack::onSyncing);
             }
             //同步消息
-            requestCount++;
+            guardLoadGateSize();
+            requestCounts.put(previewKey, requestCount + 1);
             MsgManager.getInstance().setSyncChannelMsgListener(channelId, channelType, startMsgSeq, endMsgSeq, limit, pullMode, syncChannelMsg -> {
                 if (syncChannelMsg != null) {
                     if (oldestMsgSeq == 0 || (syncChannelMsg.messages != null && syncChannelMsg.messages.size() < limit)) {
-                        requestCount = 5;
+                        requestCounts.put(previewKey, 5);
                     }
                     queryOrSyncHistoryMessages(channelId, channelType, oldestOrderSeq, contain, pullMode, limit, iGetOrSyncHistoryMsgBack);
                 } else {
-                    requestCount = 0;
-//                    more = 1;
                     //  P1-1: clear the preview gate on terminal callback
-                    previewPosted.remove(previewKey);
+                    clearLoadGates(previewKey);
                     new Handler(Looper.getMainLooper()).post(() -> iGetOrSyncHistoryMsgBack.onResult(list));
                 }
             });
         } else {
-            requestCount = 0;
-//            more = 1;
             //  P1-1: clear the preview gate on terminal callback
-            previewPosted.remove(previewKey);
+            clearLoadGates(previewKey);
             new Handler(Looper.getMainLooper()).post(() -> iGetOrSyncHistoryMsgBack.onResult(list));
         }
     }

--- a/wkim/src/main/java/com/xinbida/wukongim/db/MsgDbManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/MsgDbManager.java
@@ -285,8 +285,21 @@ public class MsgDbManager {
         return minSeq;
     }
 
+    /**
+     * 查出未删除的阅后即焚消息。
+     *
+     * <p>只取清理逻辑真正要用的列，**不返回完整 WKMsg** —— 原来是 {@code select *}，会把每条
+     * 消息的 content / searchable_word 等大字段全读出来再由 SQLCipher 逐页解密，配合 flame 列
+     * 上没有索引的整表扫描，线上实测单次执行 89 秒并独占连接（Bugly ANRWatchdog）。
+     *
+     * <p>已填充字段：clientMsgNO / messageID / channelID / channelType / messageSeq /
+     * flame / flameSecond / viewed / viewedAt。其余字段保持默认值。
+     */
     public List<WKMsg> queryWithFlame() {
-        String sql = "select * from " + message + " where " + WKDBColumns.WKMessageColumns.flame + "=1 and " + WKDBColumns.WKMessageColumns.is_deleted + "=0";
+        String sql = "select client_msg_no,message_id,channel_id,channel_type,message_seq,"
+                + "flame,flame_second,viewed,viewed_at from " + message
+                + " where " + WKDBColumns.WKMessageColumns.flame + "=1 and "
+                + WKDBColumns.WKMessageColumns.is_deleted + "=0";
         List<WKMsg> list = new ArrayList<>();
         WKDBHelper dbHelper = WKIMApplication.getInstance().getDbHelper();
         if (dbHelper == null) return list;
@@ -295,8 +308,17 @@ public class MsgDbManager {
                 return list;
             }
             for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext()) {
-                WKMsg extra = serializeMsg(cursor);
-                list.add(extra);
+                WKMsg msg = new WKMsg();
+                msg.clientMsgNO = WKCursor.readString(cursor, WKDBColumns.WKMessageColumns.client_msg_no);
+                msg.messageID = WKCursor.readString(cursor, WKDBColumns.WKMessageColumns.message_id);
+                msg.channelID = WKCursor.readString(cursor, WKDBColumns.WKMessageColumns.channel_id);
+                msg.channelType = WKCursor.readByte(cursor, WKDBColumns.WKMessageColumns.channel_type);
+                msg.messageSeq = WKCursor.readInt(cursor, WKDBColumns.WKMessageColumns.message_seq);
+                msg.flame = WKCursor.readInt(cursor, WKDBColumns.WKMessageColumns.flame);
+                msg.flameSecond = WKCursor.readInt(cursor, WKDBColumns.WKMessageColumns.flame_second);
+                msg.viewed = WKCursor.readInt(cursor, WKDBColumns.WKMessageColumns.viewed);
+                msg.viewedAt = WKCursor.readLong(cursor, WKDBColumns.WKMessageColumns.viewed_at);
+                list.add(msg);
             }
         }
         return list;

--- a/wkim/src/main/java/com/xinbida/wukongim/db/ReminderDBManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/ReminderDBManager.java
@@ -92,7 +92,10 @@ public class ReminderDBManager {
                 }
             }
         } catch (Exception e) {
-            WKLoggerUtils.getInstance().e(TAG, "queryUndoneChannelIds error");
+            // WKLoggerUtils 走 WKIM.isDebug()，本仓库 setDebug(true) 写死 → 不包 DEBUG 会进 release
+            if (BuildConfig.DEBUG) {
+                WKLoggerUtils.getInstance().e(TAG, "queryUndoneChannelIds error");
+            }
         }
         if (BuildConfig.DEBUG) {
             Log.d(WKDBHelper.PERF_TAG, "[reminder] batched query: 1 query, rows=" + channelIds.size()

--- a/wkim/src/main/java/com/xinbida/wukongim/db/ReminderDBManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/ReminderDBManager.java
@@ -5,7 +5,9 @@ import static com.xinbida.wukongim.db.WKDBColumns.TABLE.reminders;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.text.TextUtils;
+import android.util.Log;
 
+import com.xinbida.wukongim.BuildConfig;
 import com.xinbida.wukongim.WKIM;
 import com.xinbida.wukongim.WKIMApplication;
 import com.xinbida.wukongim.entity.WKReminder;
@@ -18,8 +20,11 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 public class ReminderDBManager {
     private static final String TAG = "ReminderDBManager";
@@ -65,19 +70,62 @@ public class ReminderDBManager {
     }
 
     /**
-     * 查询指定父群下所有子区的未完成提醒（channel_id LIKE 'groupNo____%'）
+     * 一次取出指定类型全部未完成提醒的 channel_id，由调用方在内存里做前缀匹配。
+     *
+     * <p>取代原来按父群逐个查 {@code channel_id LIKE 'groupNo____%'} 的写法：通配符不在末尾时
+     * SQLite 的 LIKE 索引优化本就受限，而 idx_channel 是 BINARY 排序、case_sensitive_like 默认
+     * OFF，两者不匹配 → 优化彻底失效，每次都是全表扫。会话列表刷新按分组 × 群循环调用，
+     * 主线程上放大成 N 次全表扫，是 ANRWatchdog 那批 ANR 的直接触发点。
      */
-    public boolean hasUndoneReminderWithChannelPrefix(String groupNo, int reminderType) {
-        String prefix = groupNo + "____%";
-        String sql = "select 1 from " + reminders + " where channel_id LIKE ? and done=0 and type=? limit 1";
+    public Set<String> queryUndoneChannelIds(int reminderType) {
+        final long startNs = BuildConfig.DEBUG ? System.nanoTime() : 0L;
+        Set<String> channelIds = new HashSet<>();
         WKDBHelper dbHelper = WKIMApplication.getInstance().getDbHelper();
-        if (dbHelper == null) return false;
-        try (Cursor cursor = dbHelper.rawQuery(sql, new Object[]{prefix, reminderType})) {
-            return cursor != null && cursor.moveToFirst();
+        if (dbHelper == null) return channelIds;
+        String sql = "select channel_id from " + reminders + " where done=0 and type=?";
+        try (Cursor cursor = dbHelper.rawQuery(sql, new Object[]{reminderType})) {
+            if (cursor == null) return channelIds;
+            for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext()) {
+                String channelId = cursor.getString(0);
+                if (!TextUtils.isEmpty(channelId)) {
+                    channelIds.add(channelId);
+                }
+            }
         } catch (Exception e) {
-            WKLoggerUtils.getInstance().e(TAG, "hasUndoneReminderWithChannelPrefix error");
-            return false;
+            WKLoggerUtils.getInstance().e(TAG, "queryUndoneChannelIds error");
         }
+        if (BuildConfig.DEBUG) {
+            Log.d(WKDBHelper.PERF_TAG, "[reminder] batched query: 1 query, rows=" + channelIds.size()
+                    + ", cost=" + fmtMs(System.nanoTime() - startNs)
+                    + ", thread=" + Thread.currentThread().getName());
+        }
+        return channelIds;
+    }
+
+    /**
+     * 仅 debug：跑一遍改动前的逐个 {@code LIKE 'channelId____%'} 查法并计时，用于和
+     * {@link #queryUndoneChannelIds} 做同机同数据的 A/B 对比。由调用方显式开关，默认不跑。
+     */
+    public void debugCompareLegacyPrefixScan(List<String> channelIds, int reminderType) {
+        if (!BuildConfig.DEBUG) return;
+        WKDBHelper dbHelper = WKIMApplication.getInstance().getDbHelper();
+        if (dbHelper == null || channelIds == null || channelIds.isEmpty()) return;
+        String sql = "select 1 from " + reminders + " where channel_id LIKE ? and done=0 and type=? limit 1";
+        long startNs = System.nanoTime();
+        int hits = 0;
+        for (String channelId : channelIds) {
+            try (Cursor cursor = dbHelper.rawQuery(sql,
+                    new Object[]{channelId + "____%", reminderType})) {
+                if (cursor != null && cursor.moveToFirst()) hits++;
+            } catch (Exception ignored) {
+            }
+        }
+        Log.d(WKDBHelper.PERF_TAG, "[reminder] LEGACY per-channel LIKE: " + channelIds.size()
+                + " queries, hits=" + hits + ", cost=" + fmtMs(System.nanoTime() - startNs));
+    }
+
+    private static String fmtMs(long elapsedNs) {
+        return String.format(Locale.US, "%.2fms", elapsedNs / 1_000_000.0);
     }
 
     /**

--- a/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
@@ -516,12 +516,30 @@ public class WKDBHelper {
      * <p>release 也记录，走 {@link WKLoggerUtils}，Bugly 能捞到。
      */
     private Cursor guardCursor(Cursor cursor, String sql, long acquireMs) {
-        if (acquireMs >= SLOW_ACQUIRE_MS) {
+        if (acquireMs >= SLOW_ACQUIRE_MS && shouldLogSlow("acquire:" + abbreviate(sql))) {
             WKLoggerUtils.getInstance().e(TAG, "[slow-db] acquire=" + acquireMs + "ms thread="
                     + Thread.currentThread().getName() + " sql=" + abbreviate(sql));
         }
         if (cursor == null) return null;
         return new SlowQueryCursor(cursor, sql);
+    }
+
+    private static final long SLOW_LOG_MIN_INTERVAL_MS = 60_000;
+    private static final int SLOW_LOG_KEY_CAP = 200;
+    private static final Map<String, Long> slowLogLastAt = new ConcurrentHashMap<>();
+
+    /**
+     * 按 SQL 节流：慢 DB 通常是持续状态（一次同步里同一条 SQL 反复超时），而这些日志走
+     * {@link WKLoggerUtils} 在 release 也会落盘。不节流就等于给一台已经在挣扎的设备再加一份
+     * 无上界的磁盘 IO —— 信号一条就够，重复的只是放大故障。计数存在良性竞争，不影响用途。
+     */
+    private static boolean shouldLogSlow(String key) {
+        long now = SystemClock.elapsedRealtime();
+        if (slowLogLastAt.size() > SLOW_LOG_KEY_CAP) slowLogLastAt.clear();
+        Long last = slowLogLastAt.get(key);
+        if (last != null && now - last < SLOW_LOG_MIN_INTERVAL_MS) return false;
+        slowLogLastAt.put(key, now);
+        return true;
     }
 
     private static String abbreviate(String sql) {
@@ -594,9 +612,24 @@ public class WKDBHelper {
             return moved;
         }
 
+        /**
+         * 必须覆盖：{@code while (cursor.moveToNext())} 这种写法（如
+         * {@code ChannelDBManager.isExist}）从不调 getCount/moveToFirst，首次填充
+         * CursorWindow 的开销全落在这里，不测就是盲区 —— 而这个包装器存在的意义正是抓下一个
+         * {@code queryWithFlame} 那种量级的扫描。
+         */
+        @Override
+        public boolean moveToNext() {
+            if (measured) return super.moveToNext();
+            long start = SystemClock.elapsedRealtime();
+            boolean moved = super.moveToNext();
+            report(SystemClock.elapsedRealtime() - start);
+            return moved;
+        }
+
         private void report(long fillMs) {
             measured = true;
-            if (fillMs >= SLOW_FILL_MS) {
+            if (fillMs >= SLOW_FILL_MS && shouldLogSlow("fill:" + abbreviate(sql))) {
                 WKLoggerUtils.getInstance().e(TAG, "[slow-db] fill=" + fillMs + "ms thread="
                         + Thread.currentThread().getName() + " sql=" + abbreviate(sql));
             }

--- a/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
@@ -5,11 +5,16 @@ import android.content.Context;
 import android.database.Cursor;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.SystemClock;
 import android.text.TextUtils;
+import android.util.Log;
 
+import com.xinbida.wukongim.BuildConfig;
 import com.xinbida.wukongim.utils.WKLoggerUtils;
 
 import net.zetetic.database.sqlcipher.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteDebug;
+import net.zetetic.database.sqlcipher.SQLiteGlobal;
 import net.zetetic.database.sqlcipher.SQLiteOpenHelper;
 import net.zetetic.database.sqlcipher.SQLiteConnection;
 import net.zetetic.database.sqlcipher.SQLiteDatabaseHook;
@@ -27,6 +32,9 @@ import java.util.concurrent.Executors;
 public class WKDBHelper {
     private static final String TAG = "WKDBHelper";
 
+    /** ANR 修复专用埋点 tag，只在 debug 输出：{@code adb logcat -s ANRFix}。 */
+    public static final String PERF_TAG = "ANRFix";
+
     /**
      *  D · 启用 SQLCipher WAL（Write-Ahead Logging）模式，允许多 reader 与单 writer
      * 并发。默认 rollback journal 模式下写事务期间任何读都要排队，Space 切换 saveSyncChat
@@ -37,6 +45,31 @@ public class WKDBHelper {
      * false} 重编即可恢复 rollback journal 行为。SQLCipher 4.9.0 已官方支持 WAL。
      */
     private static final boolean ENABLE_WAL = true;
+
+    /**
+     * WAL 连接池大小。SQLCipher 只在 openFlags 带 {@link SQLiteDatabase#ENABLE_WRITE_AHEAD_LOGGING}
+     * 时才把池扩到这个值，否则恒为 1（见 SQLiteConnectionPool#setMaxConnectionPoolSizeLocked）。
+     *
+     * <p>这是**惰性上限**不是预分配：SQLiteConnectionPool.open() 只建主连接一条，非主连接按需创建。
+     * 真机实测（vivo V2464A / Android 16，上限临时开到 16 + monkey 压测 + 前后台切换）峰值占用
+     * 为 4，池耗尽告警 0 次 —— 取 8 是在实测峰值上留一倍余量，当前负载下不会真的建到 8 条。
+     *
+     * <p>不取库默认 10 或更大：SQLCipher 每新建一条连接要做一次 PBKDF2-HMAC-SHA512
+     * （4.x 默认 256000 轮，实测约 400ms），谁触发谁付、可能落在主线程；连接越多也越容易出现
+     * 持旧快照的 reader 拖住 checkpoint、-wal 文件涨大。8 是"够用 + 有余量 + 不放大这两项代价"的折中。
+     */
+    private static final int WAL_CONNECTION_POOL_SIZE = 8;
+
+    /** 仅 debug：启动后跑一次连接池争用自测，见 {@link #debugContentionSelfTest()}。测完置 false。 */
+    private static final boolean DEBUG_CONTENTION_SELF_TEST = false;
+
+    /** 仅 debug：持续采样连接池实际占用峰值，用来定 {@link #WAL_CONNECTION_POOL_SIZE}。测完置 false。 */
+    private static final boolean DEBUG_POOL_USAGE_SAMPLER = false;
+    private static final long POOL_SAMPLE_INTERVAL_MS = 300;
+    private static final long SELF_TEST_START_DELAY_MS = 3000;
+    private static final long SELF_TEST_PROBE_DELAY_MS = 900;
+    private static final int SELF_TEST_PROBE_COUNT = 3;
+    private static final long SELF_TEST_TXN_HOLD_MS = 4000;
 
 //    private DatabaseHelper mDbHelper;
     private SQLiteDatabase mDb;
@@ -86,11 +119,21 @@ public class WKDBHelper {
             System.loadLibrary("sqlcipher");
             File databaseFile = ctx.getDatabasePath(myDBName);
             databaseFile.getParentFile().mkdirs();
-            mDb = SQLiteDatabase.openOrCreateDatabase(databaseFile, uid, null, null, null);
-            //  D · 启用 WAL，让 reader 与 writer 并发。必须在任何 schema 升级 /
-            // 业务读写前执行（PRAGMA journal_mode 在有 active txn 时会失效）。
-            enableWalIfNeeded();
+            // WAL 必须在 open 时经 flags 传入。openOrCreateDatabase 的 11 个重载全部写死
+            // CREATE_IF_NECESSARY，拿不到 ENABLE_WRITE_AHEAD_LOGGING，连接池就被钉死在 1 条；
+            // 事后 PRAGMA journal_mode=WAL 只改日志模式，改不了池大小（池在 open 时按 flags 定死），
+            // 主线程读依旧要排队等后台写事务放连接 —— 这是 ANRWatchdog 那批 ANR 的根因。
+            int openFlags = SQLiteDatabase.CREATE_IF_NECESSARY;
+            if (ENABLE_WAL) {
+                SQLiteGlobal.setWALConnectionPoolSize(WAL_CONNECTION_POOL_SIZE);
+                openFlags |= SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING;
+            }
+            mDb = SQLiteDatabase.openDatabase(databaseFile.getAbsolutePath(), uid, null,
+                    openFlags, null, null);
+            verifyWalMode();
             WKDBUpgrade.getInstance().onUpgrade(mDb);
+            if (BuildConfig.DEBUG) debugContentionSelfTest();
+            if (BuildConfig.DEBUG) debugPoolUsageSampler(databaseFile.getAbsolutePath());
         } catch (Exception e) {
             WKLoggerUtils.getInstance().e(TAG + " init WKDBHelper error: " + e.getMessage());
             e.printStackTrace();
@@ -98,37 +141,145 @@ public class WKDBHelper {
     }
 
     /**
-     *  D · 切 WAL 并校验实际生效。PRAGMA 在某些特殊 FS（例如 /data/user_de 某些
-     * 厂商 ROM）可能被拒绝，这里捕获异常并记日志，但不阻断数据库初始化——失败回退到
-     * rollback journal 语义，与打此 flag 前行为一致。
+     * 校验 WAL 是否真的生效。SQLCipher 在每条连接 open 时都会按 openFlags 自己设
+     * journal_mode / synchronous，正常路径下这里只需读回确认；某些厂商 ROM 的特殊 FS 会拒绝
+     * WAL，此时退回 rollback journal（池仍为 1，行为与打 flag 前一致），只记日志不阻断初始化。
+     *
+     * <p>不再手动设 wal_autocheckpoint / journal_size_limit：池 &gt; 1 后 execSQL 落到哪条
+     * 连接不确定，只能配到其中一条，反而变成不可预期的配置。沿用库默认（1000 页 / 10000 字节）。
      */
-    private void enableWalIfNeeded() {
+    private void verifyWalMode() {
         if (!ENABLE_WAL || mDb == null) return;
-        try (Cursor cursor = mDb.rawQuery("PRAGMA journal_mode=WAL", null)) {
-            String mode = null;
-            if (cursor != null && cursor.moveToFirst()) {
-                mode = cursor.getString(0);
-            }
-            if (mode != null && "wal".equalsIgnoreCase(mode)) {
-                // 开启后建议放宽 synchronous，WAL 下 NORMAL 即可，事务提交更快。
-                mDb.execSQL("PRAGMA synchronous=NORMAL");
-                //  D+ · checkpoint 调优。SQLCipher 默认 wal_autocheckpoint=1000 页
-                // （~4MB 才触发），IM saveSyncChat 写量大时 -wal 文件可涨到 20-50MB，首次
-                // auto-checkpoint 需要把整个 WAL 回写到主 db 文件，会阻塞 reader 100-500ms
-                // —— 实测相当于退化回 ANR 窗口。把 autocheckpoint 调小到 100 页（~400KB）
-                // 让 checkpoint 更频繁、每次更轻。同时用 journal_size_limit 给 -wal 文件
-                // 加硬上限（1MB），防止异常场景下无限增长。
-                // 参考：Zetetic SQLCipher 官方文档 + 多家 IM 生产实践（对齐 iOS WKIM WAL 配置）。
-                mDb.execSQL("PRAGMA wal_autocheckpoint=100");
-                mDb.execSQL("PRAGMA journal_size_limit=1048576");
-                WKLoggerUtils.getInstance().e(TAG, "SQLCipher WAL mode enabled (journal_mode=" + mode
-                        + ", synchronous=NORMAL, wal_autocheckpoint=100, journal_size_limit=1MB)");
+        try {
+            String mode = queryPragma("journal_mode");
+            if ("wal".equalsIgnoreCase(mode)) {
+                // 池 > 1 后 rawQuery 落到哪条连接不确定，但所有连接由 SQLiteConnection 在 open
+                // 时按同一份 config 配置，读回任意一条都有代表性。
+                if (BuildConfig.DEBUG) {
+                    Log.d(PERF_TAG, "[WAL] ON pool=" + SQLiteGlobal.getWALConnectionPoolSize()
+                            + " journal_mode=" + mode
+                            + " synchronous=" + queryPragma("synchronous")
+                            + " page_size=" + queryPragma("page_size")
+                            + " wal_autocheckpoint=" + queryPragma("wal_autocheckpoint")
+                            + " journal_size_limit=" + queryPragma("journal_size_limit"));
+                }
             } else {
-                WKLoggerUtils.getInstance().e(TAG, "SQLCipher WAL mode NOT active, fallback journal_mode=" + mode);
+                WKLoggerUtils.getInstance().e(TAG, "SQLCipher WAL NOT active, journal_mode=" + mode
+                        + " (connection pool stays at 1)");
             }
         } catch (Exception e) {
-            WKLoggerUtils.getInstance().e(TAG + " enableWalIfNeeded error: " + e.getMessage());
+            WKLoggerUtils.getInstance().e(TAG + " verifyWalMode error: " + e.getMessage());
         }
+    }
+
+    private String queryPragma(String name) {
+        try (Cursor cursor = mDb.rawQuery("PRAGMA " + name, null)) {
+            if (cursor != null && cursor.moveToFirst()) {
+                return cursor.getString(0);
+            }
+        } catch (Exception ignored) {
+        }
+        return null;
+    }
+
+    /**
+     * 仅 debug：复现 ANR 堆栈里的争用场景，量化"连接池 = 1"到底让主线程等多久。
+     *
+     * <p>后台线程占住一个事务 {@link #SELF_TEST_TXN_HOLD_MS} 毫秒（不 setTransactionSuccessful，
+     * 结束时回滚，不写入任何数据），期间主线程发一次读。池 = 1 时主线程拿不到连接，会一直
+     * park 到事务结束 —— 这正是 ANRWatchdog 那批堆栈的形态；池 &gt; 1 时主线程能拿到另一条
+     * 连接，立即返回。两次运行（{@link #ENABLE_WAL} 开 / 关）的 waited 值就是修复效果。
+     *
+     * <p>顺带打印 reminders 表行数：老写法每次是整表扫描，行数决定那条 SQL 的真实代价。
+     */
+    private void debugContentionSelfTest() {
+        if (!DEBUG_CONTENTION_SELF_TEST) return;
+        final SQLiteDatabase db = mDb;
+        if (db == null) return;
+        new Thread(() -> {
+            try {
+                Thread.sleep(SELF_TEST_START_DELAY_MS);
+                Log.d(PERF_TAG, "[selftest] reminders rows="
+                        + queryLong(db, "select count(*) from reminders")
+                        + " undone=" + queryLong(db, "select count(*) from reminders where done=0")
+                        + " | pool=" + (ENABLE_WAL ? SQLiteGlobal.getWALConnectionPoolSize() : 1));
+
+                Handler main = new Handler(Looper.getMainLooper());
+                for (int i = 1; i <= SELF_TEST_PROBE_COUNT; i++) {
+                    final int seq = i;
+                    final long dueAtMs = SystemClock.elapsedRealtime() + SELF_TEST_PROBE_DELAY_MS * i;
+                    main.postDelayed(() -> {
+                        // lateMs = 主线程消息队列延迟，正是 ANRWatchdog 量的东西。主线程若被
+                        // 卡在等 DB 连接，这个 runnable 根本轮不上跑，lateMs 就等于卡住的时长。
+                        long lateMs = SystemClock.elapsedRealtime() - dueAtMs;
+                        long until = txnHeldUntilMs;
+                        long t0 = System.nanoTime();
+                        long rows = queryLong(db, "select count(*) from reminders where done=0");
+                        Log.d(PERF_TAG, "[selftest] probe#" + seq
+                                + " 主线程延迟=" + lateMs + "ms"
+                                + " 查询耗时=" + (System.nanoTime() - t0) / 1_000_000 + "ms"
+                                + " inWindow=" + (until != 0 && until > SystemClock.elapsedRealtime())
+                                + " rows=" + rows);
+                    }, SELF_TEST_PROBE_DELAY_MS * i);
+                }
+
+                db.beginTransaction();
+                try {
+                    queryLong(db, "select count(*) from reminders");
+                    txnHeldUntilMs = SystemClock.elapsedRealtime() + SELF_TEST_TXN_HOLD_MS;
+                    Log.d(PERF_TAG, "[selftest] bg txn ACQUIRED, holding " + SELF_TEST_TXN_HOLD_MS + "ms");
+                    Thread.sleep(SELF_TEST_TXN_HOLD_MS);
+                } finally {
+                    db.endTransaction();
+                    txnHeldUntilMs = 0;
+                }
+                Log.d(PERF_TAG, "[selftest] bg txn RELEASED");
+            } catch (Exception e) {
+                Log.e(PERF_TAG, "[selftest] error: " + e.getMessage());
+            }
+        }, "anrfix-selftest").start();
+    }
+
+    private static volatile long txnHeldUntilMs = 0;
+
+    private static long queryLong(SQLiteDatabase db, String sql) {
+        try (Cursor cursor = db.rawQuery(sql, null)) {
+            return (cursor != null && cursor.moveToFirst()) ? cursor.getLong(0) : -1;
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+
+    /**
+     * 仅 debug：持续采样连接池实际开了几条连接，只在刷新峰值时打日志。
+     *
+     * <p>SQLCipher 每条非主连接的 {@code DbStats.dbName} 会带 {@code (connectionId)} 后缀，
+     * 按库路径前缀过滤即可数出本库的连接数。把 {@link #WAL_CONNECTION_POOL_SIZE} 临时开大
+     * （如 16）跑一轮重负载，得到的峰值就是这个 App 真实需要的并发连接数 —— 池设成
+     * 峰值 + 1 即可，再大只是白付 SQLCipher 每连接一次 PBKDF2 的开销和 checkpoint 饥饿风险。
+     */
+    private void debugPoolUsageSampler(String dbPath) {
+        if (!DEBUG_POOL_USAGE_SAMPLER) return;
+        new Thread(() -> {
+            int peak = 0;
+            while (true) {
+                try {
+                    Thread.sleep(POOL_SAMPLE_INTERVAL_MS);
+                    int n = 0;
+                    for (SQLiteDebug.DbStats s : SQLiteDebug.getDatabaseInfo().dbStats) {
+                        if (s.dbName != null && s.dbName.startsWith(dbPath)) n++;
+                    }
+                    if (n > peak) {
+                        peak = n;
+                        Log.d(PERF_TAG, "[pool] 连接数峰值 -> " + peak
+                                + " (上限 " + SQLiteGlobal.getWALConnectionPoolSize() + ")");
+                    }
+                } catch (Exception e) {
+                    Log.e(PERF_TAG, "[pool] sampler stopped: " + e.getMessage());
+                    return;
+                }
+            }
+        }, "anrfix-poolsampler").start();
     }
 
     /**

--- a/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
@@ -68,6 +68,15 @@ public class WKDBHelper {
 
     /** 仅 debug：持续采样连接池实际占用峰值，用来定 {@link #WAL_CONNECTION_POOL_SIZE}。测完置 false。 */
     private static final boolean DEBUG_POOL_USAGE_SAMPLER = false;
+
+    /**
+     * 仅 debug：对 message 表上四条 max() 热查询 + synckey 查询跑 EXPLAIN QUERY PLAN 并计时，
+     * 用来验证 {@code 202608132100.sql} 的两个复合索引是否真的被优化器选中。测完置 false。
+     *
+     * <p>看什么：计划里出现 {@code USING COVERING INDEX idx_message_channel_*} 或
+     * {@code USING INDEX idx_message_channel_*} 即命中；若仍是 {@code SCAN message} 说明没走上。
+     */
+    private static final boolean DEBUG_EXPLAIN_HOT_QUERIES = false;
     private static final long POOL_SAMPLE_INTERVAL_MS = 300;
     private static final long SELF_TEST_START_DELAY_MS = 3000;
     private static final long SELF_TEST_PROBE_DELAY_MS = 900;
@@ -137,6 +146,7 @@ public class WKDBHelper {
             WKDBUpgrade.getInstance().onUpgrade(mDb);
             if (BuildConfig.DEBUG) debugContentionSelfTest();
             if (BuildConfig.DEBUG) debugPoolUsageSampler(databaseFile.getAbsolutePath());
+            if (BuildConfig.DEBUG) debugExplainHotQueries();
         } catch (Exception e) {
             WKLoggerUtils.getInstance().e(TAG + " init WKDBHelper error: " + e.getMessage());
             e.printStackTrace();
@@ -285,6 +295,90 @@ public class WKDBHelper {
                 }
             }
         }, "anrfix-poolsampler").start();
+    }
+
+    /**
+     * 仅 debug：验证 {@code 202608132100.sql} 两个复合索引是否被优化器选中，并测实际耗时。
+     *
+     * <p>取消息量最大的频道作为最坏用例（线上样本里单群有 1.9 万条），跑
+     * message 表上全部四条 max() 查询 + synckey 查询。放后台线程 + 延迟启动，
+     * 不占冷启动主线程。
+     */
+    private void debugExplainHotQueries() {
+        if (!DEBUG_EXPLAIN_HOT_QUERIES) return;
+        new Thread(() -> {
+            try {
+                Thread.sleep(SELF_TEST_START_DELAY_MS);
+                String channelId = null;
+                int channelType = 0;
+                try (Cursor c = mDb.rawQuery("select count(*) from message", null)) {
+                    if (c != null && c.moveToFirst()) {
+                        Log.d(PERF_TAG, "[explain] message 表总行数=" + c.getLong(0));
+                    }
+                }
+                try (Cursor c = mDb.rawQuery(
+                        "select channel_id, channel_type, count(*) c from message"
+                                + " group by channel_id, channel_type order by c desc limit 10", null)) {
+                    int rank = 0;
+                    while (c != null && c.moveToNext()) {
+                        rank++;
+                        if (rank == 1) {
+                            channelId = c.getString(0);
+                            channelType = c.getInt(1);
+                        }
+                        Log.d(PERF_TAG, "[explain] top" + rank + " channel=" + c.getString(0)
+                                + " type=" + c.getInt(1) + " rows=" + c.getLong(2));
+                    }
+                }
+
+                if (channelId == null) {
+                    Log.d(PERF_TAG, "[explain] message 表为空，跳过");
+                    return;
+                }
+                Object[] args = new Object[]{channelId, channelType};
+                explainAndTime("maxOrderSeq(发消息路径)",
+                        "select max(order_seq) order_seq from message where channel_id=? and channel_type=?"
+                                + " and type<>99 and type<>0 and is_deleted=0", args);
+                explainAndTime("maxOrderSeq(开聊天页)",
+                        "SELECT max(order_seq) order_seq FROM message WHERE channel_id=? AND channel_type=?", args);
+                explainAndTime("maxMessageSeq(开聊天页)",
+                        "SELECT max(message_seq) message_seq FROM message WHERE channel_id=? AND channel_type=?", args);
+                explainAndTime("synckey(每次重连)",
+                        "select GROUP_CONCAT(channel_id||':'||channel_type||':'|| last_seq,'|') synckey"
+                                + " from (select *,(select max(message_seq) from message"
+                                + " where message.channel_id=conversation.channel_id"
+                                + " and message.channel_type=conversation.channel_type limit 1) last_seq"
+                                + " from conversation where conversation.channel_id<>''"
+                                + " AND conversation.is_deleted=0) cn", null);
+            } catch (Exception e) {
+                Log.e(PERF_TAG, "[explain] failed: " + e.getMessage());
+            }
+        }, "anrfix-explain").start();
+    }
+
+    private void explainAndTime(String label, String sql, Object[] args) {
+        StringBuilder plan = new StringBuilder();
+        try (Cursor c = mDb.rawQuery("EXPLAIN QUERY PLAN " + sql, args)) {
+            if (c != null) {
+                while (c.moveToNext()) {
+                    if (plan.length() > 0) plan.append(" | ");
+                    plan.append(c.getString(c.getColumnCount() - 1));
+                }
+            }
+        } catch (Exception e) {
+            plan.append("explain error: ").append(e.getMessage());
+        }
+        long start = SystemClock.elapsedRealtimeNanos();
+        try (Cursor c = mDb.rawQuery(sql, args)) {
+            // 必须真正取一次数据：rawQuery 返回的 Cursor 是惰性的，
+            // 扫描发生在首次填充 CursorWindow，不 moveToFirst 量不到任何东西。
+            if (c != null) c.moveToFirst();
+        } catch (Exception e) {
+            Log.e(PERF_TAG, "[explain] " + label + " query error: " + e.getMessage());
+            return;
+        }
+        long costMs = (SystemClock.elapsedRealtimeNanos() - start) / 1_000_000;
+        Log.d(PERF_TAG, "[explain] " + label + " cost=" + costMs + "ms plan=" + plan);
     }
 
     /**

--- a/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
@@ -3,6 +3,7 @@ package com.xinbida.wukongim.db;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
+import android.database.CursorWrapper;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
@@ -22,6 +23,8 @@ import net.zetetic.database.sqlcipher.SQLiteDatabaseHook;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -250,6 +253,8 @@ public class WKDBHelper {
         }
     }
 
+
+
     /**
      * 仅 debug：持续采样连接池实际开了几条连接，只在刷新峰值时打日志。
      *
@@ -353,7 +358,10 @@ public class WKDBHelper {
         if (db == null || !db.isOpen()) {
             return null;
         }
-        return db.rawQuery(sql, null);
+        warnIfMainThread(sql);
+        long start = SystemClock.elapsedRealtime();
+        Cursor cursor = db.rawQuery(sql, null);
+        return guardCursor(cursor, sql, SystemClock.elapsedRealtime() - start);
     }
 
     public Cursor rawQuery(String sql, Object[] selectionArgs) {
@@ -361,7 +369,10 @@ public class WKDBHelper {
         if (db == null || !db.isOpen()) {
             return null;
         }
-        return db.rawQuery(sql, selectionArgs);
+        warnIfMainThread(sql);
+        long start = SystemClock.elapsedRealtime();
+        Cursor cursor = db.rawQuery(sql, selectionArgs);
+        return guardCursor(cursor, sql, SystemClock.elapsedRealtime() - start);
     }
 
     public Cursor select(String table, String selection,
@@ -370,6 +381,8 @@ public class WKDBHelper {
         SQLiteDatabase db = mDb;
         if (db == null || !db.isOpen()) return null;
         Cursor cursor;
+        warnIfMainThread(table);
+        long start = SystemClock.elapsedRealtime();
         try {
             cursor = db.query(table, null, selection, selectionArgs,
                     null, null, orderBy);
@@ -377,7 +390,117 @@ public class WKDBHelper {
             WKLoggerUtils.getInstance().e(TAG + " select WKDBHelper error");
             return null;
         }
-        return cursor;
+        return guardCursor(cursor, "select from " + table + " where " + selection,
+                SystemClock.elapsedRealtime() - start);
+    }
+
+    // ==================== 慢查询护栏 ====================
+
+    /**
+     * 取连接超过这个时长就记日志。ANR 堆栈里主线程 park 在 SQLiteConnectionPool 等连接，
+     * 就是这一段 —— 有了它，下次不用等撞成 ANR 才知道池被谁占住了。
+     */
+    private static final long SLOW_ACQUIRE_MS = 300;
+
+    /** 首次填充 CursorWindow（真正的扫描）超过这个时长就记日志。 */
+    private static final long SLOW_FILL_MS = 500;
+
+    private static final int SQL_LOG_MAX_LEN = 300;
+
+    /**
+     * 给 Cursor 包一层计时。**必须包**：rawQuery 返回的 Cursor 是惰性的，真正的表扫描发生在
+     * 首次填充 CursorWindow（moveToFirst / getCount）时，在 rawQuery 外面计时什么都量不到 ——
+     * 线上那条跑了 89 秒的 {@code select * from message where flame=1} 正是卡在
+     * executeForCursorWindow，只有连接池耗尽告警（30 秒阈值）才偶然把它暴露出来。
+     *
+     * <p>release 也记录，走 {@link WKLoggerUtils}，Bugly 能捞到。
+     */
+    private Cursor guardCursor(Cursor cursor, String sql, long acquireMs) {
+        if (acquireMs >= SLOW_ACQUIRE_MS) {
+            WKLoggerUtils.getInstance().e(TAG, "[slow-db] acquire=" + acquireMs + "ms thread="
+                    + Thread.currentThread().getName() + " sql=" + abbreviate(sql));
+        }
+        if (cursor == null) return null;
+        return new SlowQueryCursor(cursor, sql);
+    }
+
+    private static String abbreviate(String sql) {
+        if (sql == null) return "null";
+        return sql.length() <= SQL_LOG_MAX_LEN ? sql : sql.substring(0, SQL_LOG_MAX_LEN) + "...";
+    }
+
+    /**
+     * debug 下把主线程 DB 访问打出来（带调用栈）。不在 release 生效，也不改变任何行为 ——
+     * 只是让这类写法在开发期就可见。ANR #2 就是 adapter.convert() 在 onBindViewHolder 里直接查库。
+     *
+     * <p>按 SQL 去重：实测一分钟正常使用会产生 3000+ 次主线程查询，但只对应十来种 SQL。
+     * 每种只打第一次，输出才是一份可行动的清单而不是刷屏。
+     */
+    private static void warnIfMainThread(String sql) {
+        if (!BuildConfig.DEBUG) return;
+        if (Looper.myLooper() != Looper.getMainLooper()) return;
+        String key = abbreviate(sql);
+        if (loggedMainThreadSql.size() >= MAIN_THREAD_SQL_LOG_CAP) return;
+        if (!loggedMainThreadSql.add(key)) return;
+        Log.w(PERF_TAG, "[main-thread-db] #" + loggedMainThreadSql.size() + " " + key,
+                new Throwable("call site"));
+    }
+
+    private static final int MAIN_THREAD_SQL_LOG_CAP = 200;
+    private static final Set<String> loggedMainThreadSql = ConcurrentHashMap.newKeySet();
+
+    private static final class SlowQueryCursor extends CursorWrapper {
+        private final String sql;
+        private boolean measured;
+
+        SlowQueryCursor(Cursor cursor, String sql) {
+            super(cursor);
+            this.sql = sql;
+        }
+
+        @Override
+        public int getCount() {
+            if (measured) return super.getCount();
+            long start = SystemClock.elapsedRealtime();
+            int count = super.getCount();
+            report(SystemClock.elapsedRealtime() - start);
+            return count;
+        }
+
+        @Override
+        public boolean moveToFirst() {
+            if (measured) return super.moveToFirst();
+            long start = SystemClock.elapsedRealtime();
+            boolean moved = super.moveToFirst();
+            report(SystemClock.elapsedRealtime() - start);
+            return moved;
+        }
+
+        @Override
+        public boolean moveToLast() {
+            if (measured) return super.moveToLast();
+            long start = SystemClock.elapsedRealtime();
+            boolean moved = super.moveToLast();
+            report(SystemClock.elapsedRealtime() - start);
+            return moved;
+        }
+
+        @Override
+        public boolean moveToPosition(int position) {
+            if (measured) return super.moveToPosition(position);
+            long start = SystemClock.elapsedRealtime();
+            boolean moved = super.moveToPosition(position);
+            report(SystemClock.elapsedRealtime() - start);
+            return moved;
+        }
+
+        private void report(long fillMs) {
+            measured = true;
+            if (fillMs >= SLOW_FILL_MS) {
+                WKLoggerUtils.getInstance().e(TAG, "[slow-db] fill=" + fillMs + "ms thread="
+                        + Thread.currentThread().getName() + " sql=" + abbreviate(sql));
+            }
+        }
     }
 
     public long insert(String table, ContentValues cv) {
@@ -480,12 +603,27 @@ public class WKDBHelper {
 
     public void execSQL(String sql) {
         SQLiteDatabase db = mDb;
-        if (db != null && db.isOpen()) db.execSQL(sql);
+        if (db == null || !db.isOpen()) return;
+        warnIfMainThread(sql);
+        long start = SystemClock.elapsedRealtime();
+        db.execSQL(sql);
+        reportSlowWrite(SystemClock.elapsedRealtime() - start, sql);
     }
 
     public void execSQL(String sql, Object[] bindArgs) {
         SQLiteDatabase db = mDb;
-        if (db != null && db.isOpen()) db.execSQL(sql, bindArgs);
+        if (db == null || !db.isOpen()) return;
+        warnIfMainThread(sql);
+        long start = SystemClock.elapsedRealtime();
+        db.execSQL(sql, bindArgs);
+        reportSlowWrite(SystemClock.elapsedRealtime() - start, sql);
+    }
+
+    /** 写操作是即时执行的，不像 rawQuery 那样惰性，直接计时即可。 */
+    private static void reportSlowWrite(long costMs, String sql) {
+        if (costMs < SLOW_FILL_MS) return;
+        WKLoggerUtils.getInstance().e(TAG, "[slow-db] write=" + costMs + "ms thread="
+                + Thread.currentThread().getName() + " sql=" + abbreviate(sql));
     }
 
     // ==================== 异步查询方法 ====================

--- a/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
@@ -177,11 +177,17 @@ public class WKDBHelper {
                             + " journal_size_limit=" + queryPragma("journal_size_limit"));
                 }
             } else {
-                WKLoggerUtils.getInstance().e(TAG, "SQLCipher WAL NOT active, journal_mode=" + mode
-                        + " (connection pool stays at 1)");
+                // 门控原因：WKLoggerUtils 走 WKIM.isDebug()，而本仓库 setDebug(true) 写死，
+                // 不包 BuildConfig.DEBUG 的话 release 里照样打印 + writeLog 落文件。
+                if (BuildConfig.DEBUG) {
+                    WKLoggerUtils.getInstance().e(TAG, "SQLCipher WAL NOT active, journal_mode=" + mode
+                            + " (connection pool stays at 1)");
+                }
             }
         } catch (Exception e) {
-            WKLoggerUtils.getInstance().e(TAG + " verifyWalMode error: " + e.getMessage());
+            if (BuildConfig.DEBUG) {
+                WKLoggerUtils.getInstance().e(TAG + " verifyWalMode error: " + e.getMessage());
+            }
         }
     }
 

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/ChannelManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/ChannelManager.java
@@ -3,6 +3,7 @@ package com.xinbida.wukongim.manager;
 import android.text.TextUtils;
 
 import com.xinbida.wukongim.db.ChannelDBManager;
+import com.xinbida.wukongim.db.ChannelMembersDbManager;
 import com.xinbida.wukongim.db.WKDBColumns;
 import com.xinbida.wukongim.entity.WKChannel;
 import com.xinbida.wukongim.entity.WKChannelSearchResult;
@@ -536,6 +537,8 @@ public class ChannelManager extends BaseManager {
         //  · ChannelInfoCache 必须同步清理，否则切账号 / 退出登录后 map 里的
         // stale 实例会让 fast path 返回旧 Space 的 channel（同 iOS `removeChannelAllCache`）。
         channelInfoCache.clear();
+        // 成员缓存同理：它 join 了 channel 表，切账号后不清会把上个账号的成员昵称/头像带过来。
+        ChannelMembersDbManager.getInstance().clearCache();
     }
 
     // 刷新频道

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
@@ -400,6 +400,22 @@ public class ConversationManager extends BaseManager {
         return ConversationDbManager.getInstance().getUIMsg(msg);
     }
 
+    /**
+     * 批量版 {@link #getUIConversationMsg(String, byte)}：同一 channelType 下一次查回多个会话，
+     * 按 channelID 建索引。查不到的 channelID 在 map 里缺席，调用方按 null 走原来的兜底分支，
+     * 与逐条查询语义一致。
+     */
+    public java.util.Map<String, WKUIConversationMsg> getUIConversationMsgs(java.util.List<String> channelIds, byte channelType) {
+        java.util.Map<String, WKUIConversationMsg> map = new java.util.HashMap<>();
+        if (channelIds == null || channelIds.isEmpty()) return map;
+        List<WKConversationMsg> list = ConversationDbManager.getInstance().queryWithChannelIds(channelIds, channelType);
+        for (WKConversationMsg msg : list) {
+            if (msg == null || TextUtils.isEmpty(msg.channelID)) continue;
+            map.put(msg.channelID, ConversationDbManager.getInstance().getUIMsg(msg));
+        }
+        return map;
+    }
+
     public long getMsgExtraMaxVersion() {
         return ConversationDbManager.getInstance().queryMsgExtraMaxVersion();
     }

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
@@ -494,7 +494,11 @@ public class ConversationManager extends BaseManager {
         if (com.xinbida.wukongim.BuildConfig.DEBUG) {
             android.util.Log.d("ConvSync", "[ConvSync] sync request: version=" + version);
         }
+        com.xinbida.wukongim.utils.WKHeapProbe.ensureBallast(PROBE_BALLAST_MB);
+        com.xinbida.wukongim.utils.WKHeapProbe.snapshot("convSync request issued");
         runOnMainThread(() -> iSyncConversationChat.syncConversationChat(lastMsgSeqStr, 10, version, syncChat -> {
+            com.xinbida.wukongim.utils.WKHeapProbe.snapshot("convSync response parsed conv="
+                    + (syncChat == null || syncChat.conversations == null ? -1 : syncChat.conversations.size()));
             dispatchQueuePool.execute(() -> saveSyncChat(syncChat, () -> {
                 try {
                     if (syncChat != null) {
@@ -528,9 +532,11 @@ public class ConversationManager extends BaseManager {
             android.os.Trace.beginSection("YUJ312-saveSyncChat");
             android.util.Log.d("YUJ312", "saveSyncChat START convCount=" + yuj312T7ConvCount);
         }
+        com.xinbida.wukongim.utils.WKHeapProbe.begin("saveSyncChat");
         try {
             saveSyncChatImpl(syncChat, iSaveSyncChatBack);
         } finally {
+            com.xinbida.wukongim.utils.WKHeapProbe.end();
             if (com.xinbida.wukongim.BuildConfig.DEBUG) {
                 android.os.Trace.endSection();
                 android.util.Log.d("YUJ312", "saveSyncChat END convCount=" + yuj312T7ConvCount
@@ -538,6 +544,28 @@ public class ConversationManager extends BaseManager {
             }
         }
     }
+
+    /**
+     * OOM 诊断开关：置 true 可在本地复现「修复前」的行为——即 insertOrReplaceExtra 写完 extra 后
+     * 再把这一批消息全查回来物化一遍。配合 WKHeapProbe 的 peak 做同一账号 A/B，用来量化那一步
+     * 到底吃掉多少内存。<b>常态必须是 false，问题闭环后连同探针一起删。</b>
+     */
+    private static final boolean PROBE_FORCE_EXTRA_REQUERY = false;
+
+    /**
+     * OOM 复现用压舱重量（MB），0 = 关闭。在同步发起前占住这么多堆并一直持有，把本机可用空间
+     * 压到线上大账号那样的紧张程度。用法：先取一个刚好会崩的值确认能复现同一条栈，然后每上一处
+     * 优化就看同一个压舱值是否还崩——崩不崩的分界线就是这处优化买到的余量，单位 MB，量出来的不是估的。
+     * <b>常态必须是 0，问题闭环后连同探针一起删。</b>
+     */
+    private static final int PROBE_BALLAST_MB = 0;
+
+    /**
+     * 会话同步的落盘批大小。一批处理完就把派生列表清空，峰值内存与这个数成正比、与账号的
+     * 会话总数无关。20 个会话 × 每会话最多 30 条 recent ≈ 600 条消息一批，既不会让事务过碎，
+     * 也远低于会撑爆堆的量级。
+     */
+    private static final int SYNC_CHAT_CONVERSATION_BATCH = 20;
 
     private void saveSyncChatImpl(WKSyncChat syncChat, final ISaveSyncChatBack iSaveSyncChatBack) {
         if (syncChat == null) {
@@ -553,10 +581,23 @@ public class ConversationManager extends BaseManager {
             }
             android.util.Log.d("ConvSync", sb.toString());
         }
+        // 全量 space 缓存必须在 UI 通知之前就绪。原实现放在写 extra 之后、写会话之前；分批之后
+        // 提到循环之前——它与逐条 prefill 互斥（prefill 只在 space_memberships == null 时跑，
+        // 而 applySpaceMemberships 收到 null 直接 return），两者不会交叉，语义不变。
+        applySpaceMemberships(syncChat.space_memberships);
+        // 这四个列表现在只装「当前这一批」会话的数据，每批落盘后 clear()：上一批的 WKMsg
+        // （含 content 字符串和已解析的 baseContentMsgModel）随即不可达，GC 立刻能回收。
+        // 峰值内存因此只与 SYNC_CHAT_CONVERSATION_BATCH 有关，与账号的会话总数无关。
+        // 服务端有没有分页不影响这一点——响应仍然整包收，但派生对象不再同时全量持有。
         List<WKConversationMsg> conversationMsgList = new ArrayList<>();
         List<WKMsg> msgList = new ArrayList<>();
         List<WKMsgReaction> msgReactionList = new ArrayList<>();
         List<WKMsgExtra> msgExtraList = new ArrayList<>();
+        // 每个会话一条，几百个也只有百来 KB，跨批累积无压力；UI 仍然只在最后刷新一次。
+        List<WKUIConversationMsg> uiMsgList = new ArrayList<>();
+        // OOM 诊断用：本次同步所有 content 字符串的总长度。
+        long probeContentChars = 0;
+        int probeBatchNo = 0;
         if (WKCommonUtils.isNotEmpty(syncChat.conversations)) {
             for (int i = 0, size = syncChat.conversations.size(); i < size; i++) {
                 //最近会话消息对象
@@ -606,89 +647,39 @@ public class ConversationManager extends BaseManager {
                             msgExtraList.add(extra);
                         }
                         msgList.add(msg);
+                        if (com.xinbida.wukongim.BuildConfig.DEBUG && msg.content != null) {
+                            probeContentChars += msg.content.length();
+                        }
                     }
                 }
 
                 conversationMsgList.add(conversationMsg);
+
+                // 消费完就把解析树上这一条的 recents 断掉。分批只让「派生列表」有上界，
+                // 但 FastJson 解出来的 WKSyncChat 树本身要活到 onBack 回调，
+                // recents 又是整棵树里最大的一块（content 字符串全在这），不断引用的话
+                // 峰值仍然与账号会话总数成正比，分批等于白做。
+                // 安全性：recents 全仓只有上面那一处消费；onBack 的三个实现只读
+                // conversations.size()（见 ChatFragment / WKIMUtils 的 sync 回调）。
+                syncChat.conversations.get(i).recents = null;
+
+                // 攒够一批（或到末尾）就落盘并清空，让这一批的对象立刻变成可回收。
+                if (conversationMsgList.size() >= SYNC_CHAT_CONVERSATION_BATCH || i == size - 1) {
+                    probeBatchNo++;
+                    flushSyncChatBatch(conversationMsgList, msgList, msgExtraList,
+                            msgReactionList, uiMsgList, probeBatchNo);
+                    conversationMsgList.clear();
+                    msgList.clear();
+                    msgExtraList.clear();
+                    msgReactionList.clear();
+                }
             }
         }
-        if (WKCommonUtils.isNotEmpty(msgExtraList)) {
-            MsgDbManager.getInstance().insertOrReplaceExtra(msgExtraList);
-        }
-        // 在 UI 通知之前应用全量 space 缓存，确保主线程过滤时数据已就绪
-        applySpaceMemberships(syncChat.space_memberships);
-        List<WKUIConversationMsg> uiMsgList = new ArrayList<>();
-        WKDBHelper txHelper = WKIMApplication.getInstance().getDbHelper();
-        if (WKCommonUtils.isNotEmpty(conversationMsgList)) {
-            if (WKCommonUtils.isNotEmpty(msgList)) {
-                MsgDbManager.getInstance().insertMsgs(msgList);
-            }
-            try {
-                if (WKCommonUtils.isNotEmpty(conversationMsgList) && txHelper != null && !txHelper.isClosed()) {
-                    List<ContentValues> cvList = new ArrayList<>();
-                    for (int i = 0, size = conversationMsgList.size(); i < size; i++) {
-                        ContentValues cv = ConversationDbManager.getInstance().getInsertSyncCV(conversationMsgList.get(i));
-                        cvList.add(cv);
-                        WKUIConversationMsg uiMsg = ConversationDbManager.getInstance().getUIMsg(conversationMsgList.get(i));
-                        if (uiMsg != null) {
-                            uiMsgList.add(uiMsg);
-                        }
-                    }
-                    txHelper.beginTransaction();
-                    for (ContentValues cv : cvList) {
-                        ConversationDbManager.getInstance().insertSyncMsg(cv);
-                    }
-                    txHelper.setTransactionSuccessful();
-                }
-            } catch (Exception ignored) {
-                WKLoggerUtils.getInstance().e(TAG, "Save synchronization session message exception");
-            } finally {
-                if (txHelper != null) {
-                    txHelper.endTransaction();
-                }
-            }
-            if (WKCommonUtils.isNotEmpty(msgReactionList)) {
-                MsgManager.getInstance().saveMsgReactions(msgReactionList);
-            }
-            // fixme 离线消息应该不能push给UI
-            if (WKCommonUtils.isNotEmpty(msgList)) {
-                HashMap<String, List<WKMsg>> allMsgMap = new HashMap<>();
-                for (WKMsg wkMsg : msgList) {
-                    if (TextUtils.isEmpty(wkMsg.channelID)) continue;
-                    List<WKMsg> list;
-                    if (allMsgMap.containsKey(wkMsg.channelID)) {
-                        list = allMsgMap.get(wkMsg.channelID);
-                        if (list == null) {
-                            list = new ArrayList<>();
-                        }
-                    } else {
-                        list = new ArrayList<>();
-                    }
-                    list.add(wkMsg);
-                    allMsgMap.put(wkMsg.channelID, list);
-                }
-
-//                for (Map.Entry<String, List<WKMsg>> entry : allMsgMap.entrySet()) {
-//                    List<WKMsg> channelMsgList = entry.getValue();
-//                    if (channelMsgList != null && channelMsgList.size() < 20) {
-//                        Collections.sort(channelMsgList, new Comparator<WKMsg>() {
-//                            @Override
-//                            public int compare(WKMsg o1, WKMsg o2) {
-//                                return Long.compare(o1.messageSeq, o2.messageSeq);
-//                            }
-//                        });
-//                        MsgManager.getInstance().pushNewMsg(channelMsgList);
-//                    }
-//                }
-
-
-            }
-            if (WKCommonUtils.isNotEmpty(uiMsgList)) {
-                setOnRefreshMsg(uiMsgList, "saveSyncChat");
-//                for (int i = 0, size = uiMsgList.size(); i < size; i++) {
-//                    WKIM.getInstance().getConversationManager().setOnRefreshMsg(uiMsgList.get(i), i == uiMsgList.size() - 1, "saveSyncChat");
-//                }
-            }
+        if (WKCommonUtils.isNotEmpty(uiMsgList)) {
+            com.xinbida.wukongim.utils.WKHeapProbe.mark("all batches done",
+                    "batches=" + probeBatchNo + " uiMsg=" + uiMsgList.size()
+                            + " contentChars=" + probeContentChars);
+            setOnRefreshMsg(uiMsgList, "saveSyncChat");
         }
 
         if (WKCommonUtils.isNotEmpty(syncChat.cmds)) {
@@ -706,6 +697,99 @@ public class ConversationManager extends BaseManager {
         }
         WKIM.getInstance().getConnectionManager().setConnectionStatus(WKConnectStatus.syncCompleted, "");
         iSaveSyncChatBack.onBack();
+    }
+
+    /**
+     * 把一批会话及其派生数据落盘。顺序与分批前保持一致：extra → message → conversation → reaction。
+     *
+     * <p>调用方在本方法返回后 {@code clear()} 这些列表，因此本方法不得持有任何入参的引用。
+     */
+    private void flushSyncChatBatch(List<WKConversationMsg> conversationMsgList,
+                                    List<WKMsg> msgList,
+                                    List<WKMsgExtra> msgExtraList,
+                                    List<WKMsgReaction> msgReactionList,
+                                    List<WKUIConversationMsg> uiMsgList,
+                                    int batchNo) {
+        if (WKCommonUtils.isNotEmpty(msgExtraList)) {
+            // needUpdatedMsgs=false：这里不用返回值。带上它会把刚写的这批消息重新查库并把每条
+            // content 解析成 JSONObject + content model，纯浪费（线上有崩溃栈就停在那一步）。
+            MsgDbManager.getInstance().insertOrReplaceExtra(msgExtraList, PROBE_FORCE_EXTRA_REQUERY);
+        }
+        if (WKCommonUtils.isNotEmpty(msgList)) {
+            MsgDbManager.getInstance().insertMsgs(msgList);
+        }
+        saveConversationBatch(conversationMsgList, uiMsgList);
+        if (WKCommonUtils.isNotEmpty(msgReactionList)) {
+            MsgManager.getInstance().saveMsgReactions(msgReactionList);
+        }
+        com.xinbida.wukongim.utils.WKHeapProbe.mark("batch " + batchNo,
+                "conv=" + conversationMsgList.size()
+                        + " msg=" + msgList.size()
+                        + " extra=" + msgExtraList.size()
+                        + " reaction=" + msgReactionList.size());
+    }
+
+    /**
+     * 写一批会话到 conversation 表，并把对应的 UI 模型追加到 {@code uiMsgList}。
+     *
+     * <p>分批后这里由一次大事务变成每批一次事务：某一批失败时前面几批已经提交，是部分成功而不是
+     * 整体回滚。对「会话列表」这种可由下次同步自愈的数据，部分成功优于全丢。
+     */
+    private void saveConversationBatch(List<WKConversationMsg> conversationMsgList,
+                                       List<WKUIConversationMsg> uiMsgList) {
+        if (WKCommonUtils.isEmpty(conversationMsgList)) return;
+        WKDBHelper txHelper = WKIMApplication.getInstance().getDbHelper();
+        if (txHelper == null || txHelper.isClosed()) return;
+        boolean began = false;
+        try {
+            List<ContentValues> cvList = new ArrayList<>();
+            for (int i = 0, size = conversationMsgList.size(); i < size; i++) {
+                ContentValues cv = ConversationDbManager.getInstance().getInsertSyncCV(conversationMsgList.get(i));
+                cvList.add(cv);
+                WKUIConversationMsg uiMsg = ConversationDbManager.getInstance().getUIMsg(conversationMsgList.get(i));
+                if (uiMsg != null) {
+                    uiMsgList.add(uiMsg);
+                }
+            }
+            txHelper.beginTransaction();
+            began = true;
+            for (ContentValues cv : cvList) {
+                ConversationDbManager.getInstance().insertSyncMsg(cv);
+            }
+            txHelper.setTransactionSuccessful();
+        } catch (Throwable t) {
+            // ⚠️⚠️ 这一段的 Error 语义必须与 main 完全一致，不许动。
+            //
+            // main 上这里是 catch (Exception ignored)：Error 不在捕获范围 → 直接抛出去 →
+            // DispatchQueuePool 线程崩 → Bugly 收到崩溃报告。线上那 6 条 OOM 栈
+            // （saveSyncChatImpl → insertOrReplaceExtra → queryWithMsgIds）就是这么捞到的，
+            // 是我们发现 OOM 的唯一渠道。把 Error 吞掉 = 线上 OOM 变成「半截数据 + 一片安静」。
+            //
+            // rethrow 必须放在最前面，早于任何字符串拼接：堆已经耗尽时，拼一条日志本身
+            // 就可能再抛一个 OOM，把原始堆栈顶掉，Bugly 收到的会是一条毫无意义的栈。
+            if (t instanceof Error) {
+                throw (Error) t;
+            }
+            // 到这里只剩 Exception。main 上是 catch (Exception ignored) + 一条不带异常信息的
+            // 日志，失败了只能靠猜；而且会话没写进库 → queryLastMsgSeqs 游标停在原地 →
+            // 下次同步服务端返回同样大的全量包 → 用户卡在这个循环里。至少让失败可见。
+            // 门控：WKLoggerUtils 走 WKIM.isDebug()，本仓库 setDebug(true) 写死，
+            // 不包 BuildConfig.DEBUG 的话 release 里照样打印。
+            if (com.xinbida.wukongim.BuildConfig.DEBUG) {
+                WKLoggerUtils.getInstance().e(TAG,
+                        "saveConversationBatch failed (size=" + conversationMsgList.size() + "): " + t);
+            }
+        } finally {
+            if (began) {
+                try {
+                    txHelper.endTransaction();
+                } catch (Exception ignored) {
+                    // 只兜 Exception（比如事务已结束的 IllegalStateException）。
+                    // 这里同样不能写成 catch (Throwable)：endTransaction 抛 OOM 时若被吞掉，
+                    // 那条 Error 就到不了 Bugly——main 上这里连 try 都没有，Error 直接往上走。
+                }
+            }
+        }
     }
 
     /**

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/MsgManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/MsgManager.java
@@ -992,6 +992,16 @@ public class MsgManager extends BaseManager {
                 }
                 iSyncChannelMsgBack.onBack(syncChannelMsg);
             }));
+        } else {
+            // listener 未注册时原先直接 return，iSyncChannelMsgBack 被静默丢弃。
+            // 调用方 MsgDbManager#queryOrSyncHistoryMessages 是在等这个回调推进的：
+            // 回调不来 → onResult 永不触发 → ChatActivity 的 isRefreshLoading/isMoreLoading
+            // 永远停在 true → 「翻着翻着再也加载不出来，退出重进才好」。
+            // 回调 API 任何分支都必须回一次，哪怕是 null。
+            if (BuildConfig.DEBUG) {
+                WKLoggerUtils.getInstance().e(TAG, "syncChannelMsgListener is null, fallback onBack(null)");
+            }
+            iSyncChannelMsgBack.onBack(null);
         }
     }
 

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/MsgManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/MsgManager.java
@@ -1037,7 +1037,9 @@ public class MsgManager extends BaseManager {
             }
         }
         if (WKCommonUtils.isNotEmpty(msgExtraList)) {
-            MsgDbManager.getInstance().insertOrReplaceExtra(msgExtraList);
+            // needUpdatedMsgs=false：下面紧接着自己 queryWithMsgIds 一次，带上返回值等于同一批消息
+            // 查两遍、content JSON 解析两遍。
+            MsgDbManager.getInstance().insertOrReplaceExtra(msgExtraList, false);
         }
         if (WKCommonUtils.isNotEmpty(msgList)) {
             MsgDbManager.getInstance().insertMsgs(msgList);
@@ -1084,7 +1086,8 @@ public class MsgManager extends BaseManager {
             }
         }
         if (WKCommonUtils.isNotEmpty(msgExtraList)) {
-            MsgDbManager.getInstance().insertOrReplaceExtra(msgExtraList);
+            // needUpdatedMsgs=false：理由同上，下面自己会 queryWithMsgIds。
+            MsgDbManager.getInstance().insertOrReplaceExtra(msgExtraList, false);
         }
         if (!msgIds.isEmpty()) {
             List<String> ids = new ArrayList<>(msgIds);

--- a/wkim/src/main/java/com/xinbida/wukongim/utils/WKHeapProbe.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/utils/WKHeapProbe.java
@@ -1,0 +1,174 @@
+package com.xinbida.wukongim.utils;
+
+import android.os.SystemClock;
+import android.util.Log;
+
+import com.xinbida.wukongim.BuildConfig;
+
+/**
+ * 临时诊断工具：给会话同步路径打 Java 堆水位，定位线上 OOM（256MB 顶格）。
+ *
+ * <p>只在 debug 构建里输出，release 每个方法首行就 return。
+ *
+ * <p>关键的不是各阶段边界的水位，而是 {@link #begin} / {@link #end} 之间的 <b>峰值</b>——
+ * OOM 发生在 {@code queryWithMsgIds} 构建列表的<b>途中</b>，边界采样看不到。所以 begin 会拉起
+ * 一个 50ms 采样的守护线程记录 peak。
+ *
+ * <p>静态状态只服务「同一时刻一次会话同步」这一个场景（ConversationManager 的 syncInFlight
+ * 保证单飞）。别的线程调 mark 会打乱 delta，因此每行都带线程名以便识别。
+ *
+ * <p>OOM 闭环后整类删除。
+ */
+public final class WKHeapProbe {
+    public static final String TAG = "WKHeapProbe";
+
+    private static final long SAMPLE_INTERVAL_MS = 50L;
+    private static final long MB = 1024L * 1024L;
+
+    private static volatile boolean sampling;
+    private static volatile long peakUsed;
+    private static long baseUsed;
+    private static long lastUsed;
+    private static long beginAt;
+    private static String scopeName;
+
+    private WKHeapProbe() {
+    }
+
+    private static long used() {
+        Runtime rt = Runtime.getRuntime();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    private static String mb(long bytes) {
+        // 小账号上增量可能只有几十 KB，整数 MB 分辨率会把一切显示成 0，必须留小数
+        return String.format(java.util.Locale.US, "%.2fMB", bytes / (double) MB);
+    }
+
+    private static String signedMb(long bytes) {
+        return (bytes >= 0 ? "+" : "-")
+                + String.format(java.util.Locale.US, "%.2fMB", Math.abs(bytes) / (double) MB);
+    }
+
+    public static void begin(String scope) {
+        if (!BuildConfig.DEBUG) return;
+        if (sampling) {
+            Log.w(TAG, "begin(" + scope + ") while '" + scopeName + "' still active, force-closing");
+            end();
+        }
+        scopeName = scope;
+        beginAt = SystemClock.elapsedRealtime();
+        baseUsed = used();
+        lastUsed = baseUsed;
+        peakUsed = baseUsed;
+        sampling = true;
+        Thread t = new Thread(() -> {
+            // 兜底：万一 end() 没被调到（回调没回来），别让采样线程一直转
+            long deadline = SystemClock.elapsedRealtime() + 120_000L;
+            while (sampling && SystemClock.elapsedRealtime() < deadline) {
+                long u = used();
+                if (u > peakUsed) peakUsed = u;
+                SystemClock.sleep(SAMPLE_INTERVAL_MS);
+            }
+        }, "WKHeapProbe-sampler");
+        t.setDaemon(true);
+        t.setPriority(Thread.MIN_PRIORITY);
+        t.start();
+        Log.d(TAG, "── " + scope + " BEGIN used=" + mb(baseUsed)
+                + " footprint=" + mb(Runtime.getRuntime().totalMemory())
+                + " max=" + mb(Runtime.getRuntime().maxMemory()));
+    }
+
+    public static void mark(String stage) {
+        mark(stage, null);
+    }
+
+    /**
+     * 与 scope 无关的独立水位快照，用于 begin/end 之外的时点（例如 HTTP 响应体解析前后）。
+     * 不影响 Δstage 的基准。
+     */
+    public static void snapshot(String label) {
+        if (!BuildConfig.DEBUG) return;
+        long u = used();
+        if (sampling && u > peakUsed) peakUsed = u;
+        Log.d(TAG, "·  " + label + " used=" + mb(u)
+                + "  [" + Thread.currentThread().getName() + "]");
+    }
+
+    /** 取当前已用堆，供调用方自己夹住一段代码测增量。release 返回 0。 */
+    public static long usedNow() {
+        return BuildConfig.DEBUG ? used() : 0L;
+    }
+
+    private static byte[][] ballast;
+
+    /**
+     * 压舱：占住 mb 兆堆空间并一直持有，把本机的可用堆压到和线上大账号等效的紧张程度，
+     * 用来在自己的账号上<b>确定性复现</b> OOM，并量化每一处优化到底买到多少 MB 余量。
+     *
+     * <p>用 1MB 一块而不是一整块，是为了落在普通 AllocSpace 而非 LOS，更接近真实数据的形态。
+     *
+     * <p><b>尽力而为</b>：拿不动了就停在那里，已拿到的继续持有，并把实际拿到的量打出来。
+     * 绝不能让压舱自己抛 OOM —— 那样崩溃栈会停在本方法上，看着像被测代码崩了，
+     * 其实是道具崩了，整场实验的结论都是错的。「实际拿到 N MB」这个数本身也是有用的信息：
+     * 它等于「当前时刻这台机器还剩多少可用堆」。
+     *
+     * <p>幂等：只分配一次。debug-only，问题闭环后删。
+     */
+    public static void ensureBallast(int mb) {
+        if (!BuildConfig.DEBUG || mb <= 0 || ballast != null) return;
+        java.util.List<byte[]> blocks = new java.util.ArrayList<>(mb);
+        int got = 0;
+        try {
+            for (int i = 0; i < mb; i++) {
+                blocks.add(new byte[(int) MB]);
+                got++;
+            }
+        } catch (OutOfMemoryError ignored) {
+            // 拿不到就停，不往上抛
+        }
+        ballast = blocks.toArray(new byte[0][]);
+        long max = Runtime.getRuntime().maxMemory();
+        long u = used();
+        Log.d(TAG, "★ ballast requested " + mb + "MB, actually got " + got + "MB"
+                + " → used=" + mb(u)
+                + " max=" + mb(max)
+                + " 剩余可用≈" + mb(max - u)
+                + (got < mb ? "  ⚠️ 没拿满，说明这台机器此刻只剩这么多" : ""));
+    }
+
+    /** 报告一段被 {@link #usedNow()} 夹住的代码的堆增量。 */
+    public static void span(String label, String detail, long before, long after) {
+        if (!BuildConfig.DEBUG) return;
+        if (sampling && after > peakUsed) peakUsed = after;
+        Log.d(TAG, "·  " + label + " " + detail
+                + " used " + mb(before) + " → " + mb(after)
+                + " Δ=" + signedMb(after - before)
+                + "  [" + Thread.currentThread().getName() + "]");
+    }
+
+    public static void mark(String stage, String detail) {
+        if (!BuildConfig.DEBUG) return;
+        long u = used();
+        if (u > peakUsed) peakUsed = u;
+        Log.d(TAG, "   " + stage
+                + " used=" + mb(u)
+                + " Δstage=" + signedMb(u - lastUsed)
+                + " Δbase=" + signedMb(u - baseUsed)
+                + (detail == null ? "" : "  " + detail)
+                + "  [" + Thread.currentThread().getName() + "]");
+        lastUsed = u;
+    }
+
+    public static void end() {
+        if (!BuildConfig.DEBUG) return;
+        if (!sampling) return;
+        sampling = false;
+        long u = used();
+        Log.d(TAG, "── " + scopeName + " END used=" + mb(u)
+                + " peak=" + mb(peakUsed)
+                + " peakΔbase=" + signedMb(peakUsed - baseUsed)
+                + " retained=" + signedMb(u - baseUsed)
+                + " +" + (SystemClock.elapsedRealtime() - beginAt) + "ms");
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -2353,10 +2353,15 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                             // 补上 onError：先把忙位放掉，保证下一次滚动还能重试。
                             isRefreshLoading = false;
                             isMoreLoading = false;
-                            removeLoadingIndicator();
                             if (BuildConfig.DEBUG) {
                                 Log.e(LOAD_TAG, "buildUiMsgList failed, busy flags released", throwable);
                             }
+                            // 忙位是纯字段，销毁后置了也无害，所以放在守卫之前。
+                            // 但 removeLoadingIndicator() 会动 wkVBinding / chatAdapter：
+                            // buildUiMsgList 跑在 computation 线程，异常回到主线程时 Activity 可能
+                            // 已经销毁，必须和 onNext 分支一样先守存活。
+                            if (isFinishing() || isDestroyed()) return;
+                            removeLoadingIndicator();
                         });
             }
         });

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -250,6 +250,29 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
     boolean isRefreshLoading = false;
     boolean isMoreLoading = false;
     boolean isCanRefresh = true;
+    /**
+     * 空结果重试护栏。
+     *
+     * <p>原实现是「{@code onResult} 拿到一次空 list 就把 {@code isCanRefresh} /
+     * {@code isCanLoadMore} 置 false」，而这两个字段是 {@link #showRefreshLoading()} /
+     * {@link #showMoreLoading()} 的闸门，一旦置 false 在本 Activity 实例内几乎不再复位
+     * （只有 {@code trimTopIfNeeded} / {@code trimBottomIfNeeded} 在列表超长时顺带复位），
+     * 于是表现为「大群往上翻着翻着就再也加载不出来，退出重进又好了」。
+     *
+     * <p>问题在于空 list 有两种含义，UI 侧分不清：
+     * <ul>
+     *     <li>真的没有更多了 —— 应该锁；</li>
+     *     <li>本轮没取到（网络失败走 {@code syncChannelMsg == null} 分支、
+     *         同步轮次被截断、本地正好是空洞）—— 不该锁。</li>
+     * </ul>
+     * 故改为连续空达到阈值才锁；只要有一次非空结果就清零。真到头时用户至多多触发
+     * 一次请求（触发点是 SCROLL_STATE_IDLE + 已在边界，需要一次新的滚动手势，不会自激）。
+     */
+    private static final int EMPTY_RESULT_LOCK_THRESHOLD = 2;
+    private int consecutiveEmptyRefresh;
+    private int consecutiveEmptyLoadMore;
+    /** debug-only：分页闸门追踪。一次复现即可判断卡在忙位还是 canLoad 位，见 showRefreshLoading/showMoreLoading。 */
+    private static final String LOAD_TAG = "ANRFix-LoadMore";
     private boolean isShowChatActivity = true;
     // typing 超时兜底：收到 typing CMD 后 8s 内无真实消息跟上则自动清除，避免 typing 永久残留。
     // Handler 绑定主线程 Looper，确保对 chatAdapter 的所有改动都在主线程，杜绝后台线程裸操作共享数据。
@@ -1552,6 +1575,10 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         isRefreshLoading = false;
         isMoreLoading = false;
         isCanRefresh = true;
+        // 空结果计数是「本 channel 本轮」的判据，切 channel 必须清，否则新 channel
+        // 会继承旧 channel 的连续空次数，第一次空就直接锁死。
+        consecutiveEmptyRefresh = 0;
+        consecutiveEmptyLoadMore = 0;
 
         //  P2-2 · RxJava subscription：旧 channel 的 media 下载 / 任务订阅如果不
         // dispose，切到新 channel 后订阅叠加 → 回调错绑（新 channel 收到旧 channel 的
@@ -2211,6 +2238,10 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         if (unreadStartMsgOrderSeq != 0) contain = true;
         // 系统 Bot 跨 Space 共享：加大加载量，确保过滤后有足够的当前 Space 消息
         int loadLimit = com.chat.base.space.SystemBotsFallback.isSystemBot(channelId) ? Math.max(limit, 500) : limit;
+        if (BuildConfig.DEBUG) {
+            Log.d(LOAD_TAG, "request pullMode=" + pullMode + " oldestOrderSeq=" + oldestOrderSeq
+                    + " contain=" + contain + " limit=" + loadLimit);
+        }
         WKIM.getInstance().getMsgManager().getOrSyncHistoryMessages(channelId, channelType, oldestOrderSeq, contain, pullMode, loadLimit, aroundMsgOrderSeq, new IGetOrSyncHistoryMsgBack() {
             @Override
             public void onSyncing() {
@@ -2228,15 +2259,28 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
 
             @Override
             public void onResult(List<WKMsg> list) {
+                if (BuildConfig.DEBUG) {
+                    Log.d(LOAD_TAG, "onResult pullMode=" + pullMode
+                            + " size=" + (list == null ? -1 : list.size()));
+                }
                 if (isShowPinnedView) {
                     EndpointManager.getInstance().invoke("is_syncing_message", 0);
                 }
                 if (pullMode == 0) {
-                    if (WKReader.isEmpty(list))
-                        isCanRefresh = false;
+                    if (WKReader.isEmpty(list)) {
+                        if (++consecutiveEmptyRefresh >= EMPTY_RESULT_LOCK_THRESHOLD) {
+                            isCanRefresh = false;
+                        }
+                    } else {
+                        consecutiveEmptyRefresh = 0;
+                    }
                 } else {
                     if (WKReader.isEmpty(list)) {
-                        isCanLoadMore = false;
+                        if (++consecutiveEmptyLoadMore >= EMPTY_RESULT_LOCK_THRESHOLD) {
+                            isCanLoadMore = false;
+                        }
+                    } else {
+                        consecutiveEmptyLoadMore = 0;
                     }
                 }
                 isSyncLastMsg = false;
@@ -2249,6 +2293,15 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                     }
                 }
                 // 预处理 msgList（快，主线程）
+                if (BuildConfig.DEBUG) {
+                    // fetched=SDK 返回条数, afterSpaceFilter=Space 过滤后, added=去重后真正入 adapter 的条数。
+                    // added=0 而 fetched>0 → 取回来的全被吃掉，adapter 不增长，
+                    // 下次 getFirstMsgOrderSeq() 不变 → 会用同一个 oldestOrderSeq 原地打转。
+                    Log.d(LOAD_TAG, "merge fetched=" + (list == null ? -1 : list.size())
+                            + " afterSpaceFilter=" + filteredList.size()
+                            + " added=" + tempList.size()
+                            + " adapterSize=" + chatAdapter.getData().size());
+                }
                 boolean msgAddEmptyView = WKReader.isNotEmpty(tempList) && tempList.size() < limit;
                 if (msgAddEmptyView) {
                     WKMsg emptyMsg = new WKMsg();
@@ -2291,6 +2344,19 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                             }
                             isRefreshLoading = false;
                             isMoreLoading = false;
+                            if (BuildConfig.DEBUG) {
+                                Log.d(LOAD_TAG, "busy flags released pullMode=" + pullMode);
+                            }
+                        }, throwable -> {
+                            // 原先是单参 subscribe：buildUiMsgList 一旦抛异常，下游 lambda 不执行，
+                            // 忙位就永远停在 true，加载彻底卡死（还会走 RxJava 默认 handler 崩主线程）。
+                            // 补上 onError：先把忙位放掉，保证下一次滚动还能重试。
+                            isRefreshLoading = false;
+                            isMoreLoading = false;
+                            removeLoadingIndicator();
+                            if (BuildConfig.DEBUG) {
+                                Log.e(LOAD_TAG, "buildUiMsgList failed, busy flags released", throwable);
+                            }
                         });
             }
         });
@@ -2790,7 +2856,14 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
 
 
     private void showRefreshLoading() {
-        if (isRefreshLoading || !isCanRefresh) return;
+        if (isRefreshLoading || !isCanRefresh) {
+            if (BuildConfig.DEBUG) {
+                Log.w(LOAD_TAG, "refresh BLOCKED isRefreshLoading=" + isRefreshLoading
+                        + " isCanRefresh=" + isCanRefresh
+                        + " emptyStreak=" + consecutiveEmptyRefresh);
+            }
+            return;
+        }
         isRefreshLoading = true;
         WKMsg wkMsg = new WKMsg();
         wkMsg.type = WKContentType.loading;
@@ -2812,7 +2885,14 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
     }
 
     private void showMoreLoading() {
-        if (isMoreLoading || !isCanLoadMore) return;
+        if (isMoreLoading || !isCanLoadMore) {
+            if (BuildConfig.DEBUG) {
+                Log.w(LOAD_TAG, "loadMore BLOCKED isMoreLoading=" + isMoreLoading
+                        + " isCanLoadMore=" + isCanLoadMore
+                        + " emptyStreak=" + consecutiveEmptyLoadMore);
+            }
+            return;
+        }
         isMoreLoading = true;
         WKMsg wkMsg = new WKMsg();
         wkMsg.type = WKContentType.loading;
@@ -2915,6 +2995,7 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
             chatAdapter.getData().get(newSize - 1).nextMsg = null;
         }
         isCanLoadMore = true;
+        consecutiveEmptyLoadMore = 0;
         chatAdapter.rebuildIndex();
     }
 
@@ -2931,6 +3012,7 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
             chatAdapter.getData().get(0).previousMsg = null;
         }
         isCanRefresh = true;
+        consecutiveEmptyRefresh = 0;
         chatAdapter.rebuildIndex();
     }
 

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChooseChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChooseChatActivity.java
@@ -750,12 +750,26 @@ public class ChooseChatActivity extends WKBaseActivity<ActChooseChatLayoutBindin
     }
 
     private void sortByTopAndTime(List<ChooseChatEntity> list) {
+        // 排序键排序前算好，理由同 ChatFragment.buildRecentDisplayList：
+        // ① getWkChannel() 为 null 时不回缓存，comparator 里写两遍就每次比较都查库；
+        // ② 懒加载/并发刷新会让比较结果在排序中途改变，触发 TimSort 契约异常。
+        // 顺带修掉原来 `uiConveursationMsg == null → return 0` 的不可传递比较（null 与任何元素
+        // 都"相等"，但被它判等的两个元素之间未必相等），改为把 null 项确定性地排到末尾。
+        java.util.Map<ChooseChatEntity, Integer> topFlags = new java.util.IdentityHashMap<>(list.size());
+        java.util.Map<ChooseChatEntity, Long> timeKeys = new java.util.IdentityHashMap<>(list.size());
+        for (int i = 0, size = list.size(); i < size; i++) {
+            ChooseChatEntity e = list.get(i);
+            WKUIConversationMsg uc = e.uiConveursationMsg;
+            WKChannel ch = uc == null ? null : uc.getWkChannel();
+            topFlags.put(e, (ch != null && ch.top == 1) ? 1 : 0);
+            timeKeys.put(e, uc == null ? Long.MIN_VALUE : uc.lastMsgTimestamp);
+        }
         list.sort((a, b) -> {
-            if (a.uiConveursationMsg == null || b.uiConveursationMsg == null) return 0;
-            int topA = (a.uiConveursationMsg.getWkChannel() != null && a.uiConveursationMsg.getWkChannel().top == 1) ? 1 : 0;
-            int topB = (b.uiConveursationMsg.getWkChannel() != null && b.uiConveursationMsg.getWkChannel().top == 1) ? 1 : 0;
+            int topA = topFlags.getOrDefault(a, 0);
+            int topB = topFlags.getOrDefault(b, 0);
             if (topA != topB) return topB - topA;
-            return Long.compare(b.uiConveursationMsg.lastMsgTimestamp, a.uiConveursationMsg.lastMsgTimestamp);
+            return Long.compare(timeKeys.getOrDefault(b, Long.MIN_VALUE),
+                    timeKeys.getOrDefault(a, Long.MIN_VALUE));
         });
     }
 

--- a/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
@@ -1577,10 +1577,13 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
         long threeDaysAgoSec = System.currentTimeMillis() / 1000 - 3L * 24 * 60 * 60;
         List<ThreadEntity> recentList = new ArrayList<>();
         List<ThreadEntity> inactiveList = new ArrayList<>();
+        // 一次批量查回本群所有子区会话：原来循环里逐个 getUIConversationMsg，每次都是一条带两个
+        // left join 的查询，在 RecyclerView bind 的主线程上按子区数放大。
+        java.util.Map<String, WKUIConversationMsg> threadConvMap =
+                queryThreadConversations(groupNo, activeList);
         for (ThreadEntity te : activeList) {
             String tcId = ThreadModel.getInstance().buildChannelId(groupNo, te.short_id);
-            WKUIConversationMsg conv = WKIM.getInstance().getConversationManager()
-                    .getUIConversationMsg(tcId, WKChannelType.COMMUNITY_TOPIC);
+            WKUIConversationMsg conv = threadConvMap.get(tcId);
             long lastTs = conv != null ? conv.lastMsgTimestamp : 0;
             if (lastTs > threeDaysAgoSec) {
                 recentList.add(te);
@@ -1653,8 +1656,7 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
             // 未读数气泡
             int unread = entity.unread_count;
             String threadChannelId = ThreadModel.getInstance().buildChannelId(groupNo, entity.short_id);
-            WKUIConversationMsg threadConv = WKIM.getInstance().getConversationManager()
-                    .getUIConversationMsg(threadChannelId, WKChannelType.COMMUNITY_TOPIC);
+            WKUIConversationMsg threadConv = threadConvMap.get(threadChannelId);
             if (threadConv != null) {
                 unread = threadConv.unreadCount;
             }
@@ -1760,8 +1762,8 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
                     moreMention = true;
                 }
                 int u = te.unread_count;
-                WKUIConversationMsg tc = WKIM.getInstance().getConversationManager()
-                        .getUIConversationMsg(tcId, WKChannelType.COMMUNITY_TOPIC);
+                // inactiveList 是 activeList 的子集，直接复用上面那次批量查询的结果
+                WKUIConversationMsg tc = threadConvMap.get(tcId);
                 if (tc != null) {
                     u = tc.unreadCount;
                 }
@@ -1895,6 +1897,10 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
         if (!(cardContainerView instanceof LinearLayout)) return;
         LinearLayout cardContainer = (LinearLayout) cardContainerView;
 
+        // 一次批量查回，替代下面循环里逐行 getUIConversationMsg（这个方法是 bind 复用路径，
+        // 每次刷新未读气泡都会走一遍）
+        java.util.Map<String, WKUIConversationMsg> threadConvMap =
+                queryThreadConversations(groupNo, activeList);
         int rowIndex = 0;
         for (int i = 0; i < cardContainer.getChildCount() && rowIndex < showCount; i++) {
             View child = cardContainer.getChildAt(i);
@@ -1903,8 +1909,7 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
             if (rowIndex >= activeList.size()) break;
             ThreadEntity entity = activeList.get(rowIndex);
             String threadChannelId = ThreadModel.getInstance().buildChannelId(groupNo, entity.short_id);
-            WKUIConversationMsg threadConv = WKIM.getInstance().getConversationManager()
-                    .getUIConversationMsg(threadChannelId, WKChannelType.COMMUNITY_TOPIC);
+            WKUIConversationMsg threadConv = threadConvMap.get(threadChannelId);
             int unread = threadConv != null ? threadConv.unreadCount : entity.unread_count;
 
             WKChannel threadChannel = WKIM.getInstance().getChannelManager()
@@ -2126,17 +2131,42 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
     private int getThreadUnreadCount(String groupNo) {
         List<ThreadEntity> cachedList = threadDataCache.get(groupNo);
         if (cachedList == null || cachedList.isEmpty()) return 0;
-        int total = 0;
+        // 只查 status==1 的子区，保持与下面循环的过滤条件一致
+        List<ThreadEntity> activeList = new ArrayList<>(cachedList.size());
         for (ThreadEntity entity : cachedList) {
-            if (entity.status != 1) continue;
+            if (entity != null && entity.status == 1) activeList.add(entity);
+        }
+        java.util.Map<String, WKUIConversationMsg> threadConvMap =
+                queryThreadConversations(groupNo, activeList);
+        int total = 0;
+        for (ThreadEntity entity : activeList) {
             String threadChannelId = ThreadModel.getInstance().buildChannelId(groupNo, entity.short_id);
-            WKUIConversationMsg threadConv = WKIM.getInstance().getConversationManager()
-                    .getUIConversationMsg(threadChannelId, WKChannelType.COMMUNITY_TOPIC);
+            WKUIConversationMsg threadConv = threadConvMap.get(threadChannelId);
             if (threadConv != null) {
                 total += threadConv.unreadCount;
             }
         }
         return total;
+    }
+
+    /**
+     * 批量查一组子区的会话，key 是子区 channelID。
+     *
+     * <p>原来各处在循环里逐个 {@code getUIConversationMsg}，每次都是一条带两个 left join 的
+     * 查询，跑在 RecyclerView bind 的主线程上、按子区数放大。这里压成 1 次。
+     * 查不到的子区在 map 里缺席，调用方拿到 null 走原来的 {@code entity.unread_count} 兜底，
+     * 与逐条查询语义一致。
+     */
+    private java.util.Map<String, WKUIConversationMsg> queryThreadConversations(
+            String groupNo, List<ThreadEntity> entities) {
+        if (entities == null || entities.isEmpty()) return java.util.Collections.emptyMap();
+        List<String> ids = new ArrayList<>(entities.size());
+        for (ThreadEntity te : entities) {
+            if (te == null) continue;
+            ids.add(ThreadModel.getInstance().buildChannelId(groupNo, te.short_id));
+        }
+        return WKIM.getInstance().getConversationManager()
+                .getUIConversationMsgs(ids, WKChannelType.COMMUNITY_TOPIC);
     }
 
     public boolean hasThreadMention(String groupNo) {

--- a/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
+++ b/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
@@ -147,6 +147,15 @@ import com.chat.uikit.sidebar.SidebarItemEntity;
  */
 public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBinding> {
 
+    /** ANR 修复专用埋点 tag，只在 debug 输出：{@code adb logcat -s ANRFix}。 */
+    private static final String PERF_TAG = "ANRFix";
+
+    /**
+     * 仅 debug：置 true 后每次刷会话列表额外跑一遍改动前的逐群 LIKE 查法并计时，
+     * 用于同机同数据的 A/B 对比。默认 false —— 打开会把被优化掉的全表扫又跑回来。
+     */
+    private static final boolean DEBUG_COMPARE_LEGACY_REMINDER_QUERY = false;
+
     private ChatConversationAdapter chatConversationAdapter;
     private ChatConversationAdapter followAdapter;
     private ChatConversationAdapter recentAdapter;
@@ -2659,31 +2668,6 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
         return total;
     }
 
-    private boolean hasMentionInCategory(CategoryEntity category, HashMap<String, ChatConversationMsg> channelMap) {
-        if (category.groups == null) return false;
-        String loginUID = WKConfig.getInstance().getUid();
-        for (CategoryEntity.CategoryGroup cg : category.groups) {
-            if (!channelMap.containsKey(cg.group_no)) continue;
-            // 从 SDK DB 直接读取提醒（不依赖会话对象的 reminderList，避免时序问题）
-            List<WKReminder> reminders = WKIM.getInstance().getReminderManager()
-                    .getReminders(cg.group_no, WKChannelType.GROUP);
-            if (WKReader.isNotEmpty(reminders)) {
-                for (WKReminder r : reminders) {
-                    if (r.type == WKMentionType.WKReminderTypeMentionMe && r.done == 0
-                            && (TextUtils.isEmpty(r.publisher) || !r.publisher.equals(loginUID))) {
-                        return true;
-                    }
-                }
-            }
-            // 检查子区：直接查 DB（不依赖 threadDataCache，冷启动时可能为空）
-            if (ReminderDBManager.getInstance().hasUndoneReminderWithChannelPrefix(
-                    cg.group_no, WKMentionType.WKReminderTypeMentionMe)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     /**
      * 为任意 ChatConversationMsg 列表计算未读总数。
      *
@@ -2711,10 +2695,12 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
     /**
      * 为任意 ChatConversationMsg 列表判定是否存在未处理的 @mention 提醒。
      *
-     * <p>：未分组 section orphan 合并路径的对应版本。保持与
-     * {@link #hasMentionInCategory} 一致的判定口径（SDK DB 查提醒 + 子区前缀查）。
+     * <p>：未分组 section orphan 合并路径的对应版本。保持与原实现一致的判定口径
+     * （SDK 缓存查本群提醒 + 子区前缀匹配），但子区那一路的 DB 查询由调用方一次批量取出，
+     * 见 {@code undoneMentionChannelIds}。
      */
-    private boolean computeHasMentionForItems(List<ChatConversationMsg> items) {
+    private boolean computeHasMentionForItems(List<ChatConversationMsg> items,
+                                              Set<String> undoneMentionChannelIds) {
         if (items == null || items.isEmpty()) return false;
         String loginUID = WKConfig.getInstance().getUid();
         for (ChatConversationMsg msg : items) {
@@ -2731,8 +2717,24 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
                     }
                 }
             }
-            if (ReminderDBManager.getInstance().hasUndoneReminderWithChannelPrefix(
-                    cid, WKMentionType.WKReminderTypeMentionMe)) {
+            if (hasUndoneThreadMention(cid, undoneMentionChannelIds)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 子区 channel_id = 父群号 + 恰好 4 字符子区后缀 + 任意，等价于原来的
+     * {@code channel_id LIKE 'parentChannelId____%'}。用 regionMatches(true, ...) 而非
+     * startsWith：SQLite 的 LIKE 对 ASCII 默认大小写不敏感，保持与原 SQL 完全相同的口径。
+     */
+    private boolean hasUndoneThreadMention(String parentChannelId, Set<String> undoneChannelIds) {
+        if (undoneChannelIds == null || undoneChannelIds.isEmpty()) return false;
+        int minLength = parentChannelId.length() + 4;
+        for (String channelId : undoneChannelIds) {
+            if (channelId.length() >= minLength
+                    && channelId.regionMatches(true, 0, parentChannelId, 0, parentChannelId.length())) {
                 return true;
             }
         }
@@ -2744,9 +2746,9 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
      * 群聊 tab (0): channelType == GROUP，按 category 分组显示
      * 私聊 tab (1): channelType == PERSONAL，无分组
      *
-     *  · 外层封装为 50ms debounce：同一 UI 帧内的多次触发（消息到达 + reminder +
-     * channel 刷新 + typing/calling 变化）合并为一次 DiffUtil 遍历，避免 ACTION_DOWN
-     * 和 ACTION_UP 之间发生多次 notifyDataSetChanged 导致 ViewHolder detach → touch cancel。
+     * <p>即时刷新，无 debounce —— 50ms debounce 已在 e68a171「对齐 iOS 体验」时移除。
+     * 保留 removeCallbacks 是为了取消 onResume 等路径 post 出去的 {@link #filterRunnable}，
+     * 避免同一次刷新跑两遍。
      */
     private void filterAndDisplay() {
         filterDebounceHandler.removeCallbacks(filterRunnable);
@@ -2806,6 +2808,9 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
     }
 
     private List<ChatConversationMsg> buildFollowDisplayList() {
+        final long buildStartNs = BuildConfig.DEBUG ? System.nanoTime() : 0L;
+        final List<String> debugScannedChannelIds = BuildConfig.DEBUG ? new ArrayList<>() : null;
+        final List<String> debugMentionSections = BuildConfig.DEBUG ? new ArrayList<>() : null;
         FollowedKeysStore store = FollowedKeysStore.getInstance();
         Map<String, List<SidebarItemEntity>> itemsByCategory = store.getItemsByCategory();
 
@@ -2824,6 +2829,11 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
         }
 
         List<ChatConversationMsg> displayList = new ArrayList<>();
+
+        // 一次取出全部未完成 @我 提醒的 channel_id，供下面每个 section 做内存前缀匹配。
+        // 原来是在 category × group 双层循环里逐个查 DB，主线程上放大成 N 次全表扫 → ANR。
+        Set<String> undoneMentionChannelIds = ReminderDBManager.getInstance()
+                .queryUndoneChannelIds(WKMentionType.WKReminderTypeMentionMe);
 
         List<CategoryEntity> categories = new ArrayList<>(categoryList);
         for (CategoryEntity category : categories) {
@@ -2850,7 +2860,16 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
             ChatConversationMsg sectionHeader = new ChatConversationMsg(category.category_id, category.name);
             sectionHeader.sectionGroupCount = sectionItems.size();
             sectionHeader.sectionUnreadCount = computeUnreadCountForItems(sectionItems);
-            sectionHeader.sectionHasMention = computeHasMentionForItems(sectionItems);
+            sectionHeader.sectionHasMention = computeHasMentionForItems(sectionItems, undoneMentionChannelIds);
+            if (BuildConfig.DEBUG) {
+                for (ChatConversationMsg m : sectionItems) {
+                    if (m != null && m.uiConversationMsg != null
+                            && !TextUtils.isEmpty(m.uiConversationMsg.channelID)) {
+                        debugScannedChannelIds.add(m.uiConversationMsg.channelID);
+                    }
+                }
+                if (sectionHeader.sectionHasMention) debugMentionSections.add(category.name);
+            }
             displayList.add(sectionHeader);
 
             if (!followAdapter.isSectionCollapsed(category.category_id)) {
@@ -2871,6 +2890,18 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
             }
         }
 
+        if (BuildConfig.DEBUG) {
+            Log.d(PERF_TAG, "[list] buildFollowDisplayList items=" + debugScannedChannelIds.size()
+                    + " undoneMentionRows=" + undoneMentionChannelIds.size()
+                    + " mentionSections=" + debugMentionSections
+                    + " cost=" + String.format(java.util.Locale.US, "%.2fms",
+                            (System.nanoTime() - buildStartNs) / 1_000_000.0)
+                    + " thread=" + Thread.currentThread().getName());
+            if (DEBUG_COMPARE_LEGACY_REMINDER_QUERY) {
+                ReminderDBManager.getInstance().debugCompareLegacyPrefixScan(
+                        debugScannedChannelIds, WKMentionType.WKReminderTypeMentionMe);
+            }
+        }
         return displayList;
     }
 

--- a/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
+++ b/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
@@ -2581,10 +2581,13 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
         List<ChatConversationMsg> topList = new ArrayList<>();
         List<ChatConversationMsg> normalList = new ArrayList<>();
         for (int i = 0, size = snapshot.size(); i < size; i++) {
-            if (snapshot.get(i).uiConversationMsg.getWkChannel() != null && snapshot.get(i).uiConversationMsg.getWkChannel().top == 1) {
-                topList.add(snapshot.get(i));
+            ChatConversationMsg m = snapshot.get(i);
+            // 取一次存局部变量：getWkChannel() 返回 null 时不会回缓存，写两遍就查两遍库。
+            WKChannel ch = m.uiConversationMsg.getWkChannel();
+            if (ch != null && ch.top == 1) {
+                topList.add(m);
             } else {
-                normalList.add(snapshot.get(i));
+                normalList.add(m);
             }
         }
         List<ChatConversationMsg> tempList = new ArrayList<>();
@@ -2960,9 +2963,23 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
             filtered.add(threadMsg);
         }
 
+        // 排序前把 top 快照成 int：comparator 里直接调 getWkChannel() 有两个问题 ——
+        // ① WKUIConversationMsg.getWkChannel() 只在非 null 时回缓存，本地缺 channel 行的会话
+        //    每次比较都重新进 ChannelManager 慢路径，O(N log N) 次比较 = 反复查库；
+        // ② 懒加载可能在排序中途成功、或并发刷新改了 top，导致同一对元素的比较结果前后不一致，
+        //    触发 TimSort 的 IllegalArgumentException: Comparison method violates its general contract!
+        // 每个对象取一次、排序期间恒定，两个问题一起解决。用 IdentityHashMap 是因为
+        // ChatConversationMsg 没有值语义的 equals/hashCode。
+        java.util.Map<ChatConversationMsg, Integer> topFlags =
+                new java.util.IdentityHashMap<>(filtered.size());
+        for (int i = 0, size = filtered.size(); i < size; i++) {
+            ChatConversationMsg m = filtered.get(i);
+            WKChannel ch = m.uiConversationMsg.getWkChannel();
+            topFlags.put(m, (ch != null && ch.top == 1) ? 1 : 0);
+        }
         filtered.sort((a, b) -> {
-            int topA = (a.uiConversationMsg.getWkChannel() != null && a.uiConversationMsg.getWkChannel().top == 1) ? 1 : 0;
-            int topB = (b.uiConversationMsg.getWkChannel() != null && b.uiConversationMsg.getWkChannel().top == 1) ? 1 : 0;
+            int topA = topFlags.getOrDefault(a, 0);
+            int topB = topFlags.getOrDefault(b, 0);
             if (topA != topB) return topB - topA;
             // 排序键退回 uc.lastMsgTimestamp 直读 (与 sortMsg 保持一致, 见那边的注释)。
             return Long.compare(

--- a/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
@@ -119,6 +119,10 @@ public class MsgModel extends WKBaseModel {
 
     private static final long FLAME_FIRST_DELAY_MS = 100;
     private static final long FLAME_INTERVAL_MS = 1000;
+    /** 连续失败到这个次数就停止轮询（下次进聊天页 startCheckFlameMsgTimer 会重新起）。 */
+    private static final int FLAME_MAX_FAILURE_STREAK = 3;
+    /** 只在 {@link WKDbScheduler} 单线程上读写，无需同步。 */
+    private int flameFailureStreak;
 
     public void stopTimer() {
         flameLoopRunning.set(false);
@@ -140,7 +144,23 @@ public class MsgModel extends WKBaseModel {
         if (!flameLoopRunning.get()) return;
         flameLoopTask = WKDbScheduler.get().scheduleDirect(() -> {
             if (!flameLoopRunning.get()) return;
-            if (sweepFlameMsg()) {
+            // sweepFlameMsg 会查库 / 写库，抛出时若不接住，递归排程不会发生而 flameLoopRunning
+            // 仍是 true —— startCheckFlameMsgTimer 的 CAS 从此永久短路，清理进程内静默停摆。
+            // 不变量：这个 runnable 退出时，要么已排下一轮，要么 flameLoopRunning 已置回 false。
+            boolean keepGoing;
+            try {
+                keepGoing = sweepFlameMsg();
+                flameFailureStreak = 0;
+            } catch (Throwable t) {
+                // 瞬时故障（同步高峰的 SQLiteException / OOM）下一轮重试，连续失败到上限才收摊，
+                // 避免把一个必然失败的 DB 操作变成每秒一次的热循环。
+                keepGoing = ++flameFailureStreak < FLAME_MAX_FAILURE_STREAK;
+                if (BuildConfig.DEBUG) {
+                    Log.w("ANRFix", "[flame] sweep failed #" + flameFailureStreak
+                            + " keepGoing=" + keepGoing, t);
+                }
+            }
+            if (keepGoing) {
                 scheduleFlameSweep(FLAME_INTERVAL_MS);
             } else {
                 flameLoopRunning.set(false);

--- a/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
@@ -80,9 +80,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /**
  * 2019-11-24 14:18
@@ -103,55 +106,86 @@ public class MsgModel extends WKBaseModel {
         return MsgModelBinder.msgModel;
     }
 
-    private Timer timer;
+    /**
+     * 阅后即焚轮询。原来用 java.util.Timer 固定每秒触发，而 TimerTask 只把任务丢进单线程的
+     * {@link WKDbScheduler} 就立刻返回 —— 队列每秒进 1 个、每次扫描却要几十秒，无界积压把 DB
+     * 线程永久占满，连接被长时间独占后主线程任何查询都 park（Bugly ANRWatchdog 那批 ANR）。
+     * 改为自排程：上一轮跑完才排下一轮，且没有待过期消息时直接停。
+     */
+    private final AtomicBoolean flameLoopRunning = new AtomicBoolean(false);
+    private volatile Disposable flameLoopTask;
+    /** 仅 debug：数轮询跑了几轮，用来确认"没有阅后即焚消息时会停"。 */
+    private final AtomicInteger flameSweepCount = new AtomicInteger();
+
+    private static final long FLAME_FIRST_DELAY_MS = 100;
+    private static final long FLAME_INTERVAL_MS = 1000;
 
     public void stopTimer() {
-        if (timer != null) {
-            timer.cancel();
-            timer.purge();
-            timer = null;
+        flameLoopRunning.set(false);
+        Disposable task = flameLoopTask;
+        if (task != null && !task.isDisposed()) {
+            task.dispose();
         }
+        flameLoopTask = null;
     }
 
-    public synchronized void startCheckFlameMsgTimer() {
-        if (timer == null) {
-            timer = new Timer();
-            timer.schedule(new TimerTask() {
-                @Override
-                public void run() {
-                    deleteFlameMsg();
-                }
-            }, 100, 1000);
-        }
+    public void startCheckFlameMsgTimer() {
+        // CAS 兼作并发保护：原来 startCheckFlameMsgTimer 是 synchronized 而 DB 线程上的
+        // timer.cancel()/timer=null 没有同步，两边竞争可能留下两个 timer。
+        if (!flameLoopRunning.compareAndSet(false, true)) return;
+        scheduleFlameSweep(FLAME_FIRST_DELAY_MS);
+    }
+
+    private void scheduleFlameSweep(long delayMs) {
+        if (!flameLoopRunning.get()) return;
+        flameLoopTask = WKDbScheduler.get().scheduleDirect(() -> {
+            if (!flameLoopRunning.get()) return;
+            if (sweepFlameMsg()) {
+                scheduleFlameSweep(FLAME_INTERVAL_MS);
+            } else {
+                flameLoopRunning.set(false);
+            }
+        }, delayMs, TimeUnit.MILLISECONDS);
     }
 
     public void deleteFlameMsg() {
         if (!WKConstants.isLogin()) return;
-        // getWithFlame + deleteWithClientMsgNos 有 DB 操作，放 IO 线程避免 ANR（onPause 等主线程调用场景）
-        WKDbScheduler.get().scheduleDirect(() -> {
-            List<WKMsg> list = WKIM.getInstance().getMsgManager().getWithFlame();
-            if (WKReader.isEmpty(list)) return;
-            List<String> deleteClientMsgNoList = new ArrayList<>();
-            List<WKMsg> deleteMsgList = new ArrayList<>();
-            boolean isStopTimer = true;
-            for (WKMsg msg : list) {
-                if (msg.flame == 1 && msg.viewed == 1) {
-                    long time = WKTimeUtils.getInstance().getCurrentMills() - msg.viewedAt;
-                    if (time / 1000 > msg.flameSecond || msg.flameSecond == 0) {
-                        deleteClientMsgNoList.add(msg.clientMsgNO);
-                        deleteMsgList.add(msg);
-                    }
-                    isStopTimer = false;
-                }
+        // 一次性清理（退出聊天页 / 前后台切换等时机调用），不参与轮询。
+        WKDbScheduler.get().scheduleDirect(this::sweepFlameMsg);
+    }
+
+    /**
+     * 扫一轮阅后即焚消息，删掉已到期的。必须在 {@link WKDbScheduler} 线程上调用。
+     *
+     * @return 是否还存在"已读的"阅后即焚消息 —— 有才需要继续轮询。返回 false 时轮询停止，
+     * 这正是原实现缺的那一步：原来 {@code if (isEmpty(list)) return;} 在 cancel 之前，
+     * 导致从没用过阅后即焚的用户（绝大多数）永远停不下来。
+     */
+    private boolean sweepFlameMsg() {
+        if (!WKConstants.isLogin()) return false;
+        List<WKMsg> list = WKIM.getInstance().getMsgManager().getWithFlame();
+        if (BuildConfig.DEBUG) {
+            Log.d("ANRFix", "[flame] sweep #" + flameSweepCount.incrementAndGet()
+                    + " rows=" + (list == null ? 0 : list.size()));
+        }
+        if (WKReader.isEmpty(list)) return false;
+        List<String> deleteClientMsgNoList = new ArrayList<>();
+        List<WKMsg> deleteMsgList = new ArrayList<>();
+        boolean hasViewedFlameMsg = false;
+        for (WKMsg msg : list) {
+            if (msg.flame != 1 || msg.viewed != 1) continue;
+            hasViewedFlameMsg = true;
+            long elapsedSecond = (WKTimeUtils.getInstance().getCurrentMills() - msg.viewedAt) / 1000;
+            if (elapsedSecond > msg.flameSecond || msg.flameSecond == 0) {
+                deleteClientMsgNoList.add(msg.clientMsgNO);
+                deleteMsgList.add(msg);
             }
-            if (isStopTimer && timer != null) {
-                timer.cancel();
-                timer.purge();
-                timer = null;
-            }
+        }
+        if (!deleteMsgList.isEmpty()) {
             deleteMsg(deleteMsgList, null);
             WKIM.getInstance().getMsgManager().deleteWithClientMsgNos(deleteClientMsgNoList);
-        });
+        }
+        return hasViewedFlameMsg;
     }
 
     private void ackMsg() {

--- a/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
@@ -146,24 +146,31 @@ public class MsgModel extends WKBaseModel {
             if (!flameLoopRunning.get()) return;
             // sweepFlameMsg 会查库 / 写库，抛出时若不接住，递归排程不会发生而 flameLoopRunning
             // 仍是 true —— startCheckFlameMsgTimer 的 CAS 从此永久短路，清理进程内静默停摆。
-            // 不变量：这个 runnable 退出时，要么已排下一轮，要么 flameLoopRunning 已置回 false。
-            boolean keepGoing;
+            boolean keepGoing = false;
             try {
                 keepGoing = sweepFlameMsg();
                 flameFailureStreak = 0;
-            } catch (Throwable t) {
-                // 瞬时故障（同步高峰的 SQLiteException / OOM）下一轮重试，连续失败到上限才收摊，
-                // 避免把一个必然失败的 DB 操作变成每秒一次的热循环。
+            } catch (Exception e) {
+                // 只接可恢复的瞬时故障（同步高峰的 SQLiteException 等）：下一轮重试，连续失败到
+                // 上限才收摊，避免把一个必然失败的 DB 操作变成每秒一次的热循环。
+                //
+                // 刻意不接 Error：本仓库没有设 RxJavaPlugins.setErrorHandler，OOM 原本会经
+                // RxJavaPlugins.onError → uncaught handler 抵达 Bugly。接住它而 release 下又
+                // 不上报，等于把这批改动（见 BaseObserver.reportIfSwallowedError）要暴露的东西
+                // 重新吞一次。让它照原路穿出去，崩溃语义与改动前一致；也不重试刚 OOM 的操作。
                 keepGoing = ++flameFailureStreak < FLAME_MAX_FAILURE_STREAK;
                 if (BuildConfig.DEBUG) {
                     Log.w("ANRFix", "[flame] sweep failed #" + flameFailureStreak
-                            + " keepGoing=" + keepGoing, t);
+                            + " keepGoing=" + keepGoing, e);
                 }
-            }
-            if (keepGoing) {
-                scheduleFlameSweep(FLAME_INTERVAL_MS);
-            } else {
-                flameLoopRunning.set(false);
+            } finally {
+                // 不变量：无论正常返回、Exception 还是 Error 穿出去，都不能把 flameLoopRunning
+                // 留在 true —— 那才是「清理永久禁用」的根因。
+                if (keepGoing) {
+                    scheduleFlameSweep(FLAME_INTERVAL_MS);
+                } else {
+                    flameLoopRunning.set(false);
+                }
             }
         }, delayMs, TimeUnit.MILLISECONDS);
     }

--- a/wkuikit/src/main/java/com/chat/uikit/user/service/UserModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/user/service/UserModel.java
@@ -37,6 +37,7 @@ import com.chat.base.net.ICommonListener;
 import com.chat.base.net.IRequestResultListener;
 import com.chat.base.net.entity.CommonResponse;
 import com.chat.base.net.ud.WKUploader;
+import com.chat.base.utils.DispatchQueuePool;
 import com.chat.base.utils.WKDeviceUtils;
 import com.chat.base.utils.WKReader;
 import com.chat.base.utils.WKTimeUtils;
@@ -64,6 +65,9 @@ import java.util.List;
  * 用户
  */
 public class UserModel extends WKBaseModel {
+    // 与 FriendModel 同一份范式: HTTP 回调在主线程, DB 读写走这个池。池大小 3 对齐 FriendModel。
+    private final DispatchQueuePool dispatchQueuePool = new DispatchQueuePool(3);
+
     private UserModel() {
     }
 
@@ -255,36 +259,52 @@ public class UserModel extends WKBaseModel {
                 }
                 WKSharedPreferencesUtil.getInstance().putInt(WKConfig.getInstance().getUid() + "_pc_online", online);
                 WKSharedPreferencesUtil.getInstance().putInt(WKConfig.getInstance().getUid() + "_mute_of_app", muteOfAPP);
-                List<WKChannel> tempList = WKIM.getInstance().getChannelManager().getWithFollowAndStatus(WKChannelType.PERSONAL, 1, 1);
-                List<WKChannel> list = new ArrayList<>();
-                if (WKReader.isNotEmpty(result.friends)) {
-                    if (WKReader.isNotEmpty(tempList)) {
-                        for (int i = 0, size = tempList.size(); i < size; i++) {
-                            boolean isReset = true;
-                            for (int j = 0, len = result.friends.size(); j < len; j++) {
-                                if (result.friends.get(j).uid.equals(tempList.get(i).channelID)) {
-                                    isReset = false;
-                                    tempList.get(i).online = result.friends.get(j).online;
-                                    tempList.get(i).lastOffline = result.friends.get(j).last_offline;
-                                    break;
+                // 整段 DB 读写下沉到后台队列: 这个回调在主线程(HTTP onSuccess), 里面有 1 次
+                // getWithFollowAndStatus 全表读 + 每个新好友 1 次 getChannel + 末尾一次
+                // saveOrUpdateChannels 写事务。同一份逻辑在 FriendModel:186 早就是
+                // dispatchQueuePool.execute 包装的, 这里是漏了。触发点是 App 回前台
+                // (TSApplication:176), 正是 Bugly 那批 ANR 的触发场景之一。
+                dispatchQueuePool.execute(() -> {
+                    List<WKChannel> tempList = WKIM.getInstance().getChannelManager().getWithFollowAndStatus(WKChannelType.PERSONAL, 1, 1);
+                    List<WKChannel> list = new ArrayList<>();
+                    if (WKReader.isNotEmpty(result.friends)) {
+                        if (WKReader.isNotEmpty(tempList)) {
+                            for (int i = 0, size = tempList.size(); i < size; i++) {
+                                boolean isReset = true;
+                                for (int j = 0, len = result.friends.size(); j < len; j++) {
+                                    if (result.friends.get(j).uid.equals(tempList.get(i).channelID)) {
+                                        isReset = false;
+                                        tempList.get(i).online = result.friends.get(j).online;
+                                        tempList.get(i).lastOffline = result.friends.get(j).last_offline;
+                                        break;
+                                    }
                                 }
+                                if (isReset) {
+                                    tempList.get(i).online = 0;
+                                    // tempList.get(i).lastOffline = 0;
+                                }
+                                list.add(tempList.get(i));
                             }
-                            if (isReset) {
-                                tempList.get(i).online = 0;
-                                // tempList.get(i).lastOffline = 0;
-                            }
-                            list.add(tempList.get(i));
-                        }
 
-                        for (int i = 0, size = result.friends.size(); i < size; i++) {
-                            boolean isAdd = true;
-                            for (int j = 0, len = tempList.size(); j < len; j++) {
-                                if (result.friends.get(i).uid.equals(tempList.get(j).channelID)) {
-                                    isAdd = false;
-                                    break;
+                            for (int i = 0, size = result.friends.size(); i < size; i++) {
+                                boolean isAdd = true;
+                                for (int j = 0, len = tempList.size(); j < len; j++) {
+                                    if (result.friends.get(i).uid.equals(tempList.get(j).channelID)) {
+                                        isAdd = false;
+                                        break;
+                                    }
+                                }
+                                if (isAdd) {
+                                    WKChannel channel = WKIM.getInstance().getChannelManager().getChannel(result.friends.get(i).uid, WKChannelType.PERSONAL);
+                                    if (channel != null) {
+                                        channel.lastOffline = result.friends.get(i).last_offline;
+                                        channel.online = result.friends.get(i).online;
+                                        list.add(channel);
+                                    }
                                 }
                             }
-                            if (isAdd) {
+                        } else {
+                            for (int i = 0, size = result.friends.size(); i < size; i++) {
                                 WKChannel channel = WKIM.getInstance().getChannelManager().getChannel(result.friends.get(i).uid, WKChannelType.PERSONAL);
                                 if (channel != null) {
                                     channel.lastOffline = result.friends.get(i).last_offline;
@@ -294,40 +314,16 @@ public class UserModel extends WKBaseModel {
                             }
                         }
                     } else {
-                        for (int i = 0, size = result.friends.size(); i < size; i++) {
-                            WKChannel channel = WKIM.getInstance().getChannelManager().getChannel(result.friends.get(i).uid, WKChannelType.PERSONAL);
-                            if (channel != null) {
-                                channel.lastOffline = result.friends.get(i).last_offline;
-                                channel.online = result.friends.get(i).online;
-                                list.add(channel);
-                            }
-                        }
-                    }
-                } else {
-                    for (int i = 0, size = tempList.size(); i < size; i++) {
-                        if (tempList.get(i).online == 1 || tempList.get(i).lastOffline > 0) {
-                            tempList.get(i).online = 0;
-                            // tempList.get(i).lastOffline = 0;
-                            list.add(tempList.get(i));
-                        }
-                    }
-                }
-
-                if (WKReader.isNotEmpty(result.friends)) {
-                    if (WKReader.isNotEmpty(tempList)) {
                         for (int i = 0, size = tempList.size(); i < size; i++) {
-                            for (int j = 0, len = result.friends.size(); j < len; j++) {
-                                if (result.friends.get(j).uid.equals(tempList.get(i).channelID)) {
-                                    tempList.get(i).online = result.friends.get(j).online;
-                                    tempList.get(i).lastOffline = result.friends.get(j).last_offline;
-                                    list.add(tempList.get(i));
-                                    break;
-                                }
+                            if (tempList.get(i).online == 1 || tempList.get(i).lastOffline > 0) {
+                                tempList.get(i).online = 0;
+                                // tempList.get(i).lastOffline = 0;
+                                list.add(tempList.get(i));
                             }
                         }
                     }
-                }
-                WKIM.getInstance().getChannelManager().saveOrUpdateChannels(list);
+                    WKIM.getInstance().getChannelManager().saveOrUpdateChannels(list);
+                });
             }
 
             @Override


### PR DESCRIPTION
Closes #122

## 修了什么

| 根因 | 修法 |
|---|---|
| SQLCipher 连接池被钉死为 1 条 | `openDatabase` 显式传 `ENABLE_WRITE_AHEAD_LOGGING`，池取 8 |
| 阅后即焚定时器空转（单次执行 89.8s 独占连接） | 轮询改自排程，空结果直接停；查询收窄到 9 列 + 部分索引 |
| `message` 四条 `max()` 无覆盖索引；`@提醒` LIKE 全表扫 × N | 两个复合索引 + synckey 过滤下推；`@提醒` 改一次批量取 + 内存前缀匹配 |
| bind 路径逐行查库 | `channel_members` 共享缓存（含负结果）；子区会话批量化 |
| conv/sync 整包物化 + 一次性构建全量列表 | >256K 字符走 `JSONReader` 流式；每 20 会话一批落盘 + 消费完释放 `recents` |
| ANR 上报堆栈恒为 `ANRWatchdog.run` | `setStackTrace(mainStack)`，Bugly 按业务帧分桶；补冻结守卫 |
| 排序 comparator 里查库 + TimSort 契约违规 | 比较键排序前快照 |
| 落进 Rx 错误管道的 OOM 静默消失 | `BaseObserver` 补一条 `postCatchedException`（每进程 ≤3 条） |

17 笔，`wkbase` / `wkim` / `wkuikit` + 3 个迁移文件（全是 `CREATE INDEX IF NOT EXISTS`，不改表结构与数据）。

## 实测（真机 vivo V2464A）

| 项 | 改前 → 改后 |
|---|---|
| 主线程等连接（后台持事务 4s 期间） | 3102ms → 1ms |
| 阅后即焚轮询 | 60 次/分钟 → 4 次后静默 |
| 成员缓存命中率 | 61% → 96% |
| OOM 峰值 | 132MB → 78MB（3× 载荷改前推算 336MB > 256MB 上限，必崩） |
| 收包 + 解析 | +100MB → +15MB |

## 测试重点

- **老用户覆盖安装**（回退 SP 的 `_db_upgrade_index` 后启动）：3 个迁移全部执行、版本号正确推进
- **全新安装**：表与索引齐备
- 大账号会话同步：列表条数 / 未读 / 置顶 / @红点 与 main 一致
- 翻历史到底、断网恢复、多频道交替翻页
- 成员缓存失效：群内改备注、对方改昵称头像、**切账号**
- 子区未读与父群汇总

## 已知 / 不在本 PR

- 「翻历史加载不出来」修了 4 处各自独立成立的缺陷，**哪一处对应实机那次卡死未坐实**（加埋点后未能复现）
- P2-4（sync rebuild 前批量预载）要碰 `SpaceFilter`，挂起
- 连接池预热：实测可把冷启动 slow-db 从 10 条降到 0，但属卡顿级非崩溃级（最坏 418ms）且未在低端机验证
- `setDebug(true)` 写死的根因：改动会让全 SDK 数百处历史日志在 release 集体闭嘴，需单独立项
- `WKHeapProbe` 与各 `PROBE_*` / `DEBUG_*` 开关是诊断用，全部 debug 门控且默认关，问题闭环后删
