### PR TITLE
fix(pdf): 修复协议 PDF 放大后无法左右滑动

### DIFF
--- a/wkbase/src/main/java/com/chat/base/act/WKPdfViewActivity.java
+++ b/wkbase/src/main/java/com/chat/base/act/WKPdfViewActivity.java
@@ -9,6 +9,7 @@ import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.ViewConfiguration;
+import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -17,6 +18,7 @@ import android.widget.TextView;
 
 import com.chat.base.R;
 
+import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatActivity;
 
 import java.io.File;
@@ -43,12 +45,18 @@ public class WKPdfViewActivity extends AppCompatActivity {
     private float lastPanX;
     private boolean panning;
     private int pendingScrollY;
-    private final Runnable applyPendingScroll = new Runnable() {
-        @Override
-        public void run() {
-            scrollView.scrollTo(0, pendingScrollY);
-        }
-    };
+    private boolean scrollCorrectionScheduled;
+    // layout 完成、绘制之前用新的高度补正 scrollY，见 applyScale
+    private final ViewTreeObserver.OnPreDrawListener scrollCorrection =
+            new ViewTreeObserver.OnPreDrawListener() {
+                @Override
+                public boolean onPreDraw() {
+                    scrollView.getViewTreeObserver().removeOnPreDrawListener(this);
+                    scrollCorrectionScheduled = false;
+                    scrollView.scrollTo(0, pendingScrollY);
+                    return true;
+                }
+            };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -58,9 +66,8 @@ public class WKPdfViewActivity extends AppCompatActivity {
         container = new LinearLayout(this);
         container.setOrientation(LinearLayout.VERTICAL);
         container.setGravity(Gravity.CENTER_HORIZONTAL);
-        // 缩放锚点固定在左上角：内容只向右、向下溢出，右侧靠 translationX、
-        // 底部靠 bottomMargin 变成可达区域。用中心锚点的话两侧同时溢出，
-        // 可平移范围和 ScrollView 的滚动范围都算不干净。
+        // 缩放锚点固定在左上角：内容只向右、向下溢出，右侧靠 translationX、底部靠
+        // 撑高测量高度变成可达区域。用中心锚点的话两侧同时溢出，可平移范围算不干净。
         container.setPivotX(0f);
         container.setPivotY(0f);
         scrollView.addView(container, new FrameLayout.LayoutParams(
@@ -99,40 +106,78 @@ public class WKPdfViewActivity extends AppCompatActivity {
 
     /**
      * 以手势焦点为锚点应用新的缩放级别。
-     * <p>
-     * 锚点在左上角时，内容坐标 c 的屏幕位置是 {@code c * scale - offset}（横向 offset 即
-     * -translationX，竖向即 scrollY）。要让焦点前后停在同一处内容上，解出新的偏移：
-     * {@code offset1 = (focus + offset0) * scale1 / scale0 - focus}。
      */
     private void applyScale(float previousScale, float focusX, float focusY) {
-        float offsetX = -container.getTranslationX();
-        float offsetY = scrollView.getScrollY();
         float ratio = scaleFactor / previousScale;
+        float offsetX = anchoredOffset(focusX, -container.getTranslationX(), ratio);
+        float offsetY = anchoredOffset(focusY, scrollView.getScrollY(), ratio);
 
         container.setScaleX(scaleFactor);
         container.setScaleY(scaleFactor);
         updateVerticalScrollRange();
-        container.setTranslationX(-clampOffsetX((focusX + offsetX) * ratio - focusX));
+        container.setTranslationX(-clampOffsetX(offsetX));
 
-        pendingScrollY = Math.max(0, Math.round((focusY + offsetY) * ratio - focusY));
-        // 先立即滚一次保证跟手（会被旧的滚动范围钳制），再等 bottomMargin 触发的
-        // layout 生效后补正一次，否则放大时竖向锚点会往回漂。
+        pendingScrollY = Math.max(0, Math.round(offsetY));
+        // setPadding 触发的 requestLayout 是异步的，此刻 scrollTo 仍会被旧高度钳制
+        // （ScrollView.scrollTo 按 child.getHeight() 夹取），所以先尽力滚一次保证跟手，
+        // 再在 layout 完成、绘制之前按新高度补正一次。
         scrollView.scrollTo(0, pendingScrollY);
-        scrollView.removeCallbacks(applyPendingScroll);
-        scrollView.post(applyPendingScroll);
+        if (!scrollCorrectionScheduled) {
+            scrollCorrectionScheduled = true;
+            scrollView.getViewTreeObserver().addOnPreDrawListener(scrollCorrection);
+        }
     }
 
     /**
-     * setScaleY 只改绘制、不改 layout 尺寸，ScrollView 仍按未缩放的高度算滚动范围。
-     * 把放大多出来的高度补进 bottomMargin，底部才滑得到（ScrollView 的滚动范围含子 View margin）。
+     * 用底部内边距把 container 的测量高度撑到 H * scale，让 ScrollView 的滚动范围跟上缩放。
+     * <p>
+     * 只能用 padding，两条约束都验证过：
+     * <ul>
+     *   <li>ScrollView 的滚动范围只认子 View 的测量高度 —— {@code getScrollRange()} 与
+     *       {@code scrollTo()} 都按 {@code child.getHeight()} 夹取，<b>不计 margin</b>
+     *       （计 margin 的是 androidx 的 NestedScrollView，两者别混）；</li>
+     *   <li>{@code ScrollView.measureChildWithMargins()} 强制以 UNSPECIFIED 测量子 View，
+     *       <b>无视 LayoutParams.height</b>，所以直接设高度同样没用。</li>
+     * </ul>
+     * 而 LinearLayout 自身测量时一定把 padding 计进 mTotalLength，不受父级 spec 影响。
+     * <p>
+     * setScaleY 只改绘制、不改测量尺寸，配合 pivotY = 0 内容绘制在 0..H*scale；撑高后
+     * 滚到底时内容底部正好落在视口底部，多出来的空白在视口之外。
      */
     private void updateVerticalScrollRange() {
-        FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) container.getLayoutParams();
-        int extraHeight = Math.round(container.getHeight() * (scaleFactor - 1f));
-        if (lp.bottomMargin != extraHeight) {
-            lp.bottomMargin = extraHeight;
-            container.setLayoutParams(lp);
+        int contentHeight = container.getHeight() - container.getPaddingBottom();
+        if (contentHeight <= 0) {
+            return;
         }
+        int padding = scaleCompensationPadding(contentHeight, scaleFactor);
+        if (container.getPaddingBottom() != padding) {
+            container.setPadding(0, 0, 0, padding);
+        }
+    }
+
+    /** 缩放 scale 倍后 container 应有的测量高度，ScrollView 靠它算滚动范围。 */
+    @VisibleForTesting
+    static int scaledContentHeight(int contentHeight, float scale) {
+        return Math.max(contentHeight, Math.round(contentHeight * scale));
+    }
+
+    /** 把测量高度从 contentHeight 撑到缩放后高度所需的底部内边距。 */
+    @VisibleForTesting
+    static int scaleCompensationPadding(int contentHeight, float scale) {
+        return scaledContentHeight(contentHeight, scale) - contentHeight;
+    }
+
+    /**
+     * 以 focus 为锚点缩放后的新偏移量。
+     * <p>
+     * 缩放锚点在左上角时，内容坐标 c 的屏幕位置是 {@code c * scale - offset}
+     * （横向 offset 即 -translationX，竖向即 scrollY）。要让 focus 处的内容在缩放前后
+     * 停在同一位置，解出 {@code offset1 = (focus + offset0) * ratio - focus}，
+     * 其中 {@code ratio = scale1 / scale0}。
+     */
+    @VisibleForTesting
+    static float anchoredOffset(float focus, float previousOffset, float ratio) {
+        return (focus + previousOffset) * ratio - focus;
     }
 
     /** 放大后内容宽度为 width * scale，可横向平移的范围是 [0, width * (scale - 1)]。 */
@@ -140,7 +185,8 @@ public class WKPdfViewActivity extends AppCompatActivity {
         return clamp(offsetX, 0f, container.getWidth() * (scaleFactor - 1f));
     }
 
-    private static float clamp(float value, float min, float max) {
+    @VisibleForTesting
+    static float clamp(float value, float min, float max) {
         return Math.max(min, Math.min(value, max));
     }
 

--- a/wkbase/src/main/java/com/chat/base/act/WKPdfViewActivity.java
+++ b/wkbase/src/main/java/com/chat/base/act/WKPdfViewActivity.java
@@ -8,7 +8,9 @@ import android.text.TextUtils;
 import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
+import android.view.View;
 import android.view.ViewConfiguration;
+import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
@@ -43,9 +45,12 @@ public class WKPdfViewActivity extends AppCompatActivity {
     // 横向拖动的跟踪状态；竖向照旧交给 ScrollView
     private int panPointerId = INVALID_POINTER;
     private float lastPanX;
+    private float lastPanY;
     private boolean panning;
     private int pendingScrollY;
     private boolean scrollCorrectionScheduled;
+    // 复用的 getLocationInWindow 出参，避免每次缩放事件都分配
+    private final int[] viewportOffset = new int[2];
     // layout 完成、绘制之前用新的高度补正 scrollY，见 applyScale
     private final ViewTreeObserver.OnPreDrawListener scrollCorrection =
             new ViewTreeObserver.OnPreDrawListener() {
@@ -85,6 +90,12 @@ public class WKPdfViewActivity extends AppCompatActivity {
         container.addView(loadingTv);
 
         scaleDetector = new ScaleGestureDetector(this, new ScaleGestureDetector.SimpleOnScaleGestureListener() {
+            // 每帧最多回调一次：ACTION_MOVE 的多个采样点会累积进同一个 MotionEvent 的
+            // history（见 MotionEvent 类文档 "Batching" 一节），触摸采样率高于刷新率时
+            // 增加的是 getHistorySize()、不是分发次数，而 ScaleGestureDetector 只读当前
+            // 坐标、不遍历 historical 点。所以两次 applyScale 之间必定隔着一次 traversal。
+            // 不过这只是背景，不构成正确性依赖 —— updateVerticalScrollRange 读的量与
+            // layout 时机无关，见 measureContentHeight()。
             @Override
             public boolean onScale(ScaleGestureDetector detector) {
                 float previousScale = scaleFactor;
@@ -106,8 +117,17 @@ public class WKPdfViewActivity extends AppCompatActivity {
 
     /**
      * 以手势焦点为锚点应用新的缩放级别。
+     * <p>
+     * 传入的 focus 是 window 坐标（Activity.dispatchTouchEvent 的事件坐标系），而锚点公式
+     * 要的是相对 ScrollView 视口的坐标。主题是 NoActionBar 且未开 edge-to-edge，视口顶边
+     * 在状态栏之下，两者差一个状态栏高度；不减掉的话每次缩放都会引入
+     * {@code offset * (ratio - 1)} 的锚点漂移并逐次累积。
      */
-    private void applyScale(float previousScale, float focusX, float focusY) {
+    private void applyScale(float previousScale, float windowFocusX, float windowFocusY) {
+        scrollView.getLocationInWindow(viewportOffset);
+        float focusX = windowFocusX - viewportOffset[0];
+        float focusY = windowFocusY - viewportOffset[1];
+
         float ratio = scaleFactor / previousScale;
         float offsetX = anchoredOffset(focusX, -container.getTranslationX(), ratio);
         float offsetY = anchoredOffset(focusY, scrollView.getScrollY(), ratio);
@@ -145,14 +165,44 @@ public class WKPdfViewActivity extends AppCompatActivity {
      * 滚到底时内容底部正好落在视口底部，多出来的空白在视口之外。
      */
     private void updateVerticalScrollRange() {
-        int contentHeight = container.getHeight() - container.getPaddingBottom();
+        int contentHeight = measureContentHeight();
         if (contentHeight <= 0) {
             return;
         }
         int padding = scaleCompensationPadding(contentHeight, scaleFactor);
         if (container.getPaddingBottom() != padding) {
+            // setPadding 会触发 requestLayout，捏合期间每帧重测一次 container。协议类 PDF
+            // 页数少、ImageView 的 measure 是常数级，成本可忽略；若长文档上出现掉帧，
+            // 可改成手势结束时才应用最终缩放级别。
             container.setPadding(0, 0, 0, padding);
         }
+    }
+
+    /**
+     * 未缩放的内容高度：末个子 View 的底边加它的下外边距。
+     * <p>
+     * 刻意不用 {@code getHeight() - getPaddingBottom()} —— 那两个量的更新时机不同
+     * （setPadding 同步生效，getHeight 要等下一次 traversal），一旦在同一次 layout 间隔里
+     * 读到「旧高度 + 新 padding」就会算出偏小的内容高度，补偿 padding 随之偏小，
+     * 放大后底部又滚不到。竖向 LinearLayout 的 paddingBottom 不参与子 View 定位
+     * （参与的是 paddingTop，这里恒为 0），所以子 View 的 getBottom() 与补偿 padding
+     * 正交，无论 layout 有没有跟上都是同一个值。
+     * <p>
+     * 正因为读的量与 layout 时机无关，也就不需要 isLayoutRequested() 延迟重算或
+     * OnLayoutChangeListener 维护一个 contentHeight 字段：前者会被 setPadding 自身触发的
+     * layout 再次唤醒、得额外防循环，后者要引入可变状态和刷新时机。
+     * <p>
+     * paddingTop 这里恒为 0；即便将来不是，公式依然闭合 —— getBottom() 已经含 paddingTop
+     * 偏移，而缩放基准正是「container 顶边到内容底边」的距离。
+     */
+    private int measureContentHeight() {
+        int count = container.getChildCount();
+        if (count == 0) {
+            return 0;
+        }
+        View last = container.getChildAt(count - 1);
+        ViewGroup.MarginLayoutParams lp = (ViewGroup.MarginLayoutParams) last.getLayoutParams();
+        return last.getBottom() + lp.bottomMargin;
     }
 
     /** 缩放 scale 倍后 container 应有的测量高度，ScrollView 靠它算滚动范围。 */
@@ -206,27 +256,46 @@ public class WKPdfViewActivity extends AppCompatActivity {
             case MotionEvent.ACTION_DOWN:
                 panPointerId = ev.getPointerId(0);
                 lastPanX = ev.getX();
+                lastPanY = ev.getY();
                 panning = false;
                 break;
+            case MotionEvent.ACTION_POINTER_DOWN: {
+                // 第二根手指落下到 ScaleGestureDetector 越过 span slop 之间有一小段空窗，
+                // 此时两轴会被不同手指带着走。重置基准，把这段交给缩放。
+                int index = ev.findPointerIndex(panPointerId);
+                if (index >= 0) {
+                    lastPanX = ev.getX(index);
+                    lastPanY = ev.getY(index);
+                }
+                panning = false;
+                break;
+            }
             case MotionEvent.ACTION_MOVE: {
                 if (panPointerId == INVALID_POINTER) break;
                 int index = ev.findPointerIndex(panPointerId);
                 if (index < 0) break;
                 float x = ev.getX(index);
+                float y = ev.getY(index);
                 if (scaleDetector.isInProgress()) {
                     // 缩放中不额外平移，但基准要跟手，否则手势结束那一下会跳
                     lastPanX = x;
+                    lastPanY = y;
                     panning = false;
                     break;
                 }
                 float dx = x - lastPanX;
                 if (!panning) {
-                    if (Math.abs(dx) < touchSlop) break;
+                    // 轴向锁定：只有横向占优才进入平移。否则一次长距离竖向滚动里累积的
+                    // 横向抖动迟早超过 slop，会把页面拖偏（基准在未锁定前不刷新，dx 从
+                    // ACTION_DOWN 起累计）。
+                    if (!shouldStartHorizontalPan(dx, y - lastPanY, touchSlop)) break;
                     panning = true;
                     lastPanX = x;
+                    lastPanY = y;
                     break;
                 }
                 lastPanX = x;
+                lastPanY = y;
                 container.setTranslationX(-clampOffsetX(-container.getTranslationX() - dx));
                 break;
             }
@@ -237,6 +306,7 @@ public class WKPdfViewActivity extends AppCompatActivity {
                     int next = index == 0 ? 1 : 0;
                     panPointerId = ev.getPointerId(next);
                     lastPanX = ev.getX(next);
+                    lastPanY = ev.getY(next);
                 }
                 break;
             }
@@ -248,6 +318,12 @@ public class WKPdfViewActivity extends AppCompatActivity {
             default:
                 break;
         }
+    }
+
+    /** 越过 slop 且横向位移占优时才开始横向平移，避免竖向滚动被判成平移。 */
+    @VisibleForTesting
+    static boolean shouldStartHorizontalPan(float dx, float dy, int touchSlop) {
+        return Math.abs(dx) >= touchSlop && Math.abs(dx) > Math.abs(dy);
     }
 
     private void downloadAndRender(String pdfUrl) {
@@ -301,7 +377,14 @@ public class WKPdfViewActivity extends AppCompatActivity {
                         lp.bottomMargin = 8;
                         container.addView(iv, lp);
                     }
-                    // 内容高度从 loading 文案变成了实际页面，按当前缩放级别重算滚动范围
+                    // 内容高度从 loading 文案变成了实际页面，按当前缩放级别重算滚动范围。
+                    // 这个 runnable 跑在 layout 之后，不是之前：上面的 addView 已触发
+                    // requestLayout()，而 ViewRootImpl.scheduleTraversals() 会先往主线程
+                    // 队列装 sync barrier、再把 traversal 作为异步消息排入；View.post 发的
+                    // 是同步消息，被 barrier 挡到 traversal 完成之后。该方法的注释把这条
+                    // 列为 "load-bearing for public API correctness"，并以
+                    // setText → post → getWidth 举例，与此处 addView → post → 读子 View
+                    // 位置同构。所以不需要换成 OnPreDrawListener。
                     container.post(this::updateVerticalScrollRange);
                 });
             } catch (Exception e) {

--- a/wkbase/src/main/java/com/chat/base/act/WKPdfViewActivity.java
+++ b/wkbase/src/main/java/com/chat/base/act/WKPdfViewActivity.java
@@ -1,7 +1,6 @@
 package com.chat.base.act;
 
 import android.graphics.Bitmap;
-import android.graphics.Matrix;
 import android.graphics.pdf.PdfRenderer;
 import android.os.Bundle;
 import android.os.ParcelFileDescriptor;
@@ -9,6 +8,8 @@ import android.text.TextUtils;
 import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
+import android.view.ViewConfiguration;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
@@ -27,11 +28,27 @@ import java.util.concurrent.Executors;
 
 public class WKPdfViewActivity extends AppCompatActivity {
 
+    private static final float MIN_SCALE = 1.0f;
+    private static final float MAX_SCALE = 4.0f;
+    private static final int INVALID_POINTER = -1;
+
     private LinearLayout container;
     private ScrollView scrollView;
     private TextView loadingTv;
     private ScaleGestureDetector scaleDetector;
     private float scaleFactor = 1.0f;
+    private int touchSlop;
+    // 横向拖动的跟踪状态；竖向照旧交给 ScrollView
+    private int panPointerId = INVALID_POINTER;
+    private float lastPanX;
+    private boolean panning;
+    private int pendingScrollY;
+    private final Runnable applyPendingScroll = new Runnable() {
+        @Override
+        public void run() {
+            scrollView.scrollTo(0, pendingScrollY);
+        }
+    };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -41,8 +58,16 @@ public class WKPdfViewActivity extends AppCompatActivity {
         container = new LinearLayout(this);
         container.setOrientation(LinearLayout.VERTICAL);
         container.setGravity(Gravity.CENTER_HORIZONTAL);
-        scrollView.addView(container);
+        // 缩放锚点固定在左上角：内容只向右、向下溢出，右侧靠 translationX、
+        // 底部靠 bottomMargin 变成可达区域。用中心锚点的话两侧同时溢出，
+        // 可平移范围和 ScrollView 的滚动范围都算不干净。
+        container.setPivotX(0f);
+        container.setPivotY(0f);
+        scrollView.addView(container, new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT));
         setContentView(scrollView);
+        touchSlop = ViewConfiguration.get(this).getScaledTouchSlop();
 
         loadingTv = new TextView(this);
         loadingTv.setText(getString(R.string.pdf_loading));
@@ -55,12 +80,11 @@ public class WKPdfViewActivity extends AppCompatActivity {
         scaleDetector = new ScaleGestureDetector(this, new ScaleGestureDetector.SimpleOnScaleGestureListener() {
             @Override
             public boolean onScale(ScaleGestureDetector detector) {
-                scaleFactor *= detector.getScaleFactor();
-                scaleFactor = Math.max(1.0f, Math.min(scaleFactor, 4.0f));
-                container.setScaleX(scaleFactor);
-                container.setScaleY(scaleFactor);
-                container.setPivotX(container.getWidth() / 2f);
-                container.setPivotY(detector.getFocusY() + scrollView.getScrollY());
+                float previousScale = scaleFactor;
+                scaleFactor = clamp(scaleFactor * detector.getScaleFactor(), MIN_SCALE, MAX_SCALE);
+                if (scaleFactor != previousScale) {
+                    applyScale(previousScale, detector.getFocusX(), detector.getFocusY());
+                }
                 return true;
             }
         });
@@ -73,10 +97,111 @@ public class WKPdfViewActivity extends AppCompatActivity {
         downloadAndRender(url);
     }
 
+    /**
+     * 以手势焦点为锚点应用新的缩放级别。
+     * <p>
+     * 锚点在左上角时，内容坐标 c 的屏幕位置是 {@code c * scale - offset}（横向 offset 即
+     * -translationX，竖向即 scrollY）。要让焦点前后停在同一处内容上，解出新的偏移：
+     * {@code offset1 = (focus + offset0) * scale1 / scale0 - focus}。
+     */
+    private void applyScale(float previousScale, float focusX, float focusY) {
+        float offsetX = -container.getTranslationX();
+        float offsetY = scrollView.getScrollY();
+        float ratio = scaleFactor / previousScale;
+
+        container.setScaleX(scaleFactor);
+        container.setScaleY(scaleFactor);
+        updateVerticalScrollRange();
+        container.setTranslationX(-clampOffsetX((focusX + offsetX) * ratio - focusX));
+
+        pendingScrollY = Math.max(0, Math.round((focusY + offsetY) * ratio - focusY));
+        // 先立即滚一次保证跟手（会被旧的滚动范围钳制），再等 bottomMargin 触发的
+        // layout 生效后补正一次，否则放大时竖向锚点会往回漂。
+        scrollView.scrollTo(0, pendingScrollY);
+        scrollView.removeCallbacks(applyPendingScroll);
+        scrollView.post(applyPendingScroll);
+    }
+
+    /**
+     * setScaleY 只改绘制、不改 layout 尺寸，ScrollView 仍按未缩放的高度算滚动范围。
+     * 把放大多出来的高度补进 bottomMargin，底部才滑得到（ScrollView 的滚动范围含子 View margin）。
+     */
+    private void updateVerticalScrollRange() {
+        FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) container.getLayoutParams();
+        int extraHeight = Math.round(container.getHeight() * (scaleFactor - 1f));
+        if (lp.bottomMargin != extraHeight) {
+            lp.bottomMargin = extraHeight;
+            container.setLayoutParams(lp);
+        }
+    }
+
+    /** 放大后内容宽度为 width * scale，可横向平移的范围是 [0, width * (scale - 1)]。 */
+    private float clampOffsetX(float offsetX) {
+        return clamp(offsetX, 0f, container.getWidth() * (scaleFactor - 1f));
+    }
+
+    private static float clamp(float value, float min, float max) {
+        return Math.max(min, Math.min(value, max));
+    }
+
     @Override
     public boolean dispatchTouchEvent(MotionEvent ev) {
         scaleDetector.onTouchEvent(ev);
+        trackHorizontalPan(ev);
         return super.dispatchTouchEvent(ev);
+    }
+
+    /**
+     * 外层只有竖向的 ScrollView，放大后横向溢出的部分没有任何载体能滑到。
+     * 这里单独跟踪横向位移转成 translationX；事件照常往下传，竖向仍由 ScrollView 消费。
+     */
+    private void trackHorizontalPan(MotionEvent ev) {
+        switch (ev.getActionMasked()) {
+            case MotionEvent.ACTION_DOWN:
+                panPointerId = ev.getPointerId(0);
+                lastPanX = ev.getX();
+                panning = false;
+                break;
+            case MotionEvent.ACTION_MOVE: {
+                if (panPointerId == INVALID_POINTER) break;
+                int index = ev.findPointerIndex(panPointerId);
+                if (index < 0) break;
+                float x = ev.getX(index);
+                if (scaleDetector.isInProgress()) {
+                    // 缩放中不额外平移，但基准要跟手，否则手势结束那一下会跳
+                    lastPanX = x;
+                    panning = false;
+                    break;
+                }
+                float dx = x - lastPanX;
+                if (!panning) {
+                    if (Math.abs(dx) < touchSlop) break;
+                    panning = true;
+                    lastPanX = x;
+                    break;
+                }
+                lastPanX = x;
+                container.setTranslationX(-clampOffsetX(-container.getTranslationX() - dx));
+                break;
+            }
+            case MotionEvent.ACTION_POINTER_UP: {
+                // 抬起的正好是被跟踪的那根手指时换一根，避免基准突跳
+                int index = ev.getActionIndex();
+                if (ev.getPointerId(index) == panPointerId) {
+                    int next = index == 0 ? 1 : 0;
+                    panPointerId = ev.getPointerId(next);
+                    lastPanX = ev.getX(next);
+                }
+                break;
+            }
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_CANCEL:
+                panPointerId = INVALID_POINTER;
+                panning = false;
+                break;
+            default:
+                break;
+        }
     }
 
     private void downloadAndRender(String pdfUrl) {
@@ -130,6 +255,8 @@ public class WKPdfViewActivity extends AppCompatActivity {
                         lp.bottomMargin = 8;
                         container.addView(iv, lp);
                     }
+                    // 内容高度从 loading 文案变成了实际页面，按当前缩放级别重算滚动范围
+                    container.post(this::updateVerticalScrollRange);
                 });
             } catch (Exception e) {
                 String errMsg = e.getMessage();

--- a/wkbase/src/test/java/com/chat/base/act/WKPdfViewActivityZoomTest.java
+++ b/wkbase/src/test/java/com/chat/base/act/WKPdfViewActivityZoomTest.java
@@ -16,6 +16,8 @@
 package com.chat.base.act;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -29,6 +31,7 @@ public class WKPdfViewActivityZoomTest {
 
     private static final int VIEWPORT_HEIGHT = 1920;
     private static final int CONTENT_HEIGHT = 8400;
+    private static final int TOUCH_SLOP = 24;
 
     /**
      * 放大后底部要滑得到 —— 本次修复的核心。ScrollView 的滚动范围只认子 View 的
@@ -83,5 +86,21 @@ public class WKPdfViewActivityZoomTest {
         assertEquals(5f, WKPdfViewActivity.clamp(-3f, 5f, 10f), 0f);
         assertEquals(10f, WKPdfViewActivity.clamp(42f, 5f, 10f), 0f);
         assertEquals(7f, WKPdfViewActivity.clamp(7f, 5f, 10f), 0f);
+    }
+
+    /** 竖向滚动里累积的横向抖动不应被判成横向平移。 */
+    @Test public void mostlyVerticalSwipeDoesNotStartHorizontalPan() {
+        assertFalse(WKPdfViewActivity.shouldStartHorizontalPan(30f, 400f, TOUCH_SLOP));
+        assertFalse(WKPdfViewActivity.shouldStartHorizontalPan(-30f, -400f, TOUCH_SLOP));
+    }
+
+    @Test public void horizontalSwipePastSlopStartsPan() {
+        assertTrue(WKPdfViewActivity.shouldStartHorizontalPan(120f, 20f, TOUCH_SLOP));
+        assertTrue(WKPdfViewActivity.shouldStartHorizontalPan(-120f, 20f, TOUCH_SLOP));
+    }
+
+    @Test public void horizontalMovementWithinSlopDoesNotStartPan() {
+        assertFalse(WKPdfViewActivity.shouldStartHorizontalPan(TOUCH_SLOP - 1f, 0f, TOUCH_SLOP));
+        assertTrue(WKPdfViewActivity.shouldStartHorizontalPan(TOUCH_SLOP, 0f, TOUCH_SLOP));
     }
 }

--- a/wkbase/src/test/java/com/chat/base/act/WKPdfViewActivityZoomTest.java
+++ b/wkbase/src/test/java/com/chat/base/act/WKPdfViewActivityZoomTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.chat.base.act;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * WKPdfViewActivity 缩放几何中可脱离 View 计算的部分。
+ * <p>
+ * ScrollView 的真实滚动范围和手势响应依赖 View 测量，模块未接 Robolectric，
+ * plain JUnit 覆盖不到，那部分只能实机验证。
+ */
+public class WKPdfViewActivityZoomTest {
+
+    private static final int VIEWPORT_HEIGHT = 1920;
+    private static final int CONTENT_HEIGHT = 8400;
+
+    /**
+     * 放大后底部要滑得到 —— 本次修复的核心。ScrollView 的滚动范围只认子 View 的
+     * 测量高度（getScrollRange 与 scrollTo 都按 child.getHeight() 夹取），撑高后
+     * 滚到底时，内容底部应正好落在视口底部。
+     */
+    @Test public void scrollingToBottomLandsContentBottomAtViewportBottom() {
+        for (float scale : new float[]{1f, 1.5f, 2f, 3f, 4f}) {
+            int measuredHeight = CONTENT_HEIGHT
+                    + WKPdfViewActivity.scaleCompensationPadding(CONTENT_HEIGHT, scale);
+            int scrollRange = measuredHeight - VIEWPORT_HEIGHT;
+            float contentBottomOnScreen = CONTENT_HEIGHT * scale - scrollRange;
+            assertEquals("scale=" + scale, VIEWPORT_HEIGHT, contentBottomOnScreen, 1f);
+        }
+    }
+
+    @Test public void unscaledContentNeedsNoCompensationPadding() {
+        assertEquals(0, WKPdfViewActivity.scaleCompensationPadding(CONTENT_HEIGHT, 1f));
+    }
+
+    @Test public void compensationPaddingIsNeverNegative() {
+        assertEquals(0, WKPdfViewActivity.scaleCompensationPadding(CONTENT_HEIGHT, 0.5f));
+    }
+
+    @Test public void unscaledContentKeepsItsLayoutHeight() {
+        assertEquals(CONTENT_HEIGHT, WKPdfViewActivity.scaledContentHeight(CONTENT_HEIGHT, 1f));
+    }
+
+    @Test public void layoutHeightNeverShrinksBelowContentHeight() {
+        assertEquals(CONTENT_HEIGHT, WKPdfViewActivity.scaledContentHeight(CONTENT_HEIGHT, 0.5f));
+    }
+
+    /** 缩放前后，焦点处的同一个内容点应停在屏幕的同一位置。 */
+    @Test public void anchoredOffsetKeepsFocusedContentInPlace() {
+        float previousScale = 1.5f;
+        float nextScale = 3f;
+        float focus = 640f;
+        float previousOffset = 900f;
+        float contentAtFocus = (focus + previousOffset) / previousScale;
+
+        float offset = WKPdfViewActivity.anchoredOffset(
+                focus, previousOffset, nextScale / previousScale);
+
+        assertEquals(focus, contentAtFocus * nextScale - offset, 0.001f);
+    }
+
+    @Test public void anchoredOffsetIsUnchangedWhenScaleDoesNotChange() {
+        assertEquals(720f, WKPdfViewActivity.anchoredOffset(300f, 720f, 1f), 0.001f);
+    }
+
+    @Test public void clampBoundsValueToRange() {
+        assertEquals(5f, WKPdfViewActivity.clamp(-3f, 5f, 10f), 0f);
+        assertEquals(10f, WKPdfViewActivity.clamp(42f, 5f, 10f), 0f);
+        assertEquals(7f, WKPdfViewActivity.clamp(7f, 5f, 10f), 0f);
+    }
+}


### PR DESCRIPTION
## 问题

登录页点击「用户协议」/「隐私政策」进入阅读页后,双指放大只能上下滑动,无法左右滑动,超出屏幕的内容够不到。

## 原因

两个入口最终都进的同一个页面:

- `WKLoginActivity` / `WKRegisterActivity` 调用 `showWebView(WKApiConfig.termsUrl / privacyUrl)`
- 这两个 URL 配置的是 `.pdf`,`WKWebViewActivity` 检测到扩展名后转发给 `WKPdfViewActivity` 并结束自身
- 实际渲染方是 `WKPdfViewActivity`

该页的视图结构是 `ScrollView > LinearLayout(VERTICAL) > ImageView × N`,缩放通过 `container.setScaleX/setScaleY` 实现。问题出在两处:

1. `setScaleX/Y` 是绘制期的 View 变换,不改变 measure/layout 尺寸;
2. 外层是只支持竖向的 `ScrollView`,代码里没有任何 `HorizontalScrollView` 或平移手势。

所以放大后横向溢出的内容没有任何载体可以滑到。同样的原因,竖向也存在放大后底部有一截滑不到的问题(`ScrollView` 的滚动范围仍按未缩放的高度计算),只是不如横向明显。

另外原实现的缩放锚点 `pivotX = width/2`、`pivotY = focusY + scrollY` 每次事件都在变,缩放过程中内容会跳动。

## 改动

均在 `wkbase/src/main/java/com/chat/base/act/WKPdfViewActivity.java`:

- **缩放锚点固定到左上角**。内容只向右下方向溢出,横竖两个方向的可达范围都能干净地算出来;中心锚点会让两侧同时溢出,可平移范围无法计算。
- **新增横向平移**。在 `dispatchTouchEvent` 中单独跟踪横向位移并转成 `translationX`,按 `[0, width * (scale - 1)]` 钳制。事件照常向下传递,竖向仍由 `ScrollView` 消费,两者互不干扰。处理了 touchSlop 判定、缩放进行中不平移(但保持基准跟手)、多指抬起时切换跟踪指针。
- **修复放大后底部滑不到**。利用 `ScrollView.getScrollRange()` 会计入子 View margin 的特性,把放大多出来的高度补进 `container` 的 `bottomMargin`。
- **缩放锚定手势焦点**。放大时以两指中心为锚,内容不再整体往一侧窜。因 `bottomMargin` 触发的 layout 是异步的,`scrollTo` 会先被旧滚动范围钳制,故在下一帧补正一次。
- 顺带删除未使用的 `import android.graphics.Matrix`。

## 验证

- `./gradlew :wkbase:compileDebugJavaWithJavac` 通过。