### PR TITLE
chore(release): 版本号升至 1.3.7 (versionCode 38)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
         applicationId appId
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 37
-        versionName "1.3.6"
+        versionCode 38
+        versionName "1.3.7"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
Closes #132

## 改动

**1 个文件，2 行，只有版本号：**

```diff
-        versionCode 37
-        versionName "1.3.6"
+        versionCode 38
+        versionName "1.3.7"
```

无代码逻辑改动、无依赖变更、无资源变更。

## 为什么要改

上一个正式版是 v1.3.6 / versionCode 37（tag `8ebd90a`，2026-07-21）。此后 main 合并了 5 个 PR（#112 #119 #123 #125 #129），版本号一直没动，导致：

- 本地打出的包与线上包版本完全相同，覆盖安装无法区分是否装成功
- `publish.sh` 从 `build.gradle` 读 `versionName` 打 tag，会打出重复的 `v1.3.6`

`versionCode 38 > 37` 保证覆盖安装成立。

## 升级自测已完成

两台设备实测 v1.3.6 → 本版本覆盖升级，五万余行日志、16 类危险信号零命中。详见 #132。

关键数字（小米 / Android 16 / 2.5 个月真实数据的账号）：

| | 冷启动 |
|---|---|
| 1.3.6 基线 | 334 / 350 / 403ms |
| 1.3.7 首次（含 4 条新索引构建） | 579ms |
| 1.3.7 稳态 | 349 / 345ms |

索引一次性构建代价 ≈ 230ms，仅升级后首次打开。

🤖 Generated with [Claude Code](https://claude.com/claude-code)