### PR TITLE
fix(chat): 修复消息气泡重叠/折叠

### DIFF
--- a/wkbase/src/main/java/com/chat/base/msg/ChatAdapter.java
+++ b/wkbase/src/main/java/com/chat/base/msg/ChatAdapter.java
@@ -578,6 +578,9 @@ public class ChatAdapter extends BaseProviderMultiAdapter<WKUIChatMsgItemEntity>
             return;
         List<WKUIChatMsgItemEntity> list = getData();
         for (int i = 0, size = list.size(); i < size; i++) {
+            // loading / 占位 item 的 wkMsg 是 null（同 #129 在其它遍历点补的空判），
+            // 这里原来直接解引用，列表里存在占位项时会 NPE。
+            if (list.get(i) == null || list.get(i).wkMsg == null) continue;
             if (list.get(i).wkMsg.baseContentMsgModel == null || list.get(i).wkMsg.baseContentMsgModel.reply == null) {
                 continue;
             }

--- a/wkbase/src/main/java/com/chat/base/msgitem/WKChatBaseProvider.kt
+++ b/wkbase/src/main/java/com/chat/base/msgitem/WKChatBaseProvider.kt
@@ -366,6 +366,16 @@ abstract class WKChatBaseProvider : BaseItemProvider<WKUIChatMsgItemEntity>() {
 //            val deleteTimerLP = deleteTimer.layoutParams as RelativeLayout.LayoutParams
             baseView.removeAllViews()
             baseView.addView(getChatViewItem(baseView, from))
+            // 气泡内部几个容器开着 animateLayoutChanges，其 CHANGING 动画默认会沿父链把本 item 根
+            // （ChatItemView）的 bounds 也一起动画掉，并停在动画开始时捕获的旧 bounds 上，
+            // 把 LayoutManager 刚排好的位置改写掉 → 气泡压住相邻消息。这里只关掉"动祖先"这一项，
+            // 气泡内部动画不变。详见 ChatItemView.disableParentHierarchyTransitions 的注释。
+            //
+            // ⚠️ 必须在整棵 item 子树 inflate 完之后调用：它只遍历调用时已存在的 view。
+            // 当前三个带 animateLayoutChanges 的布局（chat_item_base_layout / wk_msg_status_layout /
+            // chat_item_text）都在上面 getChatViewItem 里就 inflate 好了，覆盖是全的；若将来有谁在
+            // 下方的 setData 里再 inflate 带该属性的容器，需要把这行挪到其后，否则会漏成偶发重叠。
+            ChatItemView.disableParentHierarchyTransitions(baseViewHolder.itemView)
             baseViewHolder.getView<View>(R.id.viewContentLayout).setOnClickListener {
                 val chatAdapter = getAdapter() as ChatAdapter
                 chatAdapter.conversationContext.hideSoftKeyboard()

--- a/wkbase/src/main/java/com/chat/base/views/ChatItemView.java
+++ b/wkbase/src/main/java/com/chat/base/views/ChatItemView.java
@@ -16,9 +16,12 @@
 
 package com.chat.base.views;
 
+import android.animation.LayoutTransition;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
 import android.widget.LinearLayout;
 
 import androidx.annotation.Nullable;
@@ -34,6 +37,37 @@ public class ChatItemView extends LinearLayout {
 
     private IViewClick iViewClick;
     private boolean isDelivered;
+
+    /**
+     * 关掉 item 子树里所有 {@link LayoutTransition} 的 {@code animateParentHierarchy}。
+     *
+     * <p>气泡内部几个容器开着 {@code animateLayoutChanges="true"}（wkBaseContentLayout /
+     * contentLayout / contentTvLayout / textContentLayout）。绑定时
+     * {@code removeAllViews() + addView()}、以及引用块 {@code addView} 进气泡，都会触发它们的
+     * CHANGING 动画。而该动画默认 {@code mAnimateParentHierarchy=true}，会<b>沿父链一路向上</b>
+     * 把每一层祖先的 bounds 也纳入动画——包括本类（RecyclerView 的直接子 view）。
+     *
+     * <p>它用 ObjectAnimator 直接动 {@code "top"/"bottom"} 属性（即 {@code View.setTop/setBottom}），
+     * 绕过 {@code layout()} 与 {@code offsetTopAndBottom()}，把 LayoutManager 刚排好的位置改写成
+     * 动画开始时捕获的旧 bounds 并停在那里——表现就是 item 退回上一次布局的位置、压住相邻消息。
+     *
+     * <p>真机定位过程：LayoutManager 每一代排版的输出都连续（逐出口取样确认），几何流水账里也没有
+     * 对应的 layout / offset 记录，而 item 的 frame 确实变了——排除法只剩这一条路，关掉后复现不再
+     * 出现。
+     *
+     * <p>关掉后气泡内部动画照旧，只是不再伸手改祖先的几何。
+     */
+    public static void disableParentHierarchyTransitions(View root) {
+        if (!(root instanceof ViewGroup)) return;
+        ViewGroup vg = (ViewGroup) root;
+        LayoutTransition transition = vg.getLayoutTransition();
+        if (transition != null) {
+            transition.setAnimateParentHierarchy(false);
+        }
+        for (int i = 0, n = vg.getChildCount(); i < n; i++) {
+            disableParentHierarchyTransitions(vg.getChildAt(i));
+        }
+    }
 
     public void setTouchData(boolean isDelivered, IViewClick iViewClick) {
         this.isDelivered = isDelivered;

--- a/wkuikit/src/main/java/com/chat/uikit/chat/MyItemAnimator.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/MyItemAnimator.java
@@ -61,6 +61,14 @@ public class MyItemAnimator extends SimpleItemAnimator {
         //
         // 关掉之后 canReuseUpdatedViewHolder 恒为 true —— 更新复用同一个 holder，既不再创建
         // 多余 holder，也彻底没有 hidden view 需要回收。动画本来就是空实现，观感不变。
+        //
+        // ⚠️ 这个 flag 与下面 animateChange 的 oldHolder==newHolder 分支是**一对**，不能只留一个：
+        // 关掉 change 动画后，RecyclerView 会用 (h, h) 调 animateChange，DefaultItemAnimator 的
+        // 默认做法是转成 move 动画（setTranslationY 再动画回 0），高频刷新打断就会残留位移 ⇒ 气泡
+        // 重叠（v1.2.4 的 c954e92 当时是靠删掉本 flag 来规避的）。所以那个分支已改成直接归位。
+        //
+        // animateMove 保持原样（真实位移的 delta 是收敛的，v1.2.4 删 flag 后它单独跑过一个版本
+        // 没出问题），只堵掉 (h, h) 这条把"自身高度变化"误当位移的通道。
         setSupportsChangeAnimations(false);
     }
 
@@ -334,7 +342,25 @@ public class MyItemAnimator extends SimpleItemAnimator {
     public boolean animateChange(RecyclerView.ViewHolder oldHolder,
                                  RecyclerView.ViewHolder newHolder, int fromLeft, int fromTop, int toLeft, int toTop) {
         if (oldHolder == newHolder) {
-            return animateMove(oldHolder, fromLeft, fromTop, toLeft, toTop);
+            // supportsChangeAnimations=false ⇒ canReuseUpdatedViewHolder 恒 true ⇒ 复用同一个 holder，
+            // RecyclerView 用 (h, h) 调到这里。DefaultItemAnimator 在这个分支委托给 animateMove：
+            // 先同步 setTranslationY(-deltaY)，再用 ViewPropertyAnimator 动画回 0。
+            //
+            // 但本 animator 的 change 动画本来就是空实现（animateChangeImpl 全被注释掉），这个位移
+            // 纯属副作用：高频 notifyItemChanged（发送态回包 / 已读回执 / 机器人流式编辑）会在动画
+            // 落地前反复打断它，translationY 残留下来，气泡就叠在相邻消息上。
+            // v1.2.4 已经踩过一次（c954e92：删 setSupportsChangeAnimations(false) 修气泡重叠），
+            // #129 为堵 "Tmp detached view" 崩溃把 flag 加回来时把这个副作用一并带了回来。
+            //
+            // 这里直接归位 + 立即 dispatch：既不产生任何中间位移帧（重叠无从谈起），又保住 #129
+            // 靠 holder 复用堵掉的那条崩溃路径。返回 false 让 RecyclerView 不必 post 动画 runner。
+            final View view = oldHolder.itemView;
+            resetAnimation(oldHolder);
+            view.setTranslationX(0);
+            view.setTranslationY(0);
+            view.setAlpha(1);
+            dispatchChangeFinished(oldHolder, true);
+            return false;
         }
         final float prevTranslationX = oldHolder.itemView.getTranslationX();
         final float prevTranslationY = oldHolder.itemView.getTranslationY();


### PR DESCRIPTION
## 问题

聊天列表里消息气泡会重叠 / 折叠 —— item 退回上一次布局的位置，压住相邻消息。

v1.2.4 修过一次同类问题（`c954e92`），#129 修 `Tmp detached view` 崩溃时把副作用带了回来，
且这次还叠加了第二个独立成因。

## 根因

**两个独立机制，都会让 item 画在 LayoutManager 排定位置之外。**

### 1. `LayoutTransition.animateParentHierarchy`（主因）

气泡内部几个容器开着 `animateLayoutChanges="true"`（`wkBaseContentLayout` / `contentLayout` /
`contentTvLayout` / `textContentLayout` / `wk_msg_status_layout`）。绑定时的
`removeAllViews() + addView()`、以及引用块 `addView` 进气泡，都会触发它们的 CHANGING 动画。

该动画默认 `mAnimateParentHierarchy=true`，会**沿父链一路向上**把每一层祖先的 bounds 也纳入动画，
包括 `ChatItemView`（RecyclerView 的直接子 view）。它用 ObjectAnimator 直接动 `"top"/"bottom"`
属性（即 `View.setTop/setBottom`），**绕过 `layout()` 与 `offsetTopAndBottom()`**，把 LayoutManager
刚排好的位置改写成动画开始时捕获的旧 bounds 并停在那里。

定位方式：LayoutManager 每一代排版输出都连续（逐出口取样确认），几何流水账里没有对应的
layout / offset 记录，而 item 的 frame 确实变了 —— 排除法只剩 `setTop/setBottom` 这条路。

### 2. `animateChange` 把「自身高度变化」误当位移

#129 为堵崩溃加了 `setSupportsChangeAnimations(false)`，使 `canReuseUpdatedViewHolder` 恒为 true，
RecyclerView 改用 `(h, h)` 同一个 holder 调 `animateChange`。而 `DefaultItemAnimator` 在该分支
**委托给 `animateMove`**：先同步 `setTranslationY(-delta)`，再用 250ms 动画归零。

问题在于此时 item 的 position 根本没变、是它自己在长高，传进来的 delta 等于「自身高度增量」。
机器人流式回复每帧都在长高 ⇒ 每帧补一次错误位移、动画反复被打断，**永不收敛**。

真机探针实测：

```
upper pos=30 top=-572 bottom=1342 h=1914 ty=220.0 animRunning=true
lower pos=31 top=1342 bottom=1540 h=198  ty=0.0
```

`1342 == 1342` —— 布局位置严丝合缝，错的只有 `ty=220`。

## 改动

**4 文件 +74 / −1。** 唯一那 1 行删除是被替换掉的 `return animateMove(...)`，其余全是新增，
**没有任何既有逻辑被改写或删除**。

| 文件 | 改动 |
|---|---|
| `ChatItemView` | 新增 `disableParentHierarchyTransitions(View)`，递归关掉 item 子树里所有 LayoutTransition 的 `animateParentHierarchy`。气泡内部动画照旧，只是不再伸手改祖先几何 |
| `WKChatBaseProvider.showData` | 子树 inflate 完成后调用上述方法（调用顺序是隐式契约，已在调用处写明） |
| `MyItemAnimator.animateChange` | `oldHolder==newHolder` 分支不再委托 `animateMove`，改为直接归位 + `dispatchChangeFinished` + 返回 false |
| `ChatAdapter.refreshReplyMsg` | 补 `wkMsg == null` 空判（占位 item 的 wkMsg 为 null，与 #129 同类隐患） |

### 关键取舍（review 重点）

- **保留 `setSupportsChangeAnimations(false)`。** 那是 #129 的崩溃修复，不动。这次只堵掉它的
  视觉副作用。v1.2.4 当年是靠删该 flag 规避重叠的，等于用崩溃换重叠 —— 这次两个都要。
- **`animateMove` 保持原样，与 main 逐字节相同。** 真实位移的 delta 是收敛的
  （`fromY += getTranslationY()` 会把已有位移折进去），且 v1.2.4 删 flag 后它单独跑过一个版本
  没出问题。曾一并改掉（代价是插入消息少了 250ms 滑动），经分析与实机验证后**已还原**，
  只堵假位移那一条通道。
- **`dispatchChangeFinished + return false` 是框架自身的模式** —— `DefaultItemAnimator.animateMove`
  在 `delta == 0` 时就是这么写的，不会造成重复回调。语义上比原来更准：RecyclerView 调进来的是
  `animateChange`，原代码走 `animateMove` 会 dispatch move finished。

## 验证

真机跑通，诊断探针（只报动画结束后仍重叠 / 连续重叠超 700ms，在途动画与消失中的 view 已排除）
**零输出**：

- [x] 机器人流式回复长文
- [x] 流式输出的同时连发 3~5 条消息（最关键 —— 验证 `animateMove` 维持原样是否成立）
- [x] 引用长消息回复
- [x] 后台切回聊天页多次、断网重连 sync（#129 崩溃路径回归）
- [x] 交互卡 / 图片 / 文件 / 语音渲染、翻历史加载更多位置不跳
- [x] 全量 `./gradlew assembleDebug` 通过

诊断探针为临时代码，已在提交前完整移除（本 PR 不含任何探针代码）。

## 范围说明

原本一并改了「敏感词提示（type=-10）下线」，与气泡折叠机制上毫无关系，且前提（iOS/web 究竟是
服务端不下发还是客户端过滤）尚未确认，**已从本次改动中拆出**，另行处理。届时需连带处理
`WKUIKitApplication.sensitiveWords` 会变成只写不读的问题。

## 已知的既有问题（与本 PR 无关）

`./gradlew assembleRelease` 在 `wklogin` 报 `mipmap/ic_launcher not found`。**改动前就存在**，
已验证与本次改动无关，另行处理。

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
