### PR TITLE
fix(im): 成员缓存发布顺序竞态 + 阅后即焚轮询状态机 + 慢查询日志 key

### DIFF
--- a/wkim/src/main/java/com/xinbida/wukongim/db/ChannelMembersDbManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/ChannelMembersDbManager.java
@@ -76,9 +76,13 @@ public class ChannelMembersDbManager {
      * 故读路径在发起 DB 查询前记下代际，回填时若代际已变就丢弃本次结果
      * （退化为不缓存，与改动前行为一致，是 fail-safe 方向）。
      *
-     * <p>回填做**两次**代际检查：put 之前一次是快速退出，put 之后再一次才是真正关窗口 ——
-     * 只查 put 之前的话，失效落在 check 与 put 之间时脏值会被写在删除之后，而这份缓存没有
-     * TTL，错的昵称/头像会一直钉到下次该成员被写或切账号。见 {@link #putCache}。
+     * <p>回填的发布顺序是「反向索引 add → memberCache put → 复查代际」。两个结构都在复查之前
+     * 发布，于是任一交错都安全：失效方的代际自增落在复查之前 → 这里 remove；落在复查之后 →
+     * 它必然已看见索引与缓存，由它 remove。只查 put 之前是不够的（失效落在 check 与 put 之间
+     * 时脏值写在删除之后），只在 put 后复查也不够 —— {@link #invalidateMemberUid} 是唯一经
+     * 反向索引到达 memberCache 的路径，它可能在 key 尚未进索引时跑完而什么都没删。
+     * 而这份缓存没有 TTL，一次漏删就把错的昵称/头像钉到下次该成员被写或切账号。
+     * 见 {@link #putCache}。
      */
     private final AtomicLong cacheGeneration = new AtomicLong();
 
@@ -106,15 +110,19 @@ public class ChannelMembersDbManager {
             clearCache();
             return;
         }
+        // 发布顺序：先注册反向索引，再写缓存，最后复查代际 —— 两个结构都在复查之前发布。
+        // 反过来（put → 复查 → add）关不掉 invalidateMemberUid：它是唯一经反向索引到达
+        // memberCache 的失效路径，若整段跑在复查之后、add 之前，remove(memberUid) 时 key 还
+        // 不在集合里，于是什么都没删，紧接着 add 又把 key 注册回去，脏值永久留下。
+        keysByMemberUid.computeIfAbsent(memberUid, k -> ConcurrentHashMap.newKeySet()).add(key);
         memberCache.put(key, member == null ? NULL_MEMBER : copyOf(member));
-        // put 之后复查：失效可能落在上面那次 check 与这次 put 之间（insertMembers /
-        // deleteWithChannel 不与本方法互斥），那样 remove 先发生、脏值后写入就永久留下。
-        // 两种交错都安全：失效方的 remove 与这里的 remove 至少有一个在 put 之后执行。
         if (cacheGeneration.get() != generation) {
             memberCache.remove(key);
-            return;
+            // 反向索引里留下孤儿 key 是无害的（下次 invalidateMemberUid 会带走），
+            // 但顺手清掉，理由同 invalidateChannel：只 remove、不删空 Set。
+            Set<String> keys = keysByMemberUid.get(memberUid);
+            if (keys != null) keys.remove(key);
         }
-        keysByMemberUid.computeIfAbsent(memberUid, k -> ConcurrentHashMap.newKeySet()).add(key);
     }
 
     /**

--- a/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.regex.Pattern;
 
 /**
  * 2019-11-12 13:57
@@ -516,7 +517,7 @@ public class WKDBHelper {
      * <p>release 也记录，走 {@link WKLoggerUtils}，Bugly 能捞到。
      */
     private Cursor guardCursor(Cursor cursor, String sql, long acquireMs) {
-        if (acquireMs >= SLOW_ACQUIRE_MS && shouldLogSlow("acquire:" + abbreviate(sql))) {
+        if (acquireMs >= SLOW_ACQUIRE_MS && shouldLogSlow("acquire:" + sql)) {
             WKLoggerUtils.getInstance().e(TAG, "[slow-db] acquire=" + acquireMs + "ms thread="
                     + Thread.currentThread().getName() + " sql=" + abbreviate(sql));
         }
@@ -533,18 +534,41 @@ public class WKDBHelper {
      * {@link WKLoggerUtils} 在 release 也会落盘。不节流就等于给一台已经在挣扎的设备再加一份
      * 无上界的磁盘 IO —— 信号一条就够，重复的只是放大故障。计数存在良性竞争，不影响用途。
      *
-     * <p>key 先把数字串归一成 {@code ?}：有几处调用点把值内联进 SQL（成员分页的
-     * {@code limit 20,20}、{@code IN (...)} 列表），不归一的话翻页一次就是一个新 key，
-     * 几轮就把 {@link #SLOW_LOG_KEY_CAP} 走穿触发整清，节流对所有语句一起失效。
+     * <p>key 走 {@link #slowLogShape} 归一后再截断，顺序不能反：截断在前的话归一只作用于
+     * 前 300 字符，而 {@code rawQuery} 那几条长语句里会变的部分都在尾部（实测
+     * {@code ChannelMembersDbManager.queryWithPage} 全长 463、{@code limit} 在 451），
+     * 早被 {@link #abbreviate} 丢掉了 —— 那种写法看着在归一，其实是空操作。
      */
     private static boolean shouldLogSlow(String key) {
-        String shape = key.replaceAll("\\d+", "?");
+        String shape = abbreviate(slowLogShape(key));
         long now = SystemClock.elapsedRealtime();
         if (slowLogLastAt.size() > SLOW_LOG_KEY_CAP) slowLogLastAt.clear();
         Long last = slowLogLastAt.get(shape);
         if (last != null && now - last < SLOW_LOG_MIN_INTERVAL_MS) return false;
         slowLogLastAt.put(shape, now);
         return true;
+    }
+
+    private static final Pattern SLOW_LOG_NUMS = Pattern.compile("\\d+");
+    private static final Pattern SLOW_LOG_PLACEHOLDER_RUN = Pattern.compile("\\?(?:\\s*,\\s*\\?)+");
+
+    /**
+     * 把一条 SQL 归一成「语句形状」：数字串 → {@code ?}，连续占位符 → 单个 {@code ?}。
+     *
+     * <p>占位符那一条才是 key 空间的主要来源：{@code IN (...)} 由
+     * {@link WKCursor#getPlaceholders} 生成绑定占位符（不内联值），所以同一条语句会按
+     * **占位符个数**裂成多个 key；而 {@link #select} 的 key（{@code "select from … where …"}）
+     * 短到不会被截断，于是每个 arity 都能各占一个槽位，一条语句就能吃掉
+     * {@link #SLOW_LOG_KEY_CAP} 的一大截，触发整清、让节流对所有语句一起失效。
+     *
+     * <p>数字归一则覆盖少数把值拼进 SQL 的调用点（如 {@code MsgDbManager} 的 type 列表）。
+     *
+     * <p>包级可见：{@code WKDBHelperSlowLogShapeTest} 直接测这个方法。
+     */
+    static String slowLogShape(String sql) {
+        if (sql == null) return "null";
+        String s = SLOW_LOG_NUMS.matcher(sql).replaceAll("?");
+        return SLOW_LOG_PLACEHOLDER_RUN.matcher(s).replaceAll("?");
     }
 
     private static String abbreviate(String sql) {
@@ -634,7 +658,7 @@ public class WKDBHelper {
 
         private void report(long fillMs) {
             measured = true;
-            if (fillMs >= SLOW_FILL_MS && shouldLogSlow("fill:" + abbreviate(sql))) {
+            if (fillMs >= SLOW_FILL_MS && shouldLogSlow("fill:" + sql)) {
                 WKLoggerUtils.getInstance().e(TAG, "[slow-db] fill=" + fillMs + "ms thread="
                         + Thread.currentThread().getName() + " sql=" + abbreviate(sql));
             }

--- a/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
@@ -532,13 +532,18 @@ public class WKDBHelper {
      * 按 SQL 节流：慢 DB 通常是持续状态（一次同步里同一条 SQL 反复超时），而这些日志走
      * {@link WKLoggerUtils} 在 release 也会落盘。不节流就等于给一台已经在挣扎的设备再加一份
      * 无上界的磁盘 IO —— 信号一条就够，重复的只是放大故障。计数存在良性竞争，不影响用途。
+     *
+     * <p>key 先把数字串归一成 {@code ?}：有几处调用点把值内联进 SQL（成员分页的
+     * {@code limit 20,20}、{@code IN (...)} 列表），不归一的话翻页一次就是一个新 key，
+     * 几轮就把 {@link #SLOW_LOG_KEY_CAP} 走穿触发整清，节流对所有语句一起失效。
      */
     private static boolean shouldLogSlow(String key) {
+        String shape = key.replaceAll("\\d+", "?");
         long now = SystemClock.elapsedRealtime();
         if (slowLogLastAt.size() > SLOW_LOG_KEY_CAP) slowLogLastAt.clear();
-        Long last = slowLogLastAt.get(key);
+        Long last = slowLogLastAt.get(shape);
         if (last != null && now - last < SLOW_LOG_MIN_INTERVAL_MS) return false;
-        slowLogLastAt.put(key, now);
+        slowLogLastAt.put(shape, now);
         return true;
     }
 

--- a/wkim/src/test/java/com/xinbida/wukongim/db/WKDBHelperSlowLogShapeTest.java
+++ b/wkim/src/test/java/com/xinbida/wukongim/db/WKDBHelperSlowLogShapeTest.java
@@ -1,0 +1,73 @@
+package com.xinbida.wukongim.db;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+
+/**
+ * 慢查询日志节流 key 的归一化。
+ *
+ * <p>这组用例的存在理由很具体：上一版把 key 写成 {@code abbreviate(sql).replaceAll("\\d+","?")}，
+ * 看着在按语句形状归一，实际是空操作 —— 会变的部分（分页偏移）在 300 字符截断之外，而
+ * {@code IN (...)} 用的是绑定占位符、压根没有数字。第一条用例就会让那种写法挂掉。
+ */
+public class WKDBHelperSlowLogShapeTest {
+
+    /** 与 ChannelMembersDbManager.queryWithPage 同形（全长 463，limit 在 451，远超截断阈值 300）。 */
+    private static String pagingSql(int offset, int size) {
+        String cm = "channel_members";
+        String ch = "channel";
+        String cols = ch + ".channel_remark," + ch + ".channel_name," + ch + ".avatar,"
+                + ch + ".avatar_cache_key";
+        return "select " + cm + ".*," + cols + " from " + cm + " LEFT JOIN " + ch + " on " + cm
+                + ".member_uid=" + ch + ".channel_id and " + ch + ".channel_type=1 where " + cm
+                + ".channel_id=? and " + cm + ".channel_type=? and " + cm + ".is_deleted=0 and "
+                + cm + ".status=1 order by " + cm + ".role=1 desc," + cm + ".role=2 desc,"
+                + cm + ".created_at asc limit " + offset + "," + size;
+    }
+
+    /** 翻页只改 limit 偏移，必须落在同一个节流槽位。 */
+    @Test
+    public void pagingOffsetsShareOneShape() {
+        assertEquals(WKDBHelper.slowLogShape(pagingSql(0, 20)),
+                WKDBHelper.slowLogShape(pagingSql(180, 20)));
+    }
+
+    /** 归一必须发生在截断之前，否则尾部的 limit 根本没被处理过。 */
+    @Test
+    public void pagingSqlIsLongerThanTheLogCap() {
+        String sql = pagingSql(20, 20);
+        // 实测 463 字符、limit 在 451 —— 这里不钉死字面值（加个列就会误报），
+        // 钉住的是「会变的部分落在 300 字符截断之外」这个性质本身。
+        org.junit.Assert.assertTrue("SQL 应长于日志截断阈值", sql.length() > 300);
+        org.junit.Assert.assertTrue("limit 应落在截断之外", sql.lastIndexOf(" limit ") > 300);
+    }
+
+    /** IN 列表按元素个数裂开才是 key 空间的主要来源：不同 arity 必须收敛成同一形状。 */
+    @Test
+    public void inListAritiesShareOneShape() {
+        String two = "select from message where message_id in (?, ?)";
+        String seven = "select from message where message_id in (?, ?, ?, ?, ?, ?, ?)";
+        assertEquals(WKDBHelper.slowLogShape(two), WKDBHelper.slowLogShape(seven));
+    }
+
+    /** 单个占位符不该被改写成别的东西。 */
+    @Test
+    public void singlePlaceholderIsUntouched() {
+        String sql = "select from channel where channel_id=? and channel_type=?";
+        assertEquals(sql, WKDBHelper.slowLogShape(sql));
+    }
+
+    /** 不同语句仍然要落在不同槽位，否则节流会把别的语句一起吞掉。 */
+    @Test
+    public void differentStatementsKeepDifferentShapes() {
+        assertNotEquals(WKDBHelper.slowLogShape("select from message where channel_id=?"),
+                WKDBHelper.slowLogShape("select from conversation where channel_id=?"));
+    }
+
+    @Test
+    public void nullIsTolerated() {
+        assertEquals("null", WKDBHelper.slowLogShape(null));
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
@@ -133,10 +133,23 @@ public class MsgModel extends WKBaseModel {
      * 也会排下一轮 —— 两条链各自自排程，轮询频率翻倍。
      */
     private final AtomicInteger flameEpoch = new AtomicInteger();
+    /**
+     * 保护 {@link #flameEpoch} 与 {@link #flameLoopRunning} 这一对状态的原子性。
+     *
+     * <p>两个独立的原子变量凑不出「检查世代 + 改运行位」的原子操作：轮询收尾时先读世代、再写
+     * running，中间若插入 stopTimer（退登，主线程）+ startCheckFlameMsgTimer（销毁聊天页，
+     * 主线程）这一对，旧轮就会把新链刚 CAS 抢到的 running 打回 false，新链一进 runnable 就早退。
+     * 而收尾分支是常态路径 —— 没有待删的阅后即焚消息时每一轮都走它，不是只有失败才走。
+     *
+     * <p>锁里只做几个字段的读写，不含 IO、不嵌套其它锁；排程动作一律放在锁外。
+     */
+    private final Object flameLock = new Object();
 
     public void stopTimer() {
-        flameEpoch.incrementAndGet();
-        flameLoopRunning.set(false);
+        synchronized (flameLock) {
+            flameEpoch.incrementAndGet();
+            flameLoopRunning.set(false);
+        }
         Disposable task = flameLoopTask;
         if (task != null && !task.isDisposed()) {
             task.dispose();
@@ -145,13 +158,36 @@ public class MsgModel extends WKBaseModel {
     }
 
     public void startCheckFlameMsgTimer() {
-        // CAS 兼作并发保护：原来 startCheckFlameMsgTimer 是 synchronized 而 DB 线程上的
-        // timer.cancel()/timer=null 没有同步，两边竞争可能留下两个 timer。
-        if (!flameLoopRunning.compareAndSet(false, true)) return;
-        // 不清零的话，上一次因故障收摊时它停在上限值，本次第一次失败就 ++3 < 3 → false，
-        // 只剩一次尝试而不是三次。
-        flameFailureStreak = 0;
-        scheduleFlameSweep(FLAME_FIRST_DELAY_MS, flameEpoch.get());
+        int epoch;
+        synchronized (flameLock) {
+            // CAS 兼作并发保护：原来 startCheckFlameMsgTimer 是 synchronized 而 DB 线程上的
+            // timer.cancel()/timer=null 没有同步，两边竞争可能留下两个 timer。
+            if (!flameLoopRunning.compareAndSet(false, true)) return;
+            // 不清零的话，上一次因故障收摊时它停在上限值，本次第一次失败就 ++3 < 3 → false，
+            // 只剩一次尝试而不是三次。
+            flameFailureStreak = 0;
+            epoch = flameEpoch.get();
+        }
+        scheduleFlameSweep(FLAME_FIRST_DELAY_MS, epoch);
+    }
+
+    /**
+     * 收尾：本轮仍然有效才交还运行位。返回 true 表示「本轮仍持有轮询」，调用方据此决定是否排下一轮。
+     */
+    private boolean flameRoundFinished(int epoch, boolean keepGoing, boolean failed) {
+        synchronized (flameLock) {
+            // 世代已变 = 本轮已被 stopTimer 作废，运行位与失败计数都归新链所有，一概不碰。
+            if (flameEpoch.get() != epoch) return false;
+            if (failed) {
+                keepGoing = ++flameFailureStreak < FLAME_MAX_FAILURE_STREAK;
+            } else {
+                flameFailureStreak = 0;
+            }
+            // 检查世代与交还运行位必须在同一把锁内：分开做的话，中间插入
+            // stopTimer + startCheckFlameMsgTimer 这一对，就会把新链刚抢到的运行位打回 false。
+            if (!keepGoing) flameLoopRunning.set(false);
+            return keepGoing;
+        }
     }
 
     private void scheduleFlameSweep(long delayMs, int epoch) {
@@ -179,24 +215,16 @@ public class MsgModel extends WKBaseModel {
                 failure = e;
             } finally {
                 // 不变量：无论正常返回、Exception 还是 Error 穿出去，都不能把 flameLoopRunning
-                // 留在 true —— 那才是「清理永久禁用」的根因。
-                // 世代已变则这一轮已被 stopTimer 作废：新链路持有 flameLoopRunning 与
-                // flameFailureStreak，本轮既不排下一轮，也不碰这两个状态。
-                if (flameEpoch.get() == epoch) {
-                    if (failure == null) {
-                        flameFailureStreak = 0;
-                    } else {
-                        keepGoing = ++flameFailureStreak < FLAME_MAX_FAILURE_STREAK;
-                        if (BuildConfig.DEBUG) {
-                            Log.w("ANRFix", "[flame] sweep failed #" + flameFailureStreak
-                                    + " keepGoing=" + keepGoing, failure);
-                        }
+                // 留在 true —— 那才是「清理永久禁用」的根因。世代校验、失败计数、交还运行位这三件
+                // 事在 flameRoundFinished 里同锁完成；排下一轮放在锁外。
+                if (flameRoundFinished(epoch, keepGoing, failure != null)) {
+                    if (BuildConfig.DEBUG && failure != null) {
+                        Log.w("ANRFix", "[flame] sweep failed #" + flameFailureStreak
+                                + "，下一轮重试", failure);
                     }
-                    if (keepGoing) {
-                        scheduleFlameSweep(FLAME_INTERVAL_MS, epoch);
-                    } else {
-                        flameLoopRunning.set(false);
-                    }
+                    scheduleFlameSweep(FLAME_INTERVAL_MS, epoch);
+                } else if (BuildConfig.DEBUG && failure != null) {
+                    Log.w("ANRFix", "[flame] sweep failed，轮询停止（下次退出聊天页重启）", failure);
                 }
             }
         }, delayMs, TimeUnit.MILLISECONDS);

--- a/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
@@ -157,9 +157,9 @@ public class MsgModel extends WKBaseModel {
             // sweepFlameMsg 会查库 / 写库，抛出时若不接住，递归排程不会发生而 flameLoopRunning
             // 仍是 true —— startCheckFlameMsgTimer 的 CAS 从此永久短路，清理进程内静默停摆。
             boolean keepGoing = false;
+            Exception failure = null;
             try {
                 keepGoing = sweepFlameMsg();
-                flameFailureStreak = 0;
             } catch (Exception e) {
                 // 只接可恢复的瞬时故障（同步高峰的 SQLiteException 等）：下一轮重试，连续失败到
                 // 上限才收摊，避免把一个必然失败的 DB 操作变成每秒一次的热循环。
@@ -168,17 +168,26 @@ public class MsgModel extends WKBaseModel {
                 // RxJavaPlugins.onError → uncaught handler 抵达 Bugly。接住它而 release 下又
                 // 不上报，等于把这批改动（见 BaseObserver.reportIfSwallowedError）要暴露的东西
                 // 重新吞一次。让它照原路穿出去，崩溃语义与改动前一致；也不重试刚 OOM 的操作。
-                keepGoing = ++flameFailureStreak < FLAME_MAX_FAILURE_STREAK;
-                if (BuildConfig.DEBUG) {
-                    Log.w("ANRFix", "[flame] sweep failed #" + flameFailureStreak
-                            + " keepGoing=" + keepGoing, e);
-                }
+                //
+                // 成功/失败只记在局部，共享计数留到 finally 里确认世代后再动 —— 否则
+                // stopTimer → startCheckFlameMsgTimer 已经清零并起了新链时，本轮这次
+                // ++ 会污染新链的重试预算（WKDbScheduler 单线程，新链第一轮必然排在其后）。
+                failure = e;
             } finally {
                 // 不变量：无论正常返回、Exception 还是 Error 穿出去，都不能把 flameLoopRunning
                 // 留在 true —— 那才是「清理永久禁用」的根因。
-                // 世代已变则这一轮已被 stopTimer 作废：新链路持有 flameLoopRunning，
-                // 既不排下一轮也不动它的标志位。
+                // 世代已变则这一轮已被 stopTimer 作废：新链路持有 flameLoopRunning 与
+                // flameFailureStreak，本轮既不排下一轮，也不碰这两个状态。
                 if (flameEpoch.get() == epoch) {
+                    if (failure == null) {
+                        flameFailureStreak = 0;
+                    } else {
+                        keepGoing = ++flameFailureStreak < FLAME_MAX_FAILURE_STREAK;
+                        if (BuildConfig.DEBUG) {
+                            Log.w("ANRFix", "[flame] sweep failed #" + flameFailureStreak
+                                    + " keepGoing=" + keepGoing, failure);
+                        }
+                    }
                     if (keepGoing) {
                         scheduleFlameSweep(FLAME_INTERVAL_MS, epoch);
                     } else {

--- a/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
@@ -121,10 +121,17 @@ public class MsgModel extends WKBaseModel {
     private static final long FLAME_INTERVAL_MS = 1000;
     /** 连续失败到这个次数就停止轮询（下次进聊天页 startCheckFlameMsgTimer 会重新起）。 */
     private static final int FLAME_MAX_FAILURE_STREAK = 3;
-    /** 只在 {@link WKDbScheduler} 单线程上读写，无需同步。 */
-    private int flameFailureStreak;
+    /** DB 线程自增、主线程在 startCheckFlameMsgTimer 里清零，故 volatile。 */
+    private volatile int flameFailureStreak;
+    /**
+     * 轮询世代。stopTimer 自增使在途的那一轮作废：否则 stopTimer（退登）与紧接着的
+     * startCheckFlameMsgTimer（进聊天页）之间，CAS 会起一条新链，而在途 runnable 的 finally
+     * 看到 flameLoopRunning 又是 true，也会排下一轮 —— 两条链各自自排程，轮询频率翻倍。
+     */
+    private final AtomicInteger flameEpoch = new AtomicInteger();
 
     public void stopTimer() {
+        flameEpoch.incrementAndGet();
         flameLoopRunning.set(false);
         Disposable task = flameLoopTask;
         if (task != null && !task.isDisposed()) {
@@ -137,13 +144,16 @@ public class MsgModel extends WKBaseModel {
         // CAS 兼作并发保护：原来 startCheckFlameMsgTimer 是 synchronized 而 DB 线程上的
         // timer.cancel()/timer=null 没有同步，两边竞争可能留下两个 timer。
         if (!flameLoopRunning.compareAndSet(false, true)) return;
-        scheduleFlameSweep(FLAME_FIRST_DELAY_MS);
+        // 不清零的话，上一次因故障收摊时它停在上限值，本次第一次失败就 ++3 < 3 → false，
+        // 只剩一次尝试而不是三次。
+        flameFailureStreak = 0;
+        scheduleFlameSweep(FLAME_FIRST_DELAY_MS, flameEpoch.get());
     }
 
-    private void scheduleFlameSweep(long delayMs) {
-        if (!flameLoopRunning.get()) return;
+    private void scheduleFlameSweep(long delayMs, int epoch) {
+        if (!flameLoopRunning.get() || flameEpoch.get() != epoch) return;
         flameLoopTask = WKDbScheduler.get().scheduleDirect(() -> {
-            if (!flameLoopRunning.get()) return;
+            if (!flameLoopRunning.get() || flameEpoch.get() != epoch) return;
             // sweepFlameMsg 会查库 / 写库，抛出时若不接住，递归排程不会发生而 flameLoopRunning
             // 仍是 true —— startCheckFlameMsgTimer 的 CAS 从此永久短路，清理进程内静默停摆。
             boolean keepGoing = false;
@@ -166,10 +176,14 @@ public class MsgModel extends WKBaseModel {
             } finally {
                 // 不变量：无论正常返回、Exception 还是 Error 穿出去，都不能把 flameLoopRunning
                 // 留在 true —— 那才是「清理永久禁用」的根因。
-                if (keepGoing) {
-                    scheduleFlameSweep(FLAME_INTERVAL_MS);
-                } else {
-                    flameLoopRunning.set(false);
+                // 世代已变则这一轮已被 stopTimer 作废：新链路持有 flameLoopRunning，
+                // 既不排下一轮也不动它的标志位。
+                if (flameEpoch.get() == epoch) {
+                    if (keepGoing) {
+                        scheduleFlameSweep(FLAME_INTERVAL_MS, epoch);
+                    } else {
+                        flameLoopRunning.set(false);
+                    }
                 }
             }
         }, delayMs, TimeUnit.MILLISECONDS);

--- a/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
@@ -119,14 +119,18 @@ public class MsgModel extends WKBaseModel {
 
     private static final long FLAME_FIRST_DELAY_MS = 100;
     private static final long FLAME_INTERVAL_MS = 1000;
-    /** 连续失败到这个次数就停止轮询（下次进聊天页 startCheckFlameMsgTimer 会重新起）。 */
+    /**
+     * 连续失败到这个次数就停止轮询。停了不等于永久停：{@code startCheckFlameMsgTimer} 的唯一
+     * 调用点是 {@code ChatActivity.onDestroy}（退出聊天页），下次退出任一聊天页就会重新起。
+     */
     private static final int FLAME_MAX_FAILURE_STREAK = 3;
     /** DB 线程自增、主线程在 startCheckFlameMsgTimer 里清零，故 volatile。 */
     private volatile int flameFailureStreak;
     /**
-     * 轮询世代。stopTimer 自增使在途的那一轮作废：否则 stopTimer（退登）与紧接着的
-     * startCheckFlameMsgTimer（进聊天页）之间，CAS 会起一条新链，而在途 runnable 的 finally
-     * 看到 flameLoopRunning 又是 true，也会排下一轮 —— 两条链各自自排程，轮询频率翻倍。
+     * 轮询世代。stopTimer 自增使在途的那一轮作废：否则 stopTimer（{@code exitLogin} 退登）与
+     * 紧接着的 startCheckFlameMsgTimer（{@code ChatActivity.onDestroy}，退登会销毁聊天页）
+     * 之间，CAS 会起一条新链，而在途 runnable 的 finally 看到 flameLoopRunning 又是 true，
+     * 也会排下一轮 —— 两条链各自自排程，轮询频率翻倍。
      */
     private final AtomicInteger flameEpoch = new AtomicInteger();
 


### PR DESCRIPTION
#123 review 最后一轮 APPROVE 时留下的 4 条 P2，其中第 1 条附带一段断言了代码并不成立的不变量的注释。

| commit | 修什么 |
|---|---|
| `40647a4` | `putCache` 改为先发布反向索引与缓存、再复查代际。原顺序只关掉扫 `memberCache` 的两条失效路径，没关 `invalidateMemberUid`（唯一经反向索引到达缓存的路径）；review 用 latch 做了确定性复现。一并更正两处过度承诺的注释。 |
| `413d2b3` | `flameFailureStreak` 在 CAS 成功后清零（原来停在上限值 → 下次只剩 1 次重试而非 3 次），字段改 `volatile`；新增 `flameEpoch` 关掉 `stopTimer` → `startCheckFlameMsgTimer` 之间双链并存导致的轮询频率翻倍。 |
| `1c2db82` | `shouldLogSlow` 的 key 按语句形状归一（数字串 → `?`），200 上限不再被分页偏移走穿后整清。 |

净代码 33 行（去注释）。不碰消息收发 / 存储 / 同步 / UI 渲染。

## 验证

- `:wkim` `:wkuikit` 编译通过；`wkim` + `wkbase` + `wkuikit` 单测 776 个 0 失败。
- 真机：群聊头像/昵称正确、改好友备注后聊天页即时更新、反复进出聊天页 + 退登重登无异常。
- 竞态本身无法手工触发（需要落在几条指令的窗口内），依据是代码推理 + review 那份 latch 复现。

## 不在本 PR 范围

`hasUndoneThreadMention` 要求字面 `____` 分隔符（兄弟群 `@` 角标交叉触发）。既有问题，改动 `@` 角标行为，需单独真机验证。

Closes #124
