### PR TITLE
fix(docs): hand off viewer space on mobile open

### DIFF
--- a/wkbase/src/main/java/com/chat/base/act/DocsViewerUrlPolicy.java
+++ b/wkbase/src/main/java/com/chat/base/act/DocsViewerUrlPolicy.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.chat.base.act;
+
+import org.json.JSONObject;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Pattern;
+
+/** Plain-JVM URL policy for native-to-Web Docs viewer context handoff. */
+final class DocsViewerUrlPolicy {
+    private static final String DOCUMENT_ID = "[A-Za-z0-9_-]{1,128}";
+    private static final Pattern VIEWER_PATH = Pattern.compile(
+            "^/(?:d/" + DOCUMENT_ID + "|ppt/d/" + DOCUMENT_ID
+                    + "|docs/" + DOCUMENT_ID + "/present)/?$");
+
+    private DocsViewerUrlPolicy() {
+    }
+
+    /**
+     * Selects the configured Web base explicitly. The API base is accepted only to keep the
+     * independently configured inputs visible and testable at the Activity wiring boundary.
+     */
+    static String originOfConfiguredBases(String apiBaseUrl, String webBaseUrl) {
+        return originOf(webBaseUrl);
+    }
+
+    /** Returns a canonical scheme/host/port origin, or null for an invalid web base URL. */
+    static String originOf(String webBaseUrl) {
+        URI uri = parseAbsoluteHttpUri(webBaseUrl);
+        if (uri == null) return null;
+        try {
+            return new URI(
+                    uri.getScheme().toLowerCase(java.util.Locale.ROOT),
+                    null,
+                    uri.getHost().toLowerCase(java.util.Locale.ROOT),
+                    uri.getPort(),
+                    null,
+                    null,
+                    null).toString();
+        } catch (URISyntaxException ignored) {
+            return null;
+        }
+    }
+
+    static boolean isTrustedOriginUrl(String url, String origin) {
+        URI candidate = parseAbsoluteHttpUri(url);
+        URI trustedOrigin = parseAbsoluteHttpUri(origin);
+        return candidate != null && trustedOrigin != null && isSameOrigin(candidate, trustedOrigin);
+    }
+
+    static boolean isTrustedViewerUrl(String url, String origin) {
+        URI candidate = parseAbsoluteHttpUri(url);
+        URI trustedOrigin = parseAbsoluteHttpUri(origin);
+        if (candidate == null || trustedOrigin == null || !isSameOrigin(candidate, trustedOrigin)) {
+            return false;
+        }
+        String rawPath = candidate.getRawPath();
+        return rawPath != null && VIEWER_PATH.matcher(rawPath).matches();
+    }
+
+    static boolean isViewerPath(String path) {
+        return path != null && VIEWER_PATH.matcher(path).matches();
+    }
+
+    static String buildIdentityBootstrapHtml(String realUrl, String sid, String token, String uid,
+                                             String name, String currentSpaceId) {
+        String identity = "try{" +
+                "var s=" + quoteForInlineScript(sid) + ";" +
+                "localStorage.setItem('token'+s, " + quoteForInlineScript(token) + ");" +
+                "localStorage.setItem('uid'+s, " + quoteForInlineScript(uid) + ");" +
+                "localStorage.setItem('name'+s, " + quoteForInlineScript(name) + ");" +
+                "}catch(e){}";
+        return buildBootstrapHtml(realUrl, currentSpaceId, identity);
+    }
+
+    static String buildSpaceBootstrapHtml(String realUrl, String currentSpaceId) {
+        return buildBootstrapHtml(realUrl, currentSpaceId, "");
+    }
+
+    private static String buildBootstrapHtml(String realUrl, String currentSpaceId, String identity) {
+        String space = buildSpaceStorageScript(currentSpaceId);
+        return "<!DOCTYPE html><html><head><meta charset=\"UTF-8\"><title></title></head><body>" +
+                "<script>(function(){" + space + identity +
+                "window.location.replace(" + quoteForInlineScript(realUrl) + ");" +
+                "})();</script></body></html>";
+    }
+
+    /** null leaves pooled storage untouched; empty clears it; non-empty replaces it. */
+    private static String buildSpaceStorageScript(String currentSpaceId) {
+        if (currentSpaceId == null) return "";
+        return "try{" +
+                "var spaceId=" + quoteForInlineScript(currentSpaceId) + ";" +
+                "if(spaceId){localStorage.setItem('currentSpaceId', spaceId);}" +
+                "else{localStorage.removeItem('currentSpaceId');}" +
+                "}catch(e){}";
+    }
+
+    /** Quotes a value without allowing it to terminate the inline script element. */
+    private static String quoteForInlineScript(String value) {
+        return JSONObject.quote(value)
+                .replace("<", "\\u003c")
+                .replace(">", "\\u003e")
+                .replace("&", "\\u0026")
+                .replace("\u2028", "\\u2028")
+                .replace("\u2029", "\\u2029");
+    }
+
+    private static boolean isSameOrigin(URI candidate, URI origin) {
+        return candidate.getScheme().equalsIgnoreCase(origin.getScheme())
+                && candidate.getHost().equalsIgnoreCase(origin.getHost())
+                && effectivePort(candidate) == effectivePort(origin);
+    }
+
+    private static URI parseAbsoluteHttpUri(String value) {
+        if (value == null || value.length() == 0) return null;
+        try {
+            URI uri = new URI(value);
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+            if (scheme == null || host == null || host.length() == 0) return null;
+            if (uri.getRawUserInfo() != null) return null;
+            if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) return null;
+            return uri;
+        } catch (URISyntaxException ignored) {
+            return null;
+        }
+    }
+
+    private static int effectivePort(URI uri) {
+        if (uri.getPort() >= 0) return uri.getPort();
+        return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/act/WKWebViewActivity.java
+++ b/wkbase/src/main/java/com/chat/base/act/WKWebViewActivity.java
@@ -58,6 +58,7 @@ import com.chat.base.entity.PopupMenuItem;
 import com.chat.base.glide.GlideUtils;
 import com.chat.base.jsbrigde.CallBackFunction;
 import com.chat.base.net.HttpResponseCode;
+import com.chat.base.space.SpaceFilter;
 import com.chat.base.ui.Theme;
 import com.chat.base.ui.components.AvatarView;
 import com.chat.base.ui.components.BottomSheet;
@@ -213,14 +214,21 @@ public class WKWebViewActivity extends WKBaseActivity<ActWebvieiwLayoutBinding> 
      * 外链（非自家域名）不动，保持原 loadUrl。
      */
     private void loadUrlWithHandoff(String url) {
-        Uri webOrigin = getOctoWebOrigin();
-        if (webOrigin == null || !isSameOrigin(url, webOrigin)) {
+        String webOrigin = DocsViewerUrlPolicy.originOfConfiguredBases(
+                WKApiConfig.baseUrl, WKApiConfig.baseWebUrl);
+        if (webOrigin == null || !DocsViewerUrlPolicy.isTrustedOriginUrl(url, webOrigin)) {
             // 外链 / origin 解析失败：走原有 loadUrl，不注入任何 App 状态（防 token 泄露给第三方）。
             wkVBinding.webView.loadUrl(url);
             return;
         }
-        // report.html 已经走 ?uid=&token= URL 参数握手（见上面 line 174-176），不需要再走 localStorage 注入。
-        if (url.contains("report.html")) {
+        boolean docsViewer = DocsViewerUrlPolicy.isTrustedViewerUrl(url, webOrigin);
+        // Capture once for this launch, before any credential-dependent branch. Even an anonymous
+        // Docs launch must clear stale pooled storage when the native selection is empty.
+        String currentSpaceId = docsViewer ? SpaceFilter.getCurrentSpaceId() : null;
+
+        // report.html already uses its URL-parameter handshake. A query value containing that text
+        // must not bypass an otherwise valid Docs viewer handoff.
+        if (!docsViewer && url.contains("report.html")) {
             wkVBinding.webView.loadUrl(url);
             return;
         }
@@ -228,8 +236,14 @@ public class WKWebViewActivity extends WKBaseActivity<ActWebvieiwLayoutBinding> 
         String uid = WKConfig.getInstance().getUid();
         String name = WKConfig.getInstance().getUserInfo() != null ? WKConfig.getInstance().getUserInfo().name : "";
         if (TextUtils.isEmpty(token) || TextUtils.isEmpty(uid)) {
-            // 未登录或缺关键身份：不做注入，走原路径（web 端会自己跳登录）。
-            wkVBinding.webView.loadUrl(url);
+            if (docsViewer) {
+                String bootstrap = buildDocsViewerSpaceBootstrapHtml(url, currentSpaceId);
+                wkVBinding.webView.loadDataWithBaseURL(
+                        webOrigin + "/", bootstrap, "text/html", "UTF-8", null);
+            } else {
+                // 未登录或缺关键身份：不做身份注入，走原路径（web 端会自己跳登录）。
+                wkVBinding.webView.loadUrl(url);
+            }
             return;
         }
         String urlWithSid = appendSidParam(url, "android");
@@ -238,66 +252,12 @@ public class WKWebViewActivity extends WKBaseActivity<ActWebvieiwLayoutBinding> 
         // URL 带 ?sid=web 时 web 端会读 tokenweb / uidweb / nameweb（都不存在），
         // 但我们只写了 tokenandroid → 免登失效。
         String effectiveSid = extractSid(urlWithSid, "android");
-        String bootstrap = buildHandoffBootstrapHtml(urlWithSid, effectiveSid, token, uid, name);
+        // Other first-party pages keep the existing identity handoff without gaining or clearing
+        // Docs authorization context.
+        String bootstrap = buildHandoffBootstrapHtml(
+                urlWithSid, effectiveSid, token, uid, name, currentSpaceId);
         // baseURL 用自家 origin：localStorage 写入的是这个 origin 的存储，跳转到 origin 内任意页面都能读到。
-        wkVBinding.webView.loadDataWithBaseURL(webOrigin.toString() + "/", bootstrap, "text/html", "UTF-8", null);
-    }
-
-    /**
-     * 从 {@link WKApiConfig#baseUrl}（e.g. https://im-test.deepminer.com.cn/api/v1/）
-     * 抽出 web origin，作为 scheme+host+port 三元组返回（e.g. https://im-test.deepminer.com.cn，
-     * 或含端口 https://im-test.deepminer.com.cn:8443）。仅保留 origin 部分，去掉 path / query / fragment。
-     */
-    @Nullable
-    private static Uri getOctoWebOrigin() {
-        String base = WKApiConfig.baseUrl;
-        if (TextUtils.isEmpty(base)) return null;
-        try {
-            Uri u = Uri.parse(base);
-            String scheme = u.getScheme();
-            String host = u.getHost();
-            if (TextUtils.isEmpty(scheme) || TextUtils.isEmpty(host)) return null;
-            Uri.Builder b = new Uri.Builder().scheme(scheme).encodedAuthority(
-                    u.getPort() >= 0 ? host + ":" + u.getPort() : host);
-            return b.build();
-        } catch (Exception ignored) {
-            return null;
-        }
-    }
-
-    /**
-     * 判定 {@code url} 与 {@code origin} 是否属于同一 origin —— 严格按 scheme+host+port 三元组比对，
-     * 不用 {@code String.startsWith}。后者会被 {@code https://im-test.deepminer.com.cn.evil.com}
-     * 这类攻击者构造的域名绕过（前缀恰好匹配但 host 完全是另一个域），从而在 App 内 WebView
-     * 里加载攻击者页面并共享 cookies / JS bridge。
-     */
-    @VisibleForTesting
-    static boolean isSameOrigin(@Nullable String url, @Nullable Uri origin) {
-        if (TextUtils.isEmpty(url) || origin == null) return false;
-        try {
-            Uri u = Uri.parse(url);
-            String scheme = u.getScheme();
-            String host = u.getHost();
-            if (TextUtils.isEmpty(scheme) || TextUtils.isEmpty(host)) return false;
-            if (!scheme.equalsIgnoreCase(origin.getScheme())) return false;
-            if (!host.equalsIgnoreCase(origin.getHost())) return false;
-            // 端口对齐：URL 未显式给端口时视为该 scheme 的默认端口（http=80 / https=443）。
-            // Uri.getPort() 未显式给端口返回 -1。
-            int urlPort = effectivePort(u);
-            int originPort = effectivePort(origin);
-            return urlPort == originPort;
-        } catch (Exception ignored) {
-            return false;
-        }
-    }
-
-    private static int effectivePort(Uri u) {
-        int p = u.getPort();
-        if (p >= 0) return p;
-        String s = u.getScheme();
-        if ("https".equalsIgnoreCase(s)) return 443;
-        if ("http".equalsIgnoreCase(s)) return 80;
-        return -1;
+        wkVBinding.webView.loadDataWithBaseURL(webOrigin + "/", bootstrap, "text/html", "UTF-8", null);
     }
 
     /**
@@ -345,23 +305,16 @@ public class WKWebViewActivity extends WKBaseActivity<ActWebvieiwLayoutBinding> 
      * （release 里 remote debugging 通常关但仍是不良实践）。boot 失败时依赖 web 自身
      * 的登录跳转来暴露问题，不靠自打日志。
      */
-    private static String buildHandoffBootstrapHtml(String realUrl, String sid, String token, String uid, String name) {
-        // JSONObject.quote 会返回带引号的 JSON 字符串字面量（e.g. "abc\"def" → "\"abc\\\"def\""），
-        // 直接嵌 <script> 里安全。
-        String jToken = org.json.JSONObject.quote(token);
-        String jUid = org.json.JSONObject.quote(uid);
-        String jName = org.json.JSONObject.quote(name);
-        String jUrl = org.json.JSONObject.quote(realUrl);
-        String jSid = org.json.JSONObject.quote(sid);
-        return "<!DOCTYPE html><html><head><meta charset=\"UTF-8\"><title></title></head><body>" +
-                "<script>(function(){try{" +
-                "var s=" + jSid + ";" +
-                "localStorage.setItem('token'+s, " + jToken + ");" +
-                "localStorage.setItem('uid'+s, " + jUid + ");" +
-                "localStorage.setItem('name'+s, " + jName + ");" +
-                "}catch(e){}" +
-                "window.location.replace(" + jUrl + ");" +
-                "})();</script></body></html>";
+    @VisibleForTesting
+    static String buildHandoffBootstrapHtml(String realUrl, String sid, String token, String uid,
+                                            String name, @Nullable String currentSpaceId) {
+        return DocsViewerUrlPolicy.buildIdentityBootstrapHtml(
+                realUrl, sid, token, uid, name, currentSpaceId);
+    }
+
+    @VisibleForTesting
+    static String buildDocsViewerSpaceBootstrapHtml(String realUrl, @Nullable String currentSpaceId) {
+        return DocsViewerUrlPolicy.buildSpaceBootstrapHtml(realUrl, currentSpaceId);
     }
 
     @SuppressLint("SetJavaScriptEnabled")

--- a/wkbase/src/test/java/com/chat/base/act/WKWebViewActivityHandoffTest.java
+++ b/wkbase/src/test/java/com/chat/base/act/WKWebViewActivityHandoffTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.chat.base.act;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class WKWebViewActivityHandoffTest {
+    private static final String REAL_URL = "https://web.octo.test/d/42?sid=android#section";
+    private static final String TRUSTED_ORIGIN = "https://web.octo.test";
+
+    @Test public void bootstrapSetsCurrentSpaceBeforeNavigation() {
+        String html = bootstrap("space-42");
+        String write = "localStorage.setItem('currentSpaceId', spaceId);";
+        String navigate = "window.location.replace(\"" + REAL_URL + "\");";
+        assertTrue(html.contains("var spaceId=\"space-42\";"));
+        assertOrdered(html, write, navigate);
+    }
+
+    @Test public void bootstrapRemovesStaleCurrentSpaceWhenSelectionIsEmpty() {
+        String html = bootstrap("");
+        String remove = "localStorage.removeItem('currentSpaceId');";
+        assertTrue(html.contains("var spaceId=\"\";"));
+        assertOrdered(html, remove, "window.location.replace");
+    }
+
+    @Test public void bootstrapEscapesInlineScriptValues() {
+        String lineSeparator = String.valueOf((char) 0x2028);
+        String attack = "x'</script><script>injected()</script>" + lineSeparator + "&";
+        String html = DocsViewerUrlPolicy.buildIdentityBootstrapHtml(
+                REAL_URL, attack, attack, attack, attack, attack);
+        assertFalse(html.contains("</script><script>injected()"));
+        assertFalse(html.contains(lineSeparator));
+        assertTrue(html.contains("\\u003c\\/script\\u003e"));
+        assertTrue(html.contains("\\u2028"));
+        assertTrue(html.contains("\\u0026"));
+    }
+
+    @Test public void bootstrapNavigatesToUnmodifiedRealUrlWithoutSpaceQueryParameters() {
+        String html = bootstrap("space with / and ?");
+        assertTrue(html.contains("localStorage.setItem('token'+s, \"token\");"));
+        assertTrue(html.contains("localStorage.setItem('uid'+s, \"uid\");"));
+        assertTrue(html.contains("localStorage.setItem('name'+s, \"name\");"));
+        assertOrdered(html, "currentSpaceId", "localStorage.setItem('token'+s");
+        assertOrdered(html, "localStorage.setItem('token'+s", "window.location.replace");
+        assertTrue(html.contains("}catch(e){}try{"));
+        assertTrue(html.contains("window.location.replace(\"" + REAL_URL + "\");"));
+        assertFalse(html.contains("?sp="));
+        assertFalse(html.contains("&sp="));
+        assertFalse(html.contains("viewer="));
+    }
+
+    @Test public void onlyStandaloneDocsRoutesReceiveSpaceHandoff() {
+        assertTrue(DocsViewerUrlPolicy.isViewerPath("/d/doc-1"));
+        assertTrue(DocsViewerUrlPolicy.isViewerPath("/ppt/d/deck-1/"));
+        assertTrue(DocsViewerUrlPolicy.isViewerPath("/docs/deck-1/present"));
+        assertFalse(DocsViewerUrlPolicy.isViewerPath(null));
+        assertFalse(DocsViewerUrlPolicy.isViewerPath("/"));
+        assertFalse(DocsViewerUrlPolicy.isViewerPath("/d/"));
+        assertFalse(DocsViewerUrlPolicy.isViewerPath("/d/doc-1/edit"));
+        assertFalse(DocsViewerUrlPolicy.isViewerPath("/docs/deck-1"));
+        assertFalse(DocsViewerUrlPolicy.isViewerPath("/d/.."));
+        assertFalse(DocsViewerUrlPolicy.isViewerPath("/d/id.with.dot"));
+        assertFalse(DocsViewerUrlPolicy.isViewerPath("/d/a:b"));
+        assertFalse(DocsViewerUrlPolicy.isViewerPath("/ppt/d/a:b"));
+        assertFalse(DocsViewerUrlPolicy.isViewerPath("/docs/a:b/present"));
+        assertTrue(DocsViewerUrlPolicy.isViewerPath("/d/Az_09-"));
+    }
+
+    @Test public void trustedViewerGateRequiresExactOriginAndPath() {
+        assertTrue(DocsViewerUrlPolicy.isTrustedViewerUrl(
+                "https://web.octo.test/d/doc-1?next=report.html", TRUSTED_ORIGIN));
+        assertFalse(DocsViewerUrlPolicy.isTrustedViewerUrl(
+                "https://web.octo.test.evil/d/doc-1", TRUSTED_ORIGIN));
+        assertFalse(DocsViewerUrlPolicy.isTrustedViewerUrl(
+                "http://web.octo.test/d/doc-1", TRUSTED_ORIGIN));
+        assertFalse(DocsViewerUrlPolicy.isTrustedViewerUrl(
+                "https://web.octo.test:8443/d/doc-1", TRUSTED_ORIGIN));
+        assertFalse(DocsViewerUrlPolicy.isTrustedViewerUrl(
+                "https://web.octo.test/d/doc%2Fchild", TRUSTED_ORIGIN));
+        assertFalse(DocsViewerUrlPolicy.isTrustedViewerUrl(
+                "https://web.octo.test/d/%2e%2e", TRUSTED_ORIGIN));
+        assertFalse(DocsViewerUrlPolicy.isTrustedViewerUrl(
+                "https://user@web.octo.test/d/doc-1", TRUSTED_ORIGIN));
+        assertTrue(DocsViewerUrlPolicy.isTrustedViewerUrl(
+                "https://web.octo.test:443/d/doc-1#section", TRUSTED_ORIGIN));
+        assertFalse(DocsViewerUrlPolicy.isTrustedViewerUrl(
+                "https://web.octo.test/d/%64oc-1", TRUSTED_ORIGIN));
+        assertFalse(DocsViewerUrlPolicy.isTrustedViewerUrl(
+                "https://web.octo.test/d/../doc-1", TRUSTED_ORIGIN));
+    }
+
+    @Test public void webOriginComesFromAndNormalizesConfiguredWebBase() {
+        assertEquals("https://web.octo.test",
+                DocsViewerUrlPolicy.originOf("https://WEB.octo.test/docs/"));
+        assertEquals("https://web.octo.test:8443",
+                DocsViewerUrlPolicy.originOf("https://web.octo.test:8443/docs/"));
+        assertNull(DocsViewerUrlPolicy.originOf("not a URL"));
+    }
+
+    @Test public void configuredTrustUsesWebBaseInsteadOfApiBase() {
+        assertEquals("https://web.octo.test", DocsViewerUrlPolicy.originOfConfiguredBases(
+                "https://api.octo.test/v1/", "https://web.octo.test/app/"));
+    }
+
+    @Test public void anonymousDocsBootstrapClearsStaleSpaceBeforeUnmodifiedNavigation() {
+        String html = DocsViewerUrlPolicy.buildSpaceBootstrapHtml(REAL_URL, "");
+        assertOrdered(html, "localStorage.removeItem('currentSpaceId')",
+                "window.location.replace");
+        assertTrue(html.contains("window.location.replace(\"" + REAL_URL + "\");"));
+        assertFalse(html.contains("tokenandroid"));
+        assertFalse(html.contains("?sp="));
+    }
+
+    @Test public void nonDocsBootstrapDoesNotTouchCurrentSpace() {
+        String html = DocsViewerUrlPolicy.buildIdentityBootstrapHtml(
+                REAL_URL, "android", "token", "uid", "name", null);
+        assertFalse(html.contains("currentSpaceId"));
+        assertTrue(html.contains("window.location.replace(\"" + REAL_URL + "\");"));
+    }
+
+    private static String bootstrap(String currentSpaceId) {
+        return DocsViewerUrlPolicy.buildIdentityBootstrapHtml(
+                REAL_URL, "android", "token", "uid", "name", currentSpaceId);
+    }
+
+    private static void assertOrdered(String text, String first, String second) {
+        int firstIndex = text.indexOf(first);
+        int secondIndex = text.indexOf(second);
+        assertTrue("missing first fragment: " + first, firstIndex >= 0);
+        assertTrue("missing second fragment: " + second, secondIndex >= 0);
+        assertTrue("wrong fragment order", firstIndex < secondIndex);
+    }
+}


### PR DESCRIPTION
## Summary
- synchronously hand off the native current Space to trusted standalone Docs routes
- clear stale WebView Space state when the native selection is empty
- use the configured Web base URL as the WebView trust anchor, rather than the independently configured API base URL
- preserve the existing identity handoff mechanism without adding a URL parameter or bridge capability
- cover exact origin/path gating, anonymous startup, ordering, and inline-script escaping

`/docs/:docId/present` is an enterprise Docs presentation route supplied by the separate Docs module; it is intentionally included alongside `/d/:docId` and `/ppt/d/:docId`.

## Linked issue
Closes #131

## How verified
- independent review: P0/P1 = 0 before the latest focused test-hardening update
- synchronized with current `origin/main`
- JDK 17 plain-JVM focused suite with the declared `org.json:json:20231013`: 10/10 passed
- mutation gate: deleting both Space `setItem`/`removeItem` statements makes four focused tests fail
- `git diff --check` passed
- full Gradle build remains for CI because this host has no Android SDK

## Comprehension
### What does this change actually do?
Before, the Android WebView handed off login identity but not the viewer's current Space. Now trusted standalone Docs routes receive one synchronous native Space snapshot in `localStorage.currentSpaceId` before navigation; an empty selection removes stale state. The trust anchor is deliberately derived from `WKApiConfig.baseWebUrl`, because these are WebView destinations and API/Web hosts may be configured independently.

### What could break?
WebView startup for standalone Doc, PPT, and presentation routes, plus identity handoff for first-party Web pages if `WEB_BASE_URL` is misconfigured. URL parsing is fail-closed: malformed first-party URLs fall back to plain `loadUrl` without native state injection.

### How do you know it works?
The focused suite covers trusted/spoofed origins, accepted/rejected routes, explicit Web-base selection over a different API base, anonymous startup, stale-state removal, navigation ordering, and script-breaking characters. Ordering assertions require both fragments to exist, and the mutation gate proves removing the feature makes the suite fail.
