### PR TITLE
fix(chat): 重连 sync 完成后刷新会话列表

### DIFF
--- a/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
+++ b/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
@@ -317,7 +317,7 @@ public class WKUIKitApplication {
                         .postDelayed(this::startChat, 100);
                 return;
             }
-            Log.e("去连接", "-->");
+            if (BuildConfig.DEBUG) Log.e("去连接", "-->");
             WKIM.getInstance().getConnectionManager().connection();
         }
     }

--- a/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
+++ b/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
@@ -1182,6 +1182,22 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
                         });
                     }
                 }
+            } else if (i == WKConnectStatus.syncCompleted) {
+                // 会话 sync 落库完成 —— 重绘一次列表。
+                //
+                // 锁屏挂起恢复的时序是错位的：onResume 先跑（用挂起前的旧数据重绘一次）→
+                // WebSocket 才开始重连 → sync 回来更新 allConversations，但增量路径对
+                // 「已存在会话的字段更新」只做逐行 notifyItemChanged，不重建列表 → 界面停在
+                // onResume 那一帧。表现为「状态显示已连接、列表还是旧的」，直到来新消息或
+                // 进聊天页返回才自愈。
+                //
+                // 这里的数据是就绪的：setOnRefreshMsg 与本状态都经 BaseManager.runOnMainThread
+                // 投到主线程队列，且前者先投（ConversationManager 内 :682 早于 :698），
+                // FIFO 保证 allConversations 已更新完再走到这里。
+                if (BuildConfig.DEBUG) {
+                    android.util.Log.d("ConvSync", "[ConvSync] syncCompleted -> filterAndDisplay");
+                }
+                filterAndDisplay();
             } else if (i == WKConnectStatus.connecting) {
                 wkVBinding.textSwitcher.setText(getString(R.string.connecting));
                 wkVBinding.spaceChevronIv.setVisibility(View.GONE);


### PR DESCRIPTION
Closes #126

## 问题

锁屏挂起恢复后，连接状态正常变为「已连接」，但会话列表停在挂起前那一帧 —— 顺序、预览、未读都不更新。来新消息或进出聊天页才自愈。

## 根因

`onResume` 与重连的时序错位：

1. 解锁 → `onResume` 重绘一次，此时 socket 未连上，用的是旧数据
2. 重连成功 → conversation sync 回来 → `allConversations` 已更新
3. 但增量路径对「已存在会话的字段更新」只做逐行 `notifyItemChanged`，不重建列表

数据是对的，UI 是旧的。SDK 在 sync 落库结束时会发 `WKConnectStatus.syncCompleted`（`ConversationManager:698`），但 `ChatFragment` 的连接状态监听器从来没接这个信号。

## 改动

`ChatFragment` 的监听器新增 `syncCompleted` 分支，收到即 `filterAndDisplay()` 一次。

数据就绪性由主线程队列 FIFO 保证：`setOnRefreshMsg`（`ConversationManager:682`）先于 `setConnectionStatus`（`:698`）投递，两者都走 `BaseManager.runOnMainThread` → `Handler.post`。真机实测两者相隔 7ms，顺序稳定。

排序不需要额外处理：`filterAndDisplay` → `buildRecentDisplayList()` 每次 build 都按 `top` + `lastMsgTimestamp` 重排（`ChatFragment:3028`）；关注 tab 的顺序由 category 配置决定，与时间戳无关。这条重绘路径正是「来新消息时列表刷新」走的同一个，线上已验证。

顺带给 `WKUIKitApplication:320` 的连接日志加 `BuildConfig.DEBUG` 门控（本仓库 `setDebug(true)` 写死，裸日志会进 release 包）。

## 影响范围

- 纯新增分支，不修改任何既有判断
- 只碰 UI 重绘时机，未触碰数据层、消息收发、Space 过滤、列表构建逻辑
- `syncCompleted` 原本在该监听器中无任何处理
- 既有缺陷，非 #123 / #125 引入（`main` 上一直如此）

## 测试

- `:wkuikit:compileDebugJavaWithJavac` / `:wkuikit:testDebugUnitTest` / `:wkim:testDebugUnitTest` 通过
- 真机：挂起 16 分钟后回前台，日志确认 `syncCompleted -> filterAndDisplay` 触发，列表立即正确，单次重建约 150ms，无卡顿
- 回归：正常收发消息、列表滑动未见异常