### PR TITLE
fix: Bugly 崩溃批次 —— 联系人搜索 NPE、RecyclerView 状态损坏、关库后残留 DB 任务

### DIFF
--- a/wkbase/src/main/java/com/chat/base/ui/components/SecretDeleteTimer.java
+++ b/wkbase/src/main/java/com/chat/base/ui/components/SecretDeleteTimer.java
@@ -144,7 +144,7 @@ public class SecretDeleteTimer extends FrameLayout {
             EndpointManager.getInstance().invoke("deleteRemoteMsg", clientMsgNo);
             // DB 删除操作放 IO 线程，onDraw 中做 DB 操作会导致 ANR
             final String msgNo = clientMsgNo;
-            WKDbScheduler.get().scheduleDirect(() ->
+            WKDbScheduler.submit(() ->
                 WKIM.getInstance().getMsgManager().deleteWithClientMsgNO(msgNo)
             );
             return;

--- a/wkbase/src/main/java/com/chat/base/utils/AppExecutors.java
+++ b/wkbase/src/main/java/com/chat/base/utils/AppExecutors.java
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *   <li>{@link #background()} —— CPU 密集（JSON parse、图形运算、差分等）。
  *   池大小 = CPU 核心数，避免过度并发造成 context switch。</li>
  *   <li>{@link #db()} —— 单线程顺序化 DB 任务（非 Rx 场景；Rx 场景请继续走
- *   {@link WKDbScheduler#get()}）。</li>
+ *   {@link WKDbScheduler#submit(Runnable)}）。</li>
  *   <li>{@link #mainThread(Runnable)} / {@link #postDelayed(Runnable, long)} ——
  *   投递到主线程 Looper；等价于 {@code AndroidUtilities.runOnUIThread}，但不依赖它。</li>
  * </ul>

--- a/wkbase/src/main/java/com/chat/base/utils/WKDbScheduler.java
+++ b/wkbase/src/main/java/com/chat/base/utils/WKDbScheduler.java
@@ -16,9 +16,15 @@
 
 package com.chat.base.utils;
 
+import android.util.Log;
+
+import com.chat.base.BuildConfig;
+
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
@@ -27,6 +33,14 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
  * 避免多线程并发争抢 SQLCipher 连接池导致连接饥饿或 ANR。
  */
 public final class WKDbScheduler {
+
+    private static final String TAG = "WKDbScheduler";
+
+    /**
+     * SQLCipher 连接池关闭后再取连接抛出的固定文案。SQLCipher 抛的是裸
+     * {@link IllegalStateException}，没有专门的异常类型，只能按文案识别。
+     */
+    private static final String POOL_CLOSED_MSG = "connection pool has been closed";
 
     private static final Scheduler INSTANCE = Schedulers.from(
             Executors.newSingleThreadExecutor(r -> {
@@ -39,7 +53,55 @@ public final class WKDbScheduler {
     private WKDbScheduler() {
     }
 
+    /**
+     * 提交一个数据库任务，串行执行。
+     *
+     * <p>登出 / token 失效（401）会关掉数据库，但此前已排队或延迟提交的任务仍会跑到，
+     * 拿已关闭的连接池就抛 {@link IllegalStateException}。RxJava 的 ScheduledDirectTask
+     * 会把它交给 {@code RxJavaPlugins.onError}，默认实现直接调用当前线程的
+     * UncaughtExceptionHandler —— 进程当场崩在 wk-db-worker 上。
+     *
+     * <p>库都关了这些任务本来就没有意义，丢弃即可。只丢这一种，其余异常原样抛出，
+     * 不掩盖真实问题。
+     */
+    public static Disposable submit(Runnable task) {
+        return INSTANCE.scheduleDirect(guard(task));
+    }
+
+    /**
+     * 延迟提交，语义同 {@link #submit(Runnable)}。
+     */
+    public static Disposable submit(Runnable task, long delay, TimeUnit unit) {
+        return INSTANCE.scheduleDirect(guard(task), delay, unit);
+    }
+
+    private static Runnable guard(Runnable task) {
+        return () -> {
+            try {
+                task.run();
+            } catch (IllegalStateException e) {
+                if (!isPoolClosed(e)) throw e;
+                if (BuildConfig.DEBUG) Log.w(TAG, "db closed, drop pending task", e);
+            }
+        };
+    }
+
+    /**
+     * @deprecated 直接拿 Scheduler 会绕过 {@link #submit(Runnable)} 的关库保护，
+     * 新代码一律用 {@link #submit(Runnable)}。
+     */
+    @Deprecated
     public static Scheduler get() {
         return INSTANCE;
+    }
+
+    private static boolean isPoolClosed(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t.getMessage() != null && t.getMessage().contains(POOL_CLOSED_MSG)) {
+                return true;
+            }
+            if (t.getCause() == t) break;
+        }
+        return false;
     }
 }

--- a/wkbase/src/main/java/com/chat/base/views/swipeback/SwipeBackLayout.java
+++ b/wkbase/src/main/java/com/chat/base/views/swipeback/SwipeBackLayout.java
@@ -31,7 +31,9 @@ import android.widget.FrameLayout;
 
 import androidx.core.view.ViewCompat;
 
+import com.chat.base.BuildConfig;
 import com.chat.base.R;
+import com.tencent.bugly.crashreport.CrashReport;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -406,7 +408,12 @@ public class SwipeBackLayout extends FrameLayout {
                         mContentLeft + mContentView.getMeasuredWidth(),
                         mContentTop + mContentView.getMeasuredHeight());
             } catch (Exception e) {
-                Log.e("error", "e=" + e);
+                // 吞掉能避免当场崩，但异常从 RecyclerView 的 layout 里逃逸会让它的
+                // mLayoutOrScrollCounter 永久 >0，之后任意 notifyItem* 都抛
+                // "Cannot call this method while RecyclerView is computing a layout"，
+                // 崩在毫不相干的地方。所以这里必须把真正的现场上报出去。
+                if (BuildConfig.DEBUG) Log.e("SwipeBackLayout", "content layout failed", e);
+                CrashReport.postCatchedException(e);
             }
         }
         mInLayout = false;

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -3050,36 +3050,38 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         }
     }
 
-    // RecyclerView 正在 layout / scroll 时 notify* 会抛 IllegalStateException，只能延后一帧。
-    // 已有动作在排队时后续动作也必须排队，否则新回调会插到旧回调前面，
-    // 同一条消息的两次刷新会被旧状态覆盖。
-    // 若某次 layout 抛异常被上层吞掉，RecyclerView 会永久停在 computing 态，
-    // 重试多少次都没用——这时宁可丢掉这次刷新也不崩。
+    // RecyclerView 正在 layout / scroll 时 notify* 会抛 IllegalStateException，只能延后。
+    // 排队与重试规则见 SafeAdapterActionQueue —— 关键是队头被挡住时重排的是同一个队头，
+    // 后到的动作不会插队。
     private static final int MAX_SAFE_ADAPTER_RETRY = 3;
-    private int pendingAdapterActions = 0;
 
+    private final SafeAdapterActionQueue adapterActionQueue = new SafeAdapterActionQueue(
+            new SafeAdapterActionQueue.Host() {
+                @Override
+                public boolean isBusy() {
+                    return wkVBinding.recyclerView.isComputingLayout();
+                }
+
+                @Override
+                public void postDrain(Runnable drain) {
+                    wkVBinding.recyclerView.post(drain);
+                }
+
+                @Override
+                public void onDropped(int count) {
+                    if (BuildConfig.DEBUG) {
+                        Log.w("MsgDebug", "[safeAdapterAction] recyclerView stuck in computing state, drop "
+                                + count + " pending refresh");
+                    }
+                }
+            }, MAX_SAFE_ADAPTER_RETRY);
+
+    /** 只能在主线程调用 —— {@link SafeAdapterActionQueue} 的状态全是裸字段，无同步。 */
     private void safeAdapterAction(Runnable action) {
-        if (pendingAdapterActions == 0 && !wkVBinding.recyclerView.isComputingLayout()) {
-            action.run();
-            return;
+        if (BuildConfig.DEBUG && Looper.myLooper() != Looper.getMainLooper()) {
+            Log.e("MsgDebug", "[safeAdapterAction] called off main thread", new IllegalStateException());
         }
-        postAdapterAction(action, 0);
-    }
-
-    private void postAdapterAction(Runnable action, int retryCount) {
-        if (retryCount >= MAX_SAFE_ADAPTER_RETRY) {
-            if (BuildConfig.DEBUG) Log.w("MsgDebug", "[safeAdapterAction] recyclerView stuck in computing state, drop refresh");
-            return;
-        }
-        pendingAdapterActions++;
-        wkVBinding.recyclerView.post(() -> {
-            pendingAdapterActions--;
-            if (wkVBinding.recyclerView.isComputingLayout()) {
-                postAdapterAction(action, retryCount + 1);
-            } else {
-                action.run();
-            }
-        });
+        adapterActionQueue.submit(action);
     }
 
     // 显示一条时间消息

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -788,6 +788,7 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         wkVBinding.recyclerView.setLayoutManager(linearLayoutManager);
         wkVBinding.recyclerView.setAdapter(chatAdapter);
         //  perf: MyItemAnimator 需显式关 change 动画，避免 notify 刷新与 fling 叠加掉帧。
+        // 现在由 MyItemAnimator 构造函数里的 setSupportsChangeAnimations(false) 保证。
         wkVBinding.recyclerView.setItemAnimator(new MyItemAnimator());
         chatAdapter.setAnimationFirstOnly(true);
         chatAdapter.setAnimationEnable(false);
@@ -1661,34 +1662,39 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                 }
                 EndpointManager.getInstance().invoke("set_chat_bg", new SetChatBgMenu(channelId, channelType, wkVBinding.imageView, wkVBinding.rootView, wkVBinding.blurView));
             } else {
-                for (int i = 0, size = chatAdapter.getData().size(); i < size; i++) {
-                    if (TextUtils.isEmpty(chatAdapter.getData().get(i).wkMsg.fromUID)) continue;
-                    boolean isRefresh = false;
-                    if (chatAdapter.getData().get(i).wkMsg.fromUID.equals(channel.channelID) && channel.channelType == WKChannelType.PERSONAL) {
-                        chatAdapter.getData().get(i).wkMsg.setFrom(channel);
-                        isRefresh = true;
-                    }
-                    if (chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached() != null && chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberUID.equals(channel.channelID) && channel.channelType == WKChannelType.PERSONAL) {
-                        chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberRemark = channel.channelRemark;
-                        chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberName = channel.channelName;
-                        chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberAvatar = channel.avatar;
-                        chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberAvatarCacheKey = channel.avatarCacheKey;
-                        isRefresh = true;
-                    }
-                    if (chatAdapter.getData().get(i).wkMsg.baseContentMsgModel != null && WKReader.isNotEmpty(chatAdapter.getData().get(i).wkMsg.baseContentMsgModel.entities)) {
-                        for (WKMsgEntity entity : chatAdapter.getData().get(i).wkMsg.baseContentMsgModel.entities) {
-                            if (entity.type.equals(ChatContentSpanType.getMention()) && !TextUtils.isEmpty(entity.value) && entity.value.equals(channel.channelID)) {
-                                isRefresh = true;
-                                chatAdapter.getData().get(i).formatSpans(ChatActivity.this, chatAdapter.getData().get(i).wkMsg);
-                                break;
+                // 频道信息刷新是 IM SDK 回调, 可能落在 RecyclerView 的 layout / scroll 中间,
+                // 直接 notify 会抛 IllegalStateException
+                safeAdapterAction(() -> {
+                    for (int i = 0, size = chatAdapter.getData().size(); i < size; i++) {
+                        if (chatAdapter.getData().get(i).wkMsg == null) continue;
+                        if (TextUtils.isEmpty(chatAdapter.getData().get(i).wkMsg.fromUID)) continue;
+                        boolean isRefresh = false;
+                        if (chatAdapter.getData().get(i).wkMsg.fromUID.equals(channel.channelID) && channel.channelType == WKChannelType.PERSONAL) {
+                            chatAdapter.getData().get(i).wkMsg.setFrom(channel);
+                            isRefresh = true;
+                        }
+                        if (chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached() != null && chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberUID.equals(channel.channelID) && channel.channelType == WKChannelType.PERSONAL) {
+                            chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberRemark = channel.channelRemark;
+                            chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberName = channel.channelName;
+                            chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberAvatar = channel.avatar;
+                            chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberAvatarCacheKey = channel.avatarCacheKey;
+                            isRefresh = true;
+                        }
+                        if (chatAdapter.getData().get(i).wkMsg.baseContentMsgModel != null && WKReader.isNotEmpty(chatAdapter.getData().get(i).wkMsg.baseContentMsgModel.entities)) {
+                            for (WKMsgEntity entity : chatAdapter.getData().get(i).wkMsg.baseContentMsgModel.entities) {
+                                if (entity.type.equals(ChatContentSpanType.getMention()) && !TextUtils.isEmpty(entity.value) && entity.value.equals(channel.channelID)) {
+                                    isRefresh = true;
+                                    chatAdapter.getData().get(i).formatSpans(ChatActivity.this, chatAdapter.getData().get(i).wkMsg);
+                                    break;
+                                }
                             }
                         }
+                        if (isRefresh) {
+                            chatAdapter.getData().get(i).isRefreshAvatarAndName = true;
+                            chatAdapter.notifyItemChanged(i, chatAdapter.getData().get(i));
+                        }
                     }
-                    if (isRefresh) {
-                        chatAdapter.getData().get(i).isRefreshAvatarAndName = true;
-                        chatAdapter.notifyItemChanged(i, chatAdapter.getData().get(i));
-                    }
-                }
+                });
             }
         });
 
@@ -1702,15 +1708,17 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                         wkVBinding.topLayout.titleCenterTv.setText(name);
                     } else {
                         //成员名字改变
-                        for (int i = 0, size = chatAdapter.getData().size(); i < size; i++) {
-                            if (chatAdapter.getData().get(i).wkMsg != null && chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached() != null && !TextUtils.isEmpty(chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberUID) && chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberUID.equals(channelMember.memberUID)) {
-                                chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberName = channelMember.memberName;
-                                chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberRemark = channelMember.memberRemark;
-                                chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberAvatar = channelMember.memberAvatar;
-                                chatAdapter.getData().get(i).isRefreshAvatarAndName = true;
-                                chatAdapter.notifyItemChanged(i, chatAdapter.getData().get(i));
+                        safeAdapterAction(() -> {
+                            for (int i = 0, size = chatAdapter.getData().size(); i < size; i++) {
+                                if (chatAdapter.getData().get(i).wkMsg != null && chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached() != null && !TextUtils.isEmpty(chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberUID) && chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberUID.equals(channelMember.memberUID)) {
+                                    chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberName = channelMember.memberName;
+                                    chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberRemark = channelMember.memberRemark;
+                                    chatAdapter.getData().get(i).wkMsg.getMemberOfFromIfCached().memberAvatar = channelMember.memberAvatar;
+                                    chatAdapter.getData().get(i).isRefreshAvatarAndName = true;
+                                    chatAdapter.notifyItemChanged(i, chatAdapter.getData().get(i));
+                                }
                             }
-                        }
+                        });
                     }
                 }
             }
@@ -1743,7 +1751,7 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         //监听删除消息
         WKIM.getInstance().getMsgManager().addOnDeleteMsgListener(channelId, msg -> {
             if (msg != null) {
-                removeMsg(msg);
+                safeAdapterAction(() -> removeMsg(msg));
             }
         });
         // 命令消息监听
@@ -1778,10 +1786,10 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         //监听消息刷新
         WKIM.getInstance().getMsgManager().addOnRefreshMsgListener(channelId, (wkMsg, left) -> {
             if (wkMsg.remoteExtra.isMutualDeleted == 1) {
-                removeMsg(wkMsg);
+                safeAdapterAction(() -> removeMsg(wkMsg));
                 return;
             }
-            refreshMsg(wkMsg);
+            safeAdapterAction(() -> refreshMsg(wkMsg));
         });
         //监听发送消息返回
         WKIM.getInstance().getMsgManager().addOnSendMsgCallback(channelId, this::sendMsgInserted);
@@ -1800,12 +1808,14 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                     });
                     wkVBinding.recyclerView.setAdapter(chatAdapter);
                 } else {
-                    for (int i = 0; i < chatAdapter.getData().size(); i++) {
-                        if (chatAdapter.getData().get(i).wkMsg != null && !TextUtils.isEmpty(chatAdapter.getData().get(i).wkMsg.fromUID) && chatAdapter.getData().get(i).wkMsg.fromUID.equals(fromUID)) {
-                            chatAdapter.removeAt(i);
-                            i--;
+                    safeAdapterAction(() -> {
+                        for (int i = 0; i < chatAdapter.getData().size(); i++) {
+                            if (chatAdapter.getData().get(i).wkMsg != null && !TextUtils.isEmpty(chatAdapter.getData().get(i).wkMsg.fromUID) && chatAdapter.getData().get(i).wkMsg.fromUID.equals(fromUID)) {
+                                chatAdapter.removeAt(i);
+                                i--;
+                            }
                         }
-                    }
+                    });
                 }
             }
 
@@ -1857,13 +1867,15 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
             if (WKReader.isEmpty(chatAdapter.getData())) {
                 return 1;
             }
-            for (int i = 0, size = chatAdapter.getData().size(); i < size; i++) {
-                if (chatAdapter.getData().get(i).wkMsg != null && chatAdapter.getData().get(i).wkMsg.type == WKContentType.WK_TEXT) {
-                    WKIMUtils.getInstance().resetMsgProhibitWord(chatAdapter.getData().get(i).wkMsg);
-                    chatAdapter.getData().get(i).formatSpans(ChatActivity.this, chatAdapter.getData().get(i).wkMsg);
-                    chatAdapter.notifyItemChanged(i);
+            safeAdapterAction(() -> {
+                for (int i = 0, size = chatAdapter.getData().size(); i < size; i++) {
+                    if (chatAdapter.getData().get(i).wkMsg != null && chatAdapter.getData().get(i).wkMsg.type == WKContentType.WK_TEXT) {
+                        WKIMUtils.getInstance().resetMsgProhibitWord(chatAdapter.getData().get(i).wkMsg);
+                        chatAdapter.getData().get(i).formatSpans(ChatActivity.this, chatAdapter.getData().get(i).wkMsg);
+                        chatAdapter.notifyItemChanged(i);
+                    }
                 }
-            }
+            });
             return 1;
         });
     }
@@ -2141,13 +2153,15 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
      */
     private void refreshThreadCreatedCards() {
         if (chatAdapter == null) return;
-        int headerCount = chatAdapter.getHeaderLayoutCount();
-        for (int i = 0; i < chatAdapter.getData().size(); i++) {
-            WKUIChatMsgItemEntity item = chatAdapter.getData().get(i);
-            if (item.wkMsg != null && item.wkMsg.type == WKContentType.threadCreated) {
-                chatAdapter.notifyItemChanged(i + headerCount);
+        safeAdapterAction(() -> {
+            int headerCount = chatAdapter.getHeaderLayoutCount();
+            for (int i = 0; i < chatAdapter.getData().size(); i++) {
+                WKUIChatMsgItemEntity item = chatAdapter.getData().get(i);
+                if (item.wkMsg != null && item.wkMsg.type == WKContentType.threadCreated) {
+                    chatAdapter.notifyItemChanged(i + headerCount);
+                }
             }
-        }
+        });
     }
 
     private void getChannelState() {
@@ -2163,15 +2177,17 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                 if (channelState.call_info == null || WKReader.isEmpty(channelState.call_info.getCalling_participants())) {
                     wkVBinding.callLayout.setVisibility(View.GONE);
                     isShowCallingView = false;
-                    if (WKReader.isNotEmpty(chatAdapter.getData()) && chatAdapter.getData().get(0).wkMsg.type == WKContentType.spanEmptyView) {
-                        if (!isShowPinnedView) {
-                            chatAdapter.getData().remove(0);
-                            chatAdapter.notifyItemRemoved(0);
-                        } else {
-                            chatAdapter.getData().get(0).wkMsg.messageSeq = getTopPinViewHeight();
-                            chatAdapter.notifyItemChanged(0);
+                    safeAdapterAction(() -> {
+                        if (WKReader.isNotEmpty(chatAdapter.getData()) && chatAdapter.getData().get(0).wkMsg != null && chatAdapter.getData().get(0).wkMsg.type == WKContentType.spanEmptyView) {
+                            if (!isShowPinnedView) {
+                                chatAdapter.getData().remove(0);
+                                chatAdapter.notifyItemRemoved(0);
+                            } else {
+                                chatAdapter.getData().get(0).wkMsg.messageSeq = getTopPinViewHeight();
+                                chatAdapter.notifyItemChanged(0);
+                            }
                         }
-                    }
+                    });
                 } else {
                     Object object = EndpointManager.getInstance().invoke("show_calling_participants", new CallingViewMenu(this, channelState.call_info));
                     if (object != null) {
@@ -2180,13 +2196,15 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                         wkVBinding.callLayout.addView(view, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT));
                         wkVBinding.callLayout.setVisibility(View.VISIBLE);
                         isShowCallingView = true;
-                        if (isAddedSpanEmptyView()) {
-                            chatAdapter.getData().get(0).wkMsg.messageSeq = getTopPinViewHeight();
-                            chatAdapter.notifyItemChanged(0);
-                        } else {
-                            WKMsg msg = getSpanEmptyMsg();
-                            chatAdapter.addData(0, new WKUIChatMsgItemEntity(this, msg, null));
-                        }
+                        safeAdapterAction(() -> {
+                            if (isAddedSpanEmptyView()) {
+                                chatAdapter.getData().get(0).wkMsg.messageSeq = getTopPinViewHeight();
+                                chatAdapter.notifyItemChanged(0);
+                            } else {
+                                WKMsg msg = getSpanEmptyMsg();
+                                chatAdapter.addData(0, new WKUIChatMsgItemEntity(this, msg, null));
+                            }
+                        });
                     } else {
                         isShowCallingView = false;
                     }
@@ -3032,12 +3050,36 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
         }
     }
 
+    // RecyclerView 正在 layout / scroll 时 notify* 会抛 IllegalStateException，只能延后一帧。
+    // 已有动作在排队时后续动作也必须排队，否则新回调会插到旧回调前面，
+    // 同一条消息的两次刷新会被旧状态覆盖。
+    // 若某次 layout 抛异常被上层吞掉，RecyclerView 会永久停在 computing 态，
+    // 重试多少次都没用——这时宁可丢掉这次刷新也不崩。
+    private static final int MAX_SAFE_ADAPTER_RETRY = 3;
+    private int pendingAdapterActions = 0;
+
     private void safeAdapterAction(Runnable action) {
-        if (wkVBinding.recyclerView.isComputingLayout()) {
-            wkVBinding.recyclerView.post(action);
-        } else {
+        if (pendingAdapterActions == 0 && !wkVBinding.recyclerView.isComputingLayout()) {
             action.run();
+            return;
         }
+        postAdapterAction(action, 0);
+    }
+
+    private void postAdapterAction(Runnable action, int retryCount) {
+        if (retryCount >= MAX_SAFE_ADAPTER_RETRY) {
+            if (BuildConfig.DEBUG) Log.w("MsgDebug", "[safeAdapterAction] recyclerView stuck in computing state, drop refresh");
+            return;
+        }
+        pendingAdapterActions++;
+        wkVBinding.recyclerView.post(() -> {
+            pendingAdapterActions--;
+            if (wkVBinding.recyclerView.isComputingLayout()) {
+                postAdapterAction(action, retryCount + 1);
+            } else {
+                action.run();
+            }
+        });
     }
 
     // 显示一条时间消息

--- a/wkuikit/src/main/java/com/chat/uikit/chat/MyItemAnimator.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/MyItemAnimator.java
@@ -51,6 +51,19 @@ public class MyItemAnimator extends SimpleItemAnimator {
     ArrayList<RecyclerView.ViewHolder> mRemoveAnimations = new ArrayList<>();
     ArrayList<RecyclerView.ViewHolder> mChangeAnimations = new ArrayList<>();
 
+    public MyItemAnimator() {
+        // change 动画的实现早已被注释成同步 dispatchStart + dispatchFinish（见 animateChangeImpl），
+        // 但只要 supportsChangeAnimations 还是 true，不带 payload 的 notifyItemChanged 仍会走
+        // "旧 holder + 新 holder" 那条路：旧 view 被塞进 RecyclerView 的 hidden 列表，动画结束时
+        // 由 removeAnimatingView → recycleViewHolderInternal 回收。这条路径要求旧 holder 的
+        // tmpDetached 标记是干净的，一旦某次 layout 抛异常被上层吞掉，标记就永久脏了，回收时抛
+        // "Tmp detached view should be removed from RecyclerView before it can be recycled"。
+        //
+        // 关掉之后 canReuseUpdatedViewHolder 恒为 true —— 更新复用同一个 holder，既不再创建
+        // 多余 holder，也彻底没有 hidden view 需要回收。动画本来就是空实现，观感不变。
+        setSupportsChangeAnimations(false);
+    }
+
     private static class MoveInfo {
         public RecyclerView.ViewHolder holder;
         public int fromX, fromY, toX, toY;

--- a/wkuikit/src/main/java/com/chat/uikit/chat/SafeAdapterActionQueue.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/SafeAdapterActionQueue.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat;
+
+import java.util.ArrayDeque;
+
+/**
+ * 消息列表适配器刷新动作的串行队列。
+ *
+ * <p>RecyclerView 正在 layout / scroll 时调 {@code notifyItem*} 会抛
+ * IllegalStateException，只能延后。延后就必须保证顺序：同一条消息的两次刷新若被颠倒，
+ * 旧状态会覆盖新状态；删除若跑到插入前面，索引就对不上了。
+ *
+ * <p>因此排队规则是「一旦有动作在队列里，后续动作一律入队」，且**队头被 layout 挡住时
+ * 重排的是同一个队头**，绝不让后来的动作先跑（早先的实现是把队头重新 post 到队尾，
+ * 后到的动作因此会插队）。
+ *
+ * <p>若某次 layout 抛异常被上层吞掉，RecyclerView 的内部计数器会永久停在 computing 态，
+ * 这时重试多少次都没用 —— 重试到上限就把整个队列丢掉，宁可少刷几次也不崩。
+ *
+ * <p><b>非线程安全，只能在主线程使用。</b>所有状态（队列、重试计数、标志位）都是裸字段，
+ * 依赖「IM / 网络回调都已 marshal 到主线程，{@link Host#postDrain} 投递的 runnable 也在
+ * 主线程执行」这一前提。
+ */
+final class SafeAdapterActionQueue {
+
+    /** 与 RecyclerView 的耦合点，抽出来是为了能脱离 Android 单测。 */
+    interface Host {
+        /** RecyclerView 是否正在 layout / scroll。 */
+        boolean isBusy();
+
+        /** 把排空动作投递到下一帧（实现为 {@code recyclerView.post}），必须保证 FIFO。 */
+        void postDrain(Runnable drain);
+
+        /** 重试耗尽、丢弃 {@code count} 个动作时回调，用于打日志。 */
+        void onDropped(int count);
+    }
+
+    private final Host host;
+    private final int maxRetry;
+    private final ArrayDeque<Runnable> queue = new ArrayDeque<>();
+
+    private boolean drainScheduled;
+    private boolean draining;
+    private int retryCount;
+
+    SafeAdapterActionQueue(Host host, int maxRetry) {
+        this.host = host;
+        this.maxRetry = maxRetry;
+    }
+
+    /**
+     * 提交一个动作。队列为空且 RecyclerView 空闲时同步执行（与未引入队列前的行为一致），
+     * 否则入队等待排空。
+     */
+    void submit(Runnable action) {
+        if (action == null) return;
+        // draining 期间即使队列瞬时为空也必须入队：此刻是在队头的 run() 里被递归调用，
+        // 直接执行就跑到了同批次后续动作的前面。
+        if (!draining && queue.isEmpty() && !host.isBusy()) {
+            action.run();
+            return;
+        }
+        queue.addLast(action);
+        scheduleDrain();
+    }
+
+    private void scheduleDrain() {
+        if (drainScheduled) return;
+        drainScheduled = true;
+        host.postDrain(this::drain);
+    }
+
+    /** 排空队列。由 {@link Host#postDrain} 投递的 runnable 调用。 */
+    private void drain() {
+        drainScheduled = false;
+        if (queue.isEmpty()) {
+            retryCount = 0;
+            return;
+        }
+        if (host.isBusy()) {
+            if (++retryCount >= maxRetry) {
+                int dropped = queue.size();
+                queue.clear();
+                retryCount = 0;
+                host.onDropped(dropped);
+                return;
+            }
+            scheduleDrain();
+            return;
+        }
+        retryCount = 0;
+        draining = true;
+        try {
+            // 每执行一个动作前重新判一次 busy：动作本身可能触发 layout。
+            while (!queue.isEmpty() && !host.isBusy()) {
+                queue.pollFirst().run();
+            }
+        } finally {
+            draining = false;
+            // 覆盖两种情况：被 busy 中断，以及某个动作抛异常提前退出 —— 剩下的不能烂在队列里。
+            if (!queue.isEmpty()) scheduleDrain();
+        }
+    }
+
+    /** 仅供测试断言用。 */
+    int pendingCount() {
+        return queue.size();
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKIMUtils.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/manager/WKIMUtils.java
@@ -651,7 +651,7 @@ public class WKIMUtils {
                 byte channelType = (byte) jsonObject.optInt("channel_type");
                 if (BuildConfig.DEBUG) android.util.Log.d("RevokeDebug", "[revokeMsg] CMD received: messageId=" + messageId + " channelID=" + channelID + " channelType=" + channelType);
                 // 撤回消息涉及多次 DB 读写操作，放 IO 线程避免和 sync 争抢数据库锁导致 ANR
-                com.chat.base.utils.WKDbScheduler.get().scheduleDirect(() -> {
+                com.chat.base.utils.WKDbScheduler.submit(() -> {
                     WKChannel channel = WKIM.getInstance().getChannelManager().getChannel(channelID, channelType);
                     //是否撤回提醒
                     int revokeRemind = 1;
@@ -702,7 +702,7 @@ public class WKIMUtils {
      */
     private void scheduleRevokeRetry(String messageId, String channelID, byte channelType, int attempt, long delayMs) {
         new Handler(Looper.getMainLooper()).postDelayed(() -> {
-            com.chat.base.utils.WKDbScheduler.get().scheduleDirect(() -> {
+            com.chat.base.utils.WKDbScheduler.submit(() -> {
                 WKMsg local = WKIM.getInstance().getMsgManager().getWithMessageID(messageId);
                 boolean alreadyRevoked = local != null && local.remoteExtra != null && local.remoteExtra.revoke == 1;
                 if (BuildConfig.DEBUG) android.util.Log.d("RevokeDebug",
@@ -735,7 +735,7 @@ public class WKIMUtils {
      */
     public void markMsgRevokedLocallyByClientMsgNO(String clientMsgNo, String revoker) {
         if (android.text.TextUtils.isEmpty(clientMsgNo)) return;
-        com.chat.base.utils.WKDbScheduler.get().scheduleDirect(() -> {
+        com.chat.base.utils.WKDbScheduler.submit(() -> {
             WKMsg wkMsg = WKIM.getInstance().getMsgManager().getWithClientMsgNO(clientMsgNo);
             if (wkMsg == null) {
                 if (BuildConfig.DEBUG) android.util.Log.w("RevokeDebug",

--- a/wkuikit/src/main/java/com/chat/uikit/contacts/ChooseContactsActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/contacts/ChooseContactsActivity.java
@@ -85,7 +85,10 @@ public class ChooseContactsActivity extends WKBaseActivity<ActChooseContactsLayo
     // 不显示的uids
     private String unVisibleUIDs;
     //所有用户
-    private List<FriendUIEntity> allList;
+    // 成员是异步拉的, 数据到达前用户就能在搜索框输入, 所以这里必须始终非 null
+    private List<FriendUIEntity> allList = new ArrayList<>();
+    //数据到达前用户已输入的搜索词
+    private String searchKey = "";
     //默认选中的用户
     private List<WKChannel> defaultSelected;
     private int type;//0：创建群聊1：群聊加人2：选择用户
@@ -396,9 +399,14 @@ public class ChooseContactsActivity extends WKBaseActivity<ActChooseContactsLayo
         SpaceModel.getInstance().getMembers(spaceId, new SpaceModel.IMembersListener() {
             @Override
             public void onResult(List<SpaceEntity.SpaceMember> members) {
+                if (isFinishing() || isDestroyed()) return;
+                if (members == null) {
+                    loadContactsLocal();
+                    return;
+                }
                 List<WKChannel> tempList = new ArrayList<>();
                 for (SpaceEntity.SpaceMember member : members) {
-                    if (member.uid.equals(myUid)) continue;
+                    if (member == null || TextUtils.isEmpty(member.uid) || member.uid.equals(myUid)) continue;
                     WKChannel channel = new WKChannel(member.uid, WKChannelType.PERSONAL);
                     channel.channelName = member.name;
                     channel.robot = member.robot;
@@ -422,6 +430,7 @@ public class ChooseContactsActivity extends WKBaseActivity<ActChooseContactsLayo
 
             @Override
             public void onError(int code, String msg) {
+                if (isFinishing() || isDestroyed()) return;
                 loadContactsLocal();
             }
         });
@@ -433,6 +442,7 @@ public class ChooseContactsActivity extends WKBaseActivity<ActChooseContactsLayo
     }
 
     private void buildAndDisplayList(List<WKChannel> tempList) {
+        if (tempList == null) tempList = new ArrayList<>();
         WKAPPConfig wkappConfig = WKConfig.getInstance().getAppConfig();
         int inviteSystemAccountJoinGroupOn = 0;
         if (wkappConfig != null) {
@@ -493,24 +503,33 @@ public class ChooseContactsActivity extends WKBaseActivity<ActChooseContactsLayo
         allList.addAll(letterList);
         allList.addAll(numList);
         allList.addAll(otherList);
-        contactsAdapter.setList(allList);
+        // 数据到达时用户可能已经在搜索框输入了, 直接 setList 会把输入吞掉
+        if (TextUtils.isEmpty(searchKey)) {
+            contactsAdapter.setList(allList);
+        } else {
+            searchUser(searchKey);
+        }
         hideTitleRightView();
     }
 
     private void searchUser(String content) {
-        if (TextUtils.isEmpty(content)) {
+        searchKey = content == null ? "" : content;
+        if (TextUtils.isEmpty(searchKey)) {
             contactsAdapter.setList(allList);
             return;
         }
+        String key = searchKey.toLowerCase(Locale.getDefault());
         List<FriendUIEntity> tempList = new ArrayList<>();
         for (int i = 0, size = allList.size(); i < size; i++) {
-            if ((!TextUtils.isEmpty(allList.get(i).channel.channelName) && allList.get(i).channel.channelName.toLowerCase(Locale.getDefault())
-                    .contains(content.toLowerCase(Locale.getDefault())))
-                    || (!TextUtils.isEmpty(allList.get(i).channel.channelRemark) && allList.get(i).channel.channelRemark.toLowerCase(Locale.getDefault())
-                    .contains(content.toLowerCase(Locale.getDefault())))
-                    || content.contains(allList.get(i).pying.toLowerCase(
-                    Locale.getDefault()))) {
-                tempList.add(allList.get(i));
+            FriendUIEntity entity = allList.get(i);
+            if (entity == null || entity.channel == null) continue;
+            if ((!TextUtils.isEmpty(entity.channel.channelName) && entity.channel.channelName.toLowerCase(Locale.getDefault())
+                    .contains(key))
+                    || (!TextUtils.isEmpty(entity.channel.channelRemark) && entity.channel.channelRemark.toLowerCase(Locale.getDefault())
+                    .contains(key))
+                    || (!TextUtils.isEmpty(entity.pying) && key.contains(entity.pying.toLowerCase(
+                    Locale.getDefault())))) {
+                tempList.add(entity);
             }
         }
         contactsAdapter.setList(tempList);

--- a/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
+++ b/wkuikit/src/main/java/com/chat/uikit/message/MsgModel.java
@@ -192,7 +192,7 @@ public class MsgModel extends WKBaseModel {
 
     private void scheduleFlameSweep(long delayMs, int epoch) {
         if (!flameLoopRunning.get() || flameEpoch.get() != epoch) return;
-        flameLoopTask = WKDbScheduler.get().scheduleDirect(() -> {
+        flameLoopTask = WKDbScheduler.submit(() -> {
             if (!flameLoopRunning.get() || flameEpoch.get() != epoch) return;
             // sweepFlameMsg 会查库 / 写库，抛出时若不接住，递归排程不会发生而 flameLoopRunning
             // 仍是 true —— startCheckFlameMsgTimer 的 CAS 从此永久短路，清理进程内静默停摆。
@@ -233,7 +233,7 @@ public class MsgModel extends WKBaseModel {
     public void deleteFlameMsg() {
         if (!WKConstants.isLogin()) return;
         // 一次性清理（退出聊天页 / 前后台切换等时机调用），不参与轮询。
-        WKDbScheduler.get().scheduleDirect(this::sweepFlameMsg);
+        WKDbScheduler.submit(this::sweepFlameMsg);
     }
 
     /**
@@ -365,7 +365,7 @@ public class MsgModel extends WKBaseModel {
     public void clearUnread(String channelId, byte channelType, int unreadCount, ICommonListener iCommonListener) {
         final int count = Math.max(unreadCount, 0);
         // updateRedDot 内部有 DB 操作，放 IO 线程避免和 sync 争抢数据库锁导致 ANR
-        WKDbScheduler.get().scheduleDirect(() ->
+        WKDbScheduler.submit(() ->
             WKIM.getInstance().getConversationManager().updateRedDot(channelId, channelType, count)
         );
         com.alibaba.fastjson.JSONObject jsonObject = new com.alibaba.fastjson.JSONObject();
@@ -1002,7 +1002,7 @@ public class MsgModel extends WKBaseModel {
                 m.put(messageSeq, 0);   // 有进展→重置无进展计数
                 if (outcome.appliedTerminal) cardTerminalApplied.add(tk);   // 锁存终态帧,拦后续陈 transient(P1-2)
                 if (BuildConfig.DEBUG) Log.d("CardFrameDebug", "[pending] 有进展→落 extra 刷新 seq=" + messageSeq + " terminal=" + outcome.appliedTerminal);
-                WKDbScheduler.get().scheduleDirect(() ->
+                WKDbScheduler.submit(() ->
                         WKIM.getInstance().getMsgManager().saveCardMsgExtra(result.messages));
                 break;
             case MIDSTREAM_RESET:
@@ -1074,7 +1074,7 @@ public class MsgModel extends WKBaseModel {
                         }
                     }
                     // addCmd 内部有 DB 事务操作，放 IO 线程避免 ANR
-                    WKDbScheduler.get().scheduleDirect(() -> {
+                    WKDbScheduler.submit(() -> {
                         WKBaseCMDManager.getInstance().addCmd(cmdList);
                         if (last_message_seq != 0) {
                             ackMsg();
@@ -1087,7 +1087,7 @@ public class MsgModel extends WKBaseModel {
                         ackMsg();
                     }
                     // handleCmd 内部有大量 DB 读写操作，放 IO 线程避免 ANR
-                    WKDbScheduler.get().scheduleDirect(() -> WKBaseCMDManager.getInstance().handleCmd());
+                    WKDbScheduler.submit(() -> WKBaseCMDManager.getInstance().handleCmd());
                 }
             }
 
@@ -1109,7 +1109,7 @@ public class MsgModel extends WKBaseModel {
      */
     public void syncExtraMsg(String channelID, byte channelType) {
         // getMsgExtraMaxVersionWithChannel 有 DB 查询，整体放 IO 线程避免 ANR
-        WKDbScheduler.get().scheduleDirect(() -> {
+        WKDbScheduler.submit(() -> {
             JSONObject jsonObject = new JSONObject();
             jsonObject.put("channel_id", channelID);
             jsonObject.put("channel_type", channelType);
@@ -1143,7 +1143,7 @@ public class MsgModel extends WKBaseModel {
                     }
                     // saveRemoteExtraMsg 内部有 DB 操作，必须在 IO 线程执行，
                     // 放主线程会和 sync 写入争抢数据库锁导致 ANR
-                    WKDbScheduler.get().scheduleDirect(() -> {
+                    WKDbScheduler.submit(() -> {
                         WKIM.getInstance().getMsgManager().saveRemoteExtraMsg(new WKChannel(channelID, channelType), result);
                         new Handler(Looper.getMainLooper()).postDelayed(() -> syncExtraMsg(channelID, channelType), 500);
                     });
@@ -1207,7 +1207,7 @@ public class MsgModel extends WKBaseModel {
 
     public void syncReminder() {
         // getMaxVersion / getWithChannelType 有 DB 查询，整体放 IO 线程避免 ANR
-        WKDbScheduler.get().scheduleDirect(() -> {
+        WKDbScheduler.submit(() -> {
             long version = WKIM.getInstance().getReminderManager().getMaxVersion();
             List<String> channelIDs = new ArrayList<>();
             List<WKConversationMsg> list = WKIM.getInstance().getConversationManager().getWithChannelType(WKChannelType.GROUP);
@@ -1237,7 +1237,7 @@ public class MsgModel extends WKBaseModel {
                     }
                     // saveOrUpdateReminders 内部有 DB 操作，必须在 IO 线程执行，
                     // 放主线程会和 sync 写入争抢数据库锁导致 ANR
-                    WKDbScheduler.get().scheduleDirect(() ->
+                    WKDbScheduler.submit(() ->
                         WKIM.getInstance().getReminderManager().saveOrUpdateReminders(list)
                     );
                 }
@@ -1257,7 +1257,7 @@ public class MsgModel extends WKBaseModel {
 
         // DB 操作放 IO 线程，避免 onPause 主线程阻塞
         List<Long> idsCopy = new ArrayList<>(list);
-        WKDbScheduler.get().scheduleDirect(() -> {
+        WKDbScheduler.submit(() -> {
             // Step 1: 查出受影响的 channelID
             List<WKReminder> affected = ReminderDBManager.getInstance().queryWithIds(idsCopy);
             List<String> channelIds = new ArrayList<>();
@@ -1317,7 +1317,7 @@ public class MsgModel extends WKBaseModel {
             extra.draftUpdatedAt = WKTimeUtils.getInstance().getCurrentSeconds();
         }
         // updateMsgExtra 内部有 DB 操作，放 IO 线程避免 onPause 时和 sync 争抢数据库锁导致 ANR
-        WKDbScheduler.get().scheduleDirect(() ->
+        WKDbScheduler.submit(() ->
             WKIM.getInstance().getConversationManager().updateMsgExtra(extra)
         );
 
@@ -1341,7 +1341,7 @@ public class MsgModel extends WKBaseModel {
 
     public void syncCoverExtra() {
         // getMsgExtraMaxVersion 有 DB 查询，整体放 IO 线程避免 ANR
-        WKDbScheduler.get().scheduleDirect(() -> {
+        WKDbScheduler.submit(() -> {
             long version = WKIM.getInstance().getConversationManager().getMsgExtraMaxVersion();
             JSONObject jsonObject = new JSONObject();
             jsonObject.put("version", version);
@@ -1350,7 +1350,7 @@ public class MsgModel extends WKBaseModel {
             public void onSuccess(List<WKSyncConvMsgExtra> result) {
                 // saveSyncMsgExtras 内部有 DB 操作，必须在 IO 线程执行，
                 // 放主线程会和 sync 写入争抢数据库锁导致 ANR
-                WKDbScheduler.get().scheduleDirect(() -> {
+                WKDbScheduler.submit(() -> {
                     WKIM.getInstance().getConversationManager().saveSyncMsgExtras(result);
                     if (WKReader.isNotEmpty(result)) {
                         new Handler(Looper.getMainLooper()).post(() ->

--- a/wkuikit/src/test/java/com/chat/uikit/chat/SafeAdapterActionQueueTest.java
+++ b/wkuikit/src/test/java/com/chat/uikit/chat/SafeAdapterActionQueueTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.chat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link SafeAdapterActionQueue} 的顺序 / 重试语义测试。
+ *
+ * <p>FakeHost 用一个 FIFO 队列模拟 {@code recyclerView.post} 的投递顺序，测试自己控制
+ * busy 状态与「跑下一帧」的时机，从而能确定性地复现真机上极难命中的时序。
+ */
+public class SafeAdapterActionQueueTest {
+
+    private static final int MAX_RETRY = 3;
+
+    private FakeHost host;
+    private SafeAdapterActionQueue queue;
+    private List<String> executed;
+
+    private static final class FakeHost implements SafeAdapterActionQueue.Host {
+        boolean busy;
+        int droppedTotal;
+        int dropCallCount;
+        final ArrayDeque<Runnable> posted = new ArrayDeque<>();
+
+        @Override
+        public boolean isBusy() {
+            return busy;
+        }
+
+        @Override
+        public void postDrain(Runnable drain) {
+            posted.addLast(drain);
+        }
+
+        @Override
+        public void onDropped(int count) {
+            droppedTotal += count;
+            dropCallCount++;
+        }
+
+        /** 跑完当前已投递的一轮，模拟一帧过去。 */
+        boolean runOneFrame() {
+            if (posted.isEmpty()) return false;
+            posted.pollFirst().run();
+            return true;
+        }
+
+        void runUntilIdle() {
+            int guard = 0;
+            while (runOneFrame()) {
+                if (++guard > 100) throw new IllegalStateException("drain 没有收敛，疑似死循环");
+            }
+        }
+    }
+
+    @Before
+    public void setUp() {
+        host = new FakeHost();
+        executed = new ArrayList<>();
+        queue = new SafeAdapterActionQueue(host, MAX_RETRY);
+    }
+
+    private Runnable action(String name) {
+        return () -> executed.add(name);
+    }
+
+    @Test
+    public void 空闲且无排队时同步执行() {
+        queue.submit(action("A"));
+
+        assertEquals(List.of("A"), executed);
+        assertTrue("不该投递 drain", host.posted.isEmpty());
+    }
+
+    @Test
+    public void 忙时入队_排空后按提交顺序执行() {
+        host.busy = true;
+        queue.submit(action("A"));
+        queue.submit(action("B"));
+        queue.submit(action("C"));
+
+        assertEquals("忙时不该执行任何动作", List.of(), executed);
+        assertEquals(3, queue.pendingCount());
+
+        host.busy = false;
+        host.runUntilIdle();
+
+        assertEquals(List.of("A", "B", "C"), executed);
+        assertEquals(0, queue.pendingCount());
+    }
+
+    /**
+     * 回归测试：PR #129 review 指出的缺陷。
+     *
+     * <p>旧实现在队头被 layout 挡住时把队头重新 post 到**队尾**，导致后入队的 B 抢在 A 前面
+     * 执行。这里断言队头始终是队头。
+     */
+    @Test
+    public void 队头被挡住时重排的是同一个队头_后到的动作不会插队() {
+        host.busy = true;
+        queue.submit(action("A"));   // 先入队
+        queue.submit(action("B"));   // 后入队
+
+        // 第一帧：仍然 busy，队头 A 排不出去 → 重排，B 不能因此抢先
+        host.runOneFrame();
+        assertEquals("仍在 busy，不该执行任何动作", List.of(), executed);
+        assertEquals(2, queue.pendingCount());
+
+        // 第二帧：layout 结束
+        host.busy = false;
+        host.runUntilIdle();
+
+        assertEquals("A 必须先于 B", List.of("A", "B"), executed);
+    }
+
+    @Test
+    public void 重试期间新提交的动作排在原有动作之后() {
+        host.busy = true;
+        queue.submit(action("A"));
+
+        host.runOneFrame();          // 一次失败的重试
+        queue.submit(action("B"));   // 重试窗口内到达
+
+        host.busy = false;
+        host.runUntilIdle();
+
+        assertEquals(List.of("A", "B"), executed);
+    }
+
+    @Test
+    public void 重试耗尽_丢弃整个队列且不抛异常() {
+        host.busy = true;
+        queue.submit(action("A"));
+        queue.submit(action("B"));
+
+        for (int i = 0; i < MAX_RETRY; i++) {
+            host.runOneFrame();
+        }
+
+        assertEquals("重试耗尽后应丢弃而不是执行", List.of(), executed);
+        assertEquals(0, queue.pendingCount());
+        assertEquals(2, host.droppedTotal);
+        assertEquals(1, host.dropCallCount);
+        assertTrue("丢弃后不该再排下一轮", host.posted.isEmpty());
+    }
+
+    @Test
+    public void 丢弃之后队列仍然可用() {
+        host.busy = true;
+        queue.submit(action("A"));
+        for (int i = 0; i < MAX_RETRY; i++) {
+            host.runOneFrame();
+        }
+        assertEquals(0, queue.pendingCount());
+
+        host.busy = false;
+        queue.submit(action("B"));
+
+        assertEquals("重试计数应已复位，新动作照常同步执行", List.of("B"), executed);
+    }
+
+    @Test
+    public void 排空过程中动作内部再提交_追加到队尾而不是立刻执行() {
+        host.busy = true;
+        queue.submit(() -> {
+            executed.add("A");
+            queue.submit(action("A-nested"));   // 在 A 的 run() 里递归提交
+        });
+        queue.submit(action("B"));
+
+        host.busy = false;
+        host.runUntilIdle();
+
+        assertEquals(List.of("A", "B", "A-nested"), executed);
+    }
+
+    @Test
+    public void 排空途中重新变忙_剩余动作保持顺序留到下一帧() {
+        host.busy = true;
+        queue.submit(() -> {
+            executed.add("A");
+            host.busy = true;          // A 执行时又触发了一次 layout
+        });
+        queue.submit(action("B"));
+        queue.submit(action("C"));
+
+        host.busy = false;
+        host.runOneFrame();
+        assertEquals("A 之后应停下", List.of("A"), executed);
+        assertEquals(2, queue.pendingCount());
+
+        host.busy = false;
+        host.runUntilIdle();
+        assertEquals(List.of("A", "B", "C"), executed);
+    }
+
+    @Test
+    public void 动作抛异常_剩余队列不会烂在里面() {
+        host.busy = true;
+        queue.submit(() -> {
+            executed.add("A");
+            throw new RuntimeException("boom");
+        });
+        queue.submit(action("B"));
+
+        host.busy = false;
+        try {
+            host.runOneFrame();
+        } catch (RuntimeException expected) {
+            // 刻意不吞：异常照常穿出去，但队列必须已经安排好后续排空
+        }
+
+        assertEquals(List.of("A"), executed);
+        assertEquals(1, queue.pendingCount());
+
+        host.runUntilIdle();
+        assertEquals(List.of("A", "B"), executed);
+    }
+}


### PR DESCRIPTION
Closes #128

三类线上崩溃，3 笔提交一一对应。实机验证通过，`assembleDebug` 全量通过。

## 1. `fix(contacts)` 联系人选择页搜索 NPE

`allList` 只在异步回调里赋值，页面自动弹键盘 → 用户在成员请求返回前打字就崩。改为声明处初始化空列表，永不为 null，顺带消掉 `rightButtonClick()` 里同样的隐患。

另修一个被崩溃掩盖的 UX 问题：数据到达时无条件 `setList(allList)` 会吞掉用户加载期间已输入的搜索词，现在记 `searchKey` 数据到齐后重新过滤。

## 2. `fix(chat)` RecyclerView 两类崩溃（同源）

两次上报日志是同一个三段式：`去连接` → `already has a parent`（`SwipeBackLayout.onLayout` 吞掉）→ 18ms/151ms 后崩。异常从 RecyclerView 的 layout 里逃逸 → `onExitLayoutOrScroll()` 不执行、holder 停在 `tmpDetached`，此后任何 notify / 回收都崩。

- `safeAdapterAction` 加 FIFO 排队 + 3 次有界重试。原实现 post 一次后仍无条件 `run()`，卡死时照样崩；且新回调可能插到旧回调前面导致同一条消息的刷新乱序。RecyclerView 空闲且无排队时仍是同步 `run()`，与改动前一致。
- 补齐 8 处漏网的 IM/网络回调侧适配器操作（`sendMsgInserted` / `typing` / `receivedMessages` 早已在用这个模式）。
- `MyItemAnimator` 补 `setSupportsChangeAnimations(false)`。change 动画当初是靠**注释掉动画代码**「关」的，flag 一直是 true，不带 payload 的 `notifyItemChanged(i)` 仍走旧/新 holder 双份路径 —— 正是撞上脏 `tmpDetached` 的那条路。关掉后该路径整个消失。
- `SwipeBackLayout` 的 catch 保留，但换成 debug 门控日志 + `CrashReport.postCatchedException`。吞掉换来的存活时间只有 18/151ms，等于零，却把现场埋了。

> ⚠️ 根因那个重复 `addView` 尚未定位（已排除 provider view 缓存、`RecyclerAnimationScrollHelper` 死代码、msgeffect overlay、长按菜单、panel tab 切换、pinned 视图）。本 PR 先堵死两条下游路径 + 加非致命上报捞堆栈，拿到后另开 PR 一击修掉。

## 3. `fix(db)` 关库后残留 DB 任务

撤回兜底重试延迟 500/1500ms 查库，中间用户登出/401 关库 → 拿已关闭的连接池。

必崩原因：RxJava 3.1.11 `ScheduledDirectTask.call()` 是 `catch { RxJavaPlugins.onError(ex); throw ex; }`，本仓库没设 errorHandler，`IllegalStateException` 被判定为 bug 类 → 直送 UncaughtExceptionHandler。**任何**在 `WKDbScheduler` 上抛出的异常都必崩。

`WKDbScheduler` 补 `submit()` 把守卫收进调度器内部，只丢弃 `connection pool has been closed` 这一种，其余原样抛出。守卫必须包在交给 RxJava **之前**的 Runnable 上，包在外层 Executor 上来不及。18 处调用点机械替换，`get()` 标 `@Deprecated`。

## Review 提示

`ChatActivity` 的 diff 显示 +183 行，但**忽略空白后只有 +51**（`?w=1` 看），差额全是代码块包进 lambda 后的整体缩进。

## 测试计划

- [x] 弱网/飞行模式进「选择联系人」，键盘弹出立刻打字
- [x] 群里改成员备注、撤回消息、快速滑动时收消息、后台切回重连
- [x] 撤回消息后 2 秒内退出登录
- [x] 消息列表刷新频繁场景，确认关掉 change 流程后无视觉回归
- [x] `./gradlew assembleDebug`

## 不在本 PR

会话同步 OOM（`insertOrReplaceExtra → queryWithMsgIds`）已由 #122 / `df2b938` 修复，相关上报为存量老版本 —— 崩溃栈里是**单参数**重载，正是那次 diff 删掉的行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)