### PR TITLE
fix(conv-list): 修复新设备登录后置顶会话需滑动才生效

### DIFF
--- a/wkuikit/src/main/java/com/chat/uikit/fragment/ChannelInfoWarmupState.java
+++ b/wkuikit/src/main/java/com/chat/uikit/fragment/ChannelInfoWarmupState.java
@@ -132,16 +132,17 @@ final class ChannelInfoWarmupState {
     /**
      * IO 线程扫描结果回到主线程。
      *
-     * @return {@code true} 表示可以开始发批次；{@code false} 表示本代已作废
-     *         （不改任何状态）或没有待办（已收链）。
+     * @return {@code true} 表示可以开始发批次；{@code false} 表示本代已作废，
+     *         或者没有待办 —— 后者调用方仍需走 {@link #finish(int)} 收链。
      */
     boolean onScanResult(int gen, @Nullable List<Target> scanned) {
         // 陈旧代际：running 归新一代所有，这里绝不能碰。
         if (isStale(gen)) return false;
         if (scanned == null || scanned.isEmpty()) {
-            running = false;
-            pending = null;
-            offset = 0;
+            // 空扫描同样是收链，但不在这里关闭：收链的唯一出口是 finish()，
+            // 只有它会消费 dirty。若在这里直接把 running 置回 false，本轮期间被
+            // 吞掉的 kickoff 就再也没人补 —— 下一次 tryBegin 会把 dirty 重置掉，
+            // 那条新会话只能干等下一次无关的 sortMsg。
             return false;
         }
         pending = new ArrayList<>(scanned);
@@ -156,10 +157,18 @@ final class ChannelInfoWarmupState {
         return !Objects.equals(spaceId, currentSpaceId);
     }
 
-    /** 中止本代（Fragment 不可用 / Space 变了）。陈旧代际调用是 no-op。 */
+    /**
+     * 中止本代（Fragment 不可用 / Space 变了）。陈旧代际调用是 no-op。
+     *
+     * <p>中止的语义就是「这一轮不要了」，所以显式丢弃 dirty ——「链已经不跑了、
+     * dirty 却还挂着」这种中间态一旦存在，下一次 {@link #tryBegin} 会把它悄悄
+     * 重置掉，等于又开了一条能漏掉 kickoff 的缝。不变式：dirty 只由
+     * {@link #finish(int)} 消费，由 abort / {@link #reset(boolean)} 丢弃。
+     */
     void abort(int gen) {
         if (isStale(gen)) return;
         running = false;
+        dirty = false;
         pending = null;
         offset = 0;
     }

--- a/wkuikit/src/main/java/com/chat/uikit/fragment/ChannelInfoWarmupState.java
+++ b/wkuikit/src/main/java/com/chat/uikit/fragment/ChannelInfoWarmupState.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.fragment;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * channelInfo 后台预热链的状态机（纯 Java，无 Android 依赖，可 JVM 单测）。
+ *
+ * <p>背景：会话行的置顶(top)、免打扰(mute)、名称、头像只存在于 channel 表，
+ * conversation/sync 不下发。新设备 / 清数据后登录时 channel 表是空的，原本唯一的
+ * 补齐时机是 adapter bind 里的 fetchChannelInfo —— 用户不滑到那一行就永远补不上。
+ * 预热链负责在列表装配完成后把缺失的 channel 分批拉回来。
+ *
+ * <p>本类只管「该不该发、发哪些、这一代还算不算数」，不碰线程、网络和 DB ——
+ * 那些留在 {@code ChatFragment}。这样把最容易写错的代际/取消语义单独隔离出来，
+ * 可以用单测锁死，而不是靠注释维持。
+ *
+ * <p><b>线程模型</b>：所有方法只在主线程调用。IO 线程只做「本地有没有这个 channel」
+ * 的扫描，扫完把结果通过 {@link #onScanResult} 交回主线程。
+ *
+ * <p><b>代际（generation）语义</b>：Space 切换 / 销毁时 {@link #reset} 自增代际，
+ * 让在途的链自然失效。<b>关键不变式：陈旧代际的回调绝不能清掉新代际的运行标志</b> ——
+ * {@link #onScanResult}、{@link #abort}、{@link #finish} 都以 {@link #isStale} 开头，
+ * 陈旧代际直接返回、不改任何状态。
+ */
+final class ChannelInfoWarmupState {
+
+    /** 预热目标：只带 channelID + channelType，不持有会话 / 频道对象，避免跨线程读写。 */
+    static final class Target {
+        final String channelID;
+        final byte channelType;
+
+        Target(String channelID, byte channelType) {
+            this.channelID = channelID;
+            this.channelType = channelType;
+        }
+
+        @NonNull
+        String key() {
+            return channelID + "_" + channelType;
+        }
+    }
+
+    private int generation = 0;
+    private boolean running = false;
+    /**
+     * 链运行期间被吞掉的 kickoff。收链时据此重起一轮，否则那段时间内新进列表的
+     * 会话（实时消息新建、增量合并）永远等不到预热 —— 默认 tab 上尤其严重，
+     * 因为 topChanged 分支走的是 filterAndDisplay，根本不会再调 kickoff。
+     */
+    private boolean dirty = false;
+    @Nullable
+    private String spaceId = null;
+    @Nullable
+    private List<Target> pending = null;
+    private int offset = 0;
+    /**
+     * 本 Space 内已发过请求的 channel key。kickoff 触发频率很高（预热拉回来的每个
+     * channel 都会触发 topChanged → sortMsg → kickoff），没有这个集合的话，永远
+     * 拉不到的 channel（已解散 / 无权限）会被反复请求。
+     */
+    private final Set<String> attempted = new HashSet<>();
+
+    int generation() {
+        return generation;
+    }
+
+    boolean isRunning() {
+        return running;
+    }
+
+    boolean isDirty() {
+        return dirty;
+    }
+
+    boolean isAttempted(String channelID, byte channelType) {
+        return attempted.contains(channelID + "_" + channelType);
+    }
+
+    int attemptedCount() {
+        return attempted.size();
+    }
+
+    /**
+     * 尝试开链。
+     *
+     * @return {@code true} 表示本次调用取得了链的所有权，调用方应当去做扫描；
+     *         {@code false} 表示已有链在跑，本次被记为 {@link #dirty}，
+     *         收链时会自动重起一轮。
+     */
+    boolean tryBegin(@Nullable String currentSpaceId) {
+        if (running) {
+            dirty = true;
+            return false;
+        }
+        running = true;
+        dirty = false;
+        spaceId = currentSpaceId;
+        pending = null;
+        offset = 0;
+        return true;
+    }
+
+    /** 代际是否已被 {@link #reset} 推进 —— 是则说明新一代已接管，本代应当噤声。 */
+    boolean isStale(int gen) {
+        return gen != generation;
+    }
+
+    /**
+     * IO 线程扫描结果回到主线程。
+     *
+     * @return {@code true} 表示可以开始发批次；{@code false} 表示本代已作废
+     *         （不改任何状态）或没有待办（已收链）。
+     */
+    boolean onScanResult(int gen, @Nullable List<Target> scanned) {
+        // 陈旧代际：running 归新一代所有，这里绝不能碰。
+        if (isStale(gen)) return false;
+        if (scanned == null || scanned.isEmpty()) {
+            running = false;
+            pending = null;
+            offset = 0;
+            return false;
+        }
+        pending = new ArrayList<>(scanned);
+        offset = 0;
+        return true;
+    }
+
+    /** 当前 Space 是否已不是开链时的那个。 */
+    boolean spaceChanged(@Nullable String currentSpaceId) {
+        // 注意：空 spaceId 是合法状态（无 Space 模式），不能当成「没有 Space 就不预热」，
+        // 只比较「是否还是开链时的那个 Space」。
+        return !Objects.equals(spaceId, currentSpaceId);
+    }
+
+    /** 中止本代（Fragment 不可用 / Space 变了）。陈旧代际调用是 no-op。 */
+    void abort(int gen) {
+        if (isStale(gen)) return;
+        running = false;
+        pending = null;
+        offset = 0;
+    }
+
+    /** 取下一批目标并推进游标；返回空列表表示已取完。 */
+    @NonNull
+    List<Target> nextBatch(int batchSize) {
+        if (pending == null || batchSize <= 0 || offset >= pending.size()) {
+            return Collections.emptyList();
+        }
+        int end = Math.min(offset + batchSize, pending.size());
+        List<Target> batch = new ArrayList<>(pending.subList(offset, end));
+        offset = end;
+        return batch;
+    }
+
+    /** 是否还有未发出的目标。 */
+    boolean hasMore() {
+        return pending != null && offset < pending.size();
+    }
+
+    void markAttempted(@NonNull Target target) {
+        attempted.add(target.key());
+    }
+
+    /**
+     * 收链。
+     *
+     * @return {@code true} 表示期间有被吞掉的 kickoff，调用方应当立即重起一轮。
+     *         因为 {@link #attempted} 会把已请求过的过滤掉，重起必然收敛而不会打转。
+     */
+    boolean finish(int gen) {
+        if (isStale(gen)) return false;
+        running = false;
+        pending = null;
+        offset = 0;
+        boolean wasDirty = dirty;
+        dirty = false;
+        return wasDirty;
+    }
+
+    /**
+     * 让在跑的链失效。
+     *
+     * @param clearAttempted Space 切换 / 重新联网传 {@code true} —— 允许对同一个
+     *                       channel 重新尝试；单纯销毁传 {@code false}。
+     */
+    void reset(boolean clearAttempted) {
+        generation++;
+        running = false;
+        dirty = false;
+        spaceId = null;
+        pending = null;
+        offset = 0;
+        if (clearAttempted) attempted.clear();
+    }
+
+    /**
+     * 只清「已请求过」记录，不打断在跑的链。
+     *
+     * <p>用于网络恢复：拉取失败没有任何回调信号（provider 对非子区频道传的是 null
+     * 回调，失败被静默吞掉），所以无法区分「永久失败」和「网络抖动」。连接恢复时清空，
+     * 让下一轮 kickoff 重新尝试；重试量受实际仍缺失的数量约束，不会放大。
+     */
+    void clearAttempted() {
+        attempted.clear();
+    }
+}

--- a/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
+++ b/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
@@ -2309,7 +2309,14 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
                 Log.w(TAG_WARMUP, "scan failed", e);
             }
             AndroidUtilities.runOnUIThread(() -> {
-                if (!warmupState.onScanResult(gen, pending)) return;
+                if (!warmupState.onScanResult(gen, pending)) {
+                    // 扫描结果为空同样是收链，必须走 finish 把期间被吞掉的 kickoff
+                    // 补回来。代际已作废时 finish 会被 isStale 挡掉，不会误重起。
+                    if (warmupState.finish(gen)) {
+                        kickoffChannelInfoWarmup();
+                    }
+                    return;
+                }
                 warmupNextBatch(gen);
             });
         });

--- a/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
+++ b/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
@@ -203,6 +203,32 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
     private final Handler filterDebounceHandler = new Handler(Looper.getMainLooper());
     private final Runnable filterRunnable = this::filterAndDisplayInternal;
     private static final long FILTER_DEBOUNCE_MS = 50L;
+
+    //  · setAllCount 的 150ms 合并刷新。
+    //
+    // setAllCount 自身会全表扫一遍 allConversations，内部还会调 computeFollowUnread
+    // 再扫一遍，每行都读 getWkChannel()。本地缺 channel 的行每次都会重进
+    // ChannelManager 慢路径（synchronized + 线性扫 + DB 点查，且缺失结果不进缓存），
+    // 所以在「新设备刚登录、大批 channel 陆续到达」时，逐条同步重算会把主线程压垮。
+    //
+    // 频道刷新监听是唯一的高频调用方（每个 channel 响应一次），改走合并入口：窗口内
+    // 的多次请求只实算一次。这样重算次数由时间窗口决定，而不再随响应条数线性增长
+    // —— 这是预热期间主线程不被压垮的关键（配套的批次节奏见 WARMUP_BATCH 注释）。
+    //
+    // 其余 14 处调用点保持同步不变 —— 像「点开会话后立刻清红点」这类路径需要即时生效。
+    private static final long SET_ALL_COUNT_DEBOUNCE_MS = 150L;
+    private boolean setAllCountPending = false;
+    private final Runnable setAllCountRunnable = () -> {
+        setAllCountPending = false;
+        setAllCount();
+    };
+
+    /** 合并版 {@link #setAllCount()}：窗口内多次调用只实算一次。 */
+    private void setAllCountDebounced() {
+        if (setAllCountPending) return;
+        setAllCountPending = true;
+        filterDebounceHandler.postDelayed(setAllCountRunnable, SET_ALL_COUNT_DEBOUNCE_MS);
+    }
     // 诊断：每 10s 汇总一次 filterAndDisplay 触发次数（Fix 6），便于 Yu / ReviewBot 观察
     // debounce 合并效果。
     private long lastFilterLogMs = 0;
@@ -219,36 +245,26 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
     // 这里在列表装配完成后启动一条后台链，分批把缺失的 channel 拉回来。拉回后走
     // 既有的 saveOrUpdateChannel → setRefreshChannel → 本类的刷新监听 → topChanged
     // → 重排链路自然收敛，不新增任何刷新路径；拉取失败就退化回原来的「滑到才拉」。
+    //
+    // 代际 / 取消 / 重起等易错语义抽到 ChannelInfoWarmupState（可 JVM 单测），
+    // 本类只负责线程、网络和生命周期。
     private static final String TAG_WARMUP = "ConvTopWarmup";
-    // 批次大小 / 间隔的取值理由：
-    // ① OkHttp 默认 maxRequestsPerHost=5（OkHttpUtils 没有自定义 Dispatcher），取 4 是为了
-    //    给用户主动触发的请求留一个槽位，不让预热把 host 并发占满。
-    // ② 每收到一个 channel 响应，刷新监听都会走一次 setAllCount() 全表扫。新设备上尚未
-    //    补齐的行每次都要重进 ChannelManager 慢路径，整体是 O(N²) 的主线程开销。放慢节奏
-    //    不减少总量，但把它摊平，避免首屏几秒内集中掉帧。
-    private static final int WARMUP_BATCH = 4;
-    private static final long WARMUP_INTERVAL_MS = 300L;
-    private int warmupGen = 0;
-    private boolean warmupRunning = false;
-    private String warmupSpaceId = null;
-    private List<WarmupTarget> warmupPending = null;
-    private int warmupOffset = 0;
-    // 本 Space 内已发过请求的 channel key。sortMsg 触发频率很高（预热拉回来的每个
-    // channel 都会触发 topChanged → sortMsg 再进来一次），没有这个集合的话，永远
-    // 拉不到的 channel（已解散 / 无权限）会在每次 sortMsg 被重复请求。
-    // Space 切换时清空，允许在新 Space 重新尝试。
-    private final Set<String> warmupAttempted = new HashSet<>();
-
-    /** 预热目标：只带 channelID + channelType，不持有会话 / 频道对象，避免跨线程读写。 */
-    private static final class WarmupTarget {
-        final String channelID;
-        final byte channelType;
-
-        WarmupTarget(String channelID, byte channelType) {
-            this.channelID = channelID;
-            this.channelType = channelType;
-        }
-    }
+    // 批次大小 / 间隔：8 个 / 200ms。
+    //
+    // 直觉上「拉慢一点更不容易卡」是错的 —— 在 setAllCount 已经按窗口合并之后，
+    // 全表重算的次数不再取决于响应条数，而取决于时间：
+    //     重算次数 ≈ 预热时长 / 合并窗口 = (N / 响应速率) / 窗口
+    //     主线程总工作量 ≈ N² / (响应速率 × 窗口)
+    // 也就是说「响应速率 × 窗口」越大越省：拉得越快，每个合并窗口能吸收的响应越多，
+    // 摊到每条响应的重算成本越低。把批次调慢反而会让每个窗口只吸收到寥寥几条，
+    // 总工作量不降反升。
+    //
+    // 另外真实响应速率还受服务端吞吐和 OkHttp 默认 maxRequestsPerHost=5 约束
+    // （OkHttpUtils 没有自定义 Dispatcher），客户端这边的节流只能把速率往下压、
+    // 压不上去 —— 所以压低是纯损失。
+    private static final int WARMUP_BATCH = 8;
+    private static final long WARMUP_INTERVAL_MS = 200L;
+    private final ChannelInfoWarmupState warmupState = new ChannelInfoWarmupState();
 
     /**
      *  · DiffUtil callback。
@@ -748,11 +764,13 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
                     } else {
                         sortMsg(allConversations);
                     }
-                    setAllCount();
+                    // 本回调在预热期间会被每个 channel 响应触发一次，走合并入口，
+                    // 避免逐条全表重算把主线程压垮（见 setAllCountDebounced 注释）。
+                    setAllCountDebounced();
                 } else {
                     refreshChannelInAdapter(followAdapter, channel);
                     refreshChannelInAdapter(recentAdapter, channel);
-                    setAllCount();
+                    setAllCountDebounced();
                 }
             }
         });
@@ -1204,6 +1222,11 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
                 connectedAtMs = System.currentTimeMillis();
                 // 立即触发第一次 ping，有真实数据后才显示信号栏
                 startPingTimer();
+                // 网络恢复：预热的拉取失败没有任何回调信号（provider 对非子区频道传的是
+                // null 回调，超时 / 5xx 被静默吞掉），所以「已尝试」集合无法区分永久失败
+                // （已解散 / 无权限）和网络抖动。而全新登录恰恰是网络最拥挤的时候。这里
+                // 清空让后续 kickoff 重新尝试；重试量受实际仍缺失的数量约束，不会放大。
+                warmupState.clearAttempted();
                 // 注册流程补偿：SDK 连接成功时如果列表仍为空（getChatMsg 的 sync 因连接未就绪而未触发），补一次 sync
                 // 必须等 DB 查询完成后再判断，否则查询还在飞行中会误判为空并 clearAll
                 String spaceId = MsgModel.getInstance().getCurrentSpaceId();
@@ -1470,11 +1493,7 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
             ChatConversationMsg item = source.get(i);
             if (item.isSectionHeader) continue;
             if (item.uiConversationMsg == null) continue;
-            // 取一次存局部变量：getWkChannel() 只在非 null 时回缓存，本地缺 channel 行的
-            // 会话每次调用都会重进 ChannelManager 慢路径（synchronized + 线性扫 + DB 查），
-            // 写两遍就查两遍库。本方法在每次 channel 刷新回调里都会全表跑一遍，是热路径。
-            WKChannel ch = item.uiConversationMsg.getWkChannel();
-            if (ch != null && ch.mute == 1)
+            if (item.uiConversationMsg.getWkChannel() != null && item.uiConversationMsg.getWkChannel().mute == 1)
                 continue;
             byte type = item.uiConversationMsg.channelType;
             if (type == WKChannelType.PERSONAL) {
@@ -1490,9 +1509,7 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
         // 子区未读（allThreadConversations 独立于 allConversations）
         for (ChatConversationMsg threadMsg : allThreadConversations) {
             if (threadMsg.uiConversationMsg == null) continue;
-            // 同上：取一次存局部变量，避免缺 channel 时重复走慢路径。
-            WKChannel threadCh = threadMsg.uiConversationMsg.getWkChannel();
-            if (threadCh != null && threadCh.mute == 1)
+            if (threadMsg.uiConversationMsg.getWkChannel() != null && threadMsg.uiConversationMsg.getWkChannel().mute == 1)
                 continue;
             long ts = threadMsg.uiConversationMsg.lastMsgTimestamp;
             if (ts <= 0) continue;
@@ -1517,9 +1534,7 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
                 ? chatConversationAdapter.getData() : allConversations;
         for (ChatConversationMsg item : source) {
             if (item.isSectionHeader || item.uiConversationMsg == null) continue;
-            // 同 setAllCount：取一次存局部变量，避免缺 channel 时重复走慢路径。
-            WKChannel ch = item.uiConversationMsg.getWkChannel();
-            if (ch != null && ch.mute == 1)
+            if (item.uiConversationMsg.getWkChannel() != null && item.uiConversationMsg.getWkChannel().mute == 1)
                 continue;
             String channelID = item.uiConversationMsg.channelID;
             byte channelType = item.uiConversationMsg.channelType;
@@ -1537,9 +1552,7 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
         long threeDaysAgoForFollow = System.currentTimeMillis() / 1000 - 3L * 24 * 60 * 60;
         for (ChatConversationMsg threadMsg : allThreadConversations) {
             if (threadMsg.uiConversationMsg == null) continue;
-            // 同上：取一次存局部变量，避免缺 channel 时重复走慢路径。
-            WKChannel threadCh = threadMsg.uiConversationMsg.getWkChannel();
-            if (threadCh != null && threadCh.mute == 1)
+            if (threadMsg.uiConversationMsg.getWkChannel() != null && threadMsg.uiConversationMsg.getWkChannel().mute == 1)
                 continue;
             long ts = threadMsg.uiConversationMsg.lastMsgTimestamp;
             if (ts <= 0 || ts <= threeDaysAgoForFollow) continue;
@@ -2091,6 +2104,10 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
         //  · 同步清 allConversations + conversationIndex
         clearAllConversations();
         allThreadConversations.clear();
+        // 会话集被整体清空重来，和 performSpaceSwitch 是同一种情况：在跑的预热链
+        // 拉的都是已经不在列表里的目标，必须让它失效，否则它会一直占着运行标志、
+        // 把重建后列表的 kickoff 全部吞掉。清 attempted 让重建后可以重新尝试。
+        resetChannelInfoWarmup(true);
         followAdapter.setList(new ArrayList<>());
         recentAdapter.setList(new ArrayList<>());
         //  · resync 也接入 coordinator 去重
@@ -2247,42 +2264,41 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
     }
 
     /**
-     * 启动 channelInfo 后台预热链（幂等）。
+     * 启动 channelInfo 后台预热链。
      *
      * <p>注意与 {@link #prewarmChannelInfoCache(List)} 的区别：那个只把 <b>本地已有</b>
      * 的 channel 从 DB 捞进内存 cache，省主线程 IO；本方法负责把 <b>本地根本没有</b>
      * 的 channel 从网络拉回来，是置顶 / 免打扰 / 名称在新设备上能否生效的关键。
      *
-     * <p>接入点只有 {@link #sortMsg(List)} 的 UI 收尾一处 —— 冷启动 getChatMsg、
-     * Space 切换、sync 完成重建三条路径最终都汇流到 sortMsg。
-     *
-     * <p>幂等（{@link #warmupRunning}）很关键：预热拉回 channel 会触发刷新监听里的
-     * topChanged 分支，那里又会调回 sortMsg。如果每次进来都重启链，链就会被自己
-     * 制造出来的刷新反复掐断，永远走不完。只有 Space 切换 / 销毁才通过自增
-     * {@link #warmupGen} 让在跑的链失效。
+     * <p>已有链在跑时不会重复开链 —— 预热拉回 channel 会触发刷新监听的 topChanged
+     * 分支回调 sortMsg，每次都重启的话链会被自己制造的刷新反复掐断。但这次调用会被
+     * {@link ChannelInfoWarmupState#tryBegin} 记为 dirty，收链时自动重起一轮，
+     * 保证链运行期间新进列表的会话不会被漏掉。
      */
     private void kickoffChannelInfoWarmup() {
-        if (warmupRunning) return;
         // 主线程只做无 IO 的快照，判空(要查 DB)挪到 IO 线程。
-        final List<WarmupTarget> snapshot = new ArrayList<>(allConversations.size());
+        final List<ChannelInfoWarmupState.Target> snapshot =
+                new ArrayList<>(allConversations.size());
         for (int i = 0, size = allConversations.size(); i < size; i++) {
             ChatConversationMsg m = allConversations.get(i);
             if (m == null || m.isSectionHeader || m.uiConversationMsg == null) continue;
             String id = m.uiConversationMsg.channelID;
             if (TextUtils.isEmpty(id)) continue;
             byte type = m.uiConversationMsg.channelType;
-            if (warmupAttempted.contains(channelKey(id, type))) continue;
-            snapshot.add(new WarmupTarget(id, type));
+            if (warmupState.isAttempted(id, type)) continue;
+            snapshot.add(new ChannelInfoWarmupState.Target(id, type));
         }
+        // 没有任何候选就别去打扰在跑的链（也不必置 dirty，本来就没活干）。
         if (snapshot.isEmpty()) return;
-        warmupRunning = true;
-        warmupSpaceId = MsgModel.getInstance().getCurrentSpaceId();
-        final int gen = warmupGen;
+        if (!warmupState.tryBegin(MsgModel.getInstance().getCurrentSpaceId())) return;
+        final int gen = warmupState.generation();
         Schedulers.io().scheduleDirect(() -> {
-            final List<WarmupTarget> pending = new ArrayList<>();
+            final List<ChannelInfoWarmupState.Target> pending = new ArrayList<>();
             try {
                 for (int i = 0, size = snapshot.size(); i < size; i++) {
-                    WarmupTarget t = snapshot.get(i);
+                    ChannelInfoWarmupState.Target t = snapshot.get(i);
+                    // 这里要的是「本地到底有没有」，必须走会查 DB 的 getChannel；
+                    // 在 IO 线程所以不阻塞主线程。
                     if (WKIM.getInstance().getChannelManager()
                             .getChannel(t.channelID, t.channelType) == null) {
                         pending.add(t);
@@ -2293,15 +2309,7 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
                 Log.w(TAG_WARMUP, "scan failed", e);
             }
             AndroidUtilities.runOnUIThread(() -> {
-                // gen 不匹配说明新一代已接管，warmupRunning 归新一代所有，这里不要动它。
-                if (gen != warmupGen) return;
-                if (pending.isEmpty()) {
-                    warmupRunning = false;
-                    warmupPending = null;
-                    return;
-                }
-                warmupPending = pending;
-                warmupOffset = 0;
+                if (!warmupState.onScanResult(gen, pending)) return;
                 warmupNextBatch(gen);
             });
         });
@@ -2312,72 +2320,51 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
      * {@link #WARMUP_INTERVAL_MS} 后递归下一拍。
      *
      * <p>下一拍是 lambda，{@code removeCallbacks} 拿不到引用，所以收链一律靠
-     * {@code gen} 判定 —— 与 Space 切换 / onDestroy 的自增配合。
+     * 代际判定 —— 与 Space 切换 / 视图销毁时的 {@code reset} 配合。
      */
     private void warmupNextBatch(int gen) {
-        // gen 不匹配说明新一代已接管，warmupRunning 归新一代所有，这里不要动它。
-        if (gen != warmupGen) return;
+        if (warmupState.isStale(gen)) return;
         if (!isAdded() || getActivity() == null) {
-            warmupRunning = false;
-            warmupPending = null;
+            warmupState.abort(gen);
             return;
         }
-        String currentSpaceId = MsgModel.getInstance().getCurrentSpaceId();
-        // 注意：这里不能像"空 spaceId 直接 return"那样处理 —— 本项目有无 Space 模式
-        // （见 getChatMsg 的第二个分支），空 spaceId 是合法状态，直接 return 会让
-        // 该模式永远不预热。只比较「是否还是启动这条链时的那个 Space」。
-        if (!TextUtils.equals(currentSpaceId, warmupSpaceId)) {
-            warmupRunning = false;
-            warmupPending = null;
+        if (warmupState.spaceChanged(MsgModel.getInstance().getCurrentSpaceId())) {
+            warmupState.abort(gen);
             return;
         }
-        if (warmupPending == null || warmupOffset >= warmupPending.size()) {
-            finishChannelInfoWarmup();
-            return;
-        }
-        int end = Math.min(warmupOffset + WARMUP_BATCH, warmupPending.size());
-        for (int i = warmupOffset; i < end; i++) {
-            WarmupTarget t = warmupPending.get(i);
+        for (ChannelInfoWarmupState.Target t : warmupState.nextBatch(WARMUP_BATCH)) {
             // 这一拍之前如果别的路径（用户滑到该行 / 推送 / 好友同步）已经把 channel
-            // 填上了，就跳过，避免重复请求。
+            // 填上了，就跳过，避免重复请求。这里刻意用只读内存缓存的版本：本方法在
+            // 主线程，而这些目标当初就是因为「本地没有」才入选的，走会查 DB 的
+            // getChannel 等于每拍在主线程做几次 SQLite 点查。返回 stale null 的唯一
+            // 代价是多发一个请求，划算。
             if (WKIM.getInstance().getChannelManager()
-                    .getChannel(t.channelID, t.channelType) != null) {
+                    .getChannelIfCached(t.channelID, t.channelType) != null) {
                 continue;
             }
-            warmupAttempted.add(channelKey(t.channelID, t.channelType));
+            warmupState.markAttempted(t);
             WKIM.getInstance().getChannelManager().fetchChannelInfo(t.channelID, t.channelType);
         }
-        warmupOffset = end;
-        if (warmupOffset >= warmupPending.size()) {
-            finishChannelInfoWarmup();
+        if (warmupState.hasMore()) {
+            pingHandler.postDelayed(() -> warmupNextBatch(gen), WARMUP_INTERVAL_MS);
             return;
         }
-        pingHandler.postDelayed(() -> warmupNextBatch(gen), WARMUP_INTERVAL_MS);
+        // 收链；期间若有被吞掉的 kickoff，立刻重起一轮。已请求过的会被 attempted
+        // 过滤掉，所以重起必然收敛（下一轮没有新候选时 snapshot 为空直接返回）。
+        if (warmupState.finish(gen)) {
+            kickoffChannelInfoWarmup();
+        }
     }
 
     /**
-     * 收链。不在这里主动重启：预热拉回来的 channel 会触发 topChanged → sortMsg →
-     * {@link #kickoffChannelInfoWarmup()}，此时 running 已置回 false，新会话
-     * （如果有）会在那一次自然被扫到，已请求过的则被 warmupAttempted 挡住。
-     */
-    private void finishChannelInfoWarmup() {
-        warmupRunning = false;
-        warmupPending = null;
-    }
-
-    /**
-     * 让在跑的预热链失效。Space 切换（会话集换了一批，旧链继续拉毫无意义）和
-     * onDestroy（Fragment 没了）都要调。
+     * 让在跑的预热链失效。Space 切换、整体重新同步（会话集换了一批，旧链继续拉毫无
+     * 意义）以及视图销毁都要调。
      *
-     * @param clearAttempted Space 切换传 true —— 新 Space 允许对同一个 channel 重新尝试；
-     *                       销毁传 false。
+     * @param clearAttempted Space 切换 / 重新同步传 true —— 允许对同一个 channel
+     *                       重新尝试；单纯销毁传 false。
      */
     private void resetChannelInfoWarmup(boolean clearAttempted) {
-        warmupGen++;
-        warmupRunning = false;
-        warmupPending = null;
-        warmupOffset = 0;
-        if (clearAttempted) warmupAttempted.clear();
+        warmupState.reset(clearAttempted);
     }
 
     /**
@@ -4541,7 +4528,9 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
         pingHandler.removeCallbacks(spaceResyncRunnable);
         //  · 清理 filterAndDisplay debounce handler，防止 Fragment 销毁后 Runnable 回调。
         filterDebounceHandler.removeCallbacks(filterRunnable);
-        // 预热链的下一拍是 lambda，removeCallbacks 拿不到引用，靠自增 gen 让它下次醒来自行收链。
+        filterDebounceHandler.removeCallbacks(setAllCountRunnable);
+        setAllCountPending = false;
+        // 预热链的下一拍是 lambda，removeCallbacks 拿不到引用，靠自增代际让它下次醒来自行收链。
         resetChannelInfoWarmup(false);
         stopPingTimer();
     }
@@ -4550,6 +4539,12 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
     public void onDestroyView() {
         super.onDestroyView();
         filterDebounceHandler.removeCallbacks(filterRunnable);
+        filterDebounceHandler.removeCallbacks(setAllCountRunnable);
+        setAllCountPending = false;
+        // 视图没了就停预热：isAdded() / getActivity() 对「view 已销毁但 fragment 还在」
+        // 的状态仍然为 true，不在这里收链的话，链会继续发请求并持有 fragment。
+        // 下一拍是 lambda、removeCallbacks 拿不到引用，所以靠自增代际让它醒来即退。
+        resetChannelInfoWarmup(false);
         FollowedKeysStore.getInstance().removeListener(followedKeysChangeListener);
     }
 

--- a/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
+++ b/wkuikit/src/main/java/com/chat/uikit/fragment/ChatFragment.java
@@ -209,6 +209,46 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
     private int filterCallCount = 0;
     private static final String TAG_FILTER = "ChatFragment.filter";
 
+    // ── channelInfo 后台预热 ────────────────────────────────────────────────
+    // 会话行的置顶(top)、免打扰(mute)、名称、头像全部只存在于 channel 表，
+    // conversation/sync 不下发这些字段。新设备 / 清数据后登录时 channel 表是空的，
+    // sortMsg 读 getWkChannel() 拿到 null，置顶会话就被当普通会话排，名字显示成
+    // 「聊天」占位。原本唯一的补齐时机是 adapter bind 里的 fetchChannelInfo，
+    // 所以用户不滑到那一行就永远补不上 —— 表现为「滑到哪条哪条才置顶」。
+    //
+    // 这里在列表装配完成后启动一条后台链，分批把缺失的 channel 拉回来。拉回后走
+    // 既有的 saveOrUpdateChannel → setRefreshChannel → 本类的刷新监听 → topChanged
+    // → 重排链路自然收敛，不新增任何刷新路径；拉取失败就退化回原来的「滑到才拉」。
+    private static final String TAG_WARMUP = "ConvTopWarmup";
+    // 批次大小 / 间隔的取值理由：
+    // ① OkHttp 默认 maxRequestsPerHost=5（OkHttpUtils 没有自定义 Dispatcher），取 4 是为了
+    //    给用户主动触发的请求留一个槽位，不让预热把 host 并发占满。
+    // ② 每收到一个 channel 响应，刷新监听都会走一次 setAllCount() 全表扫。新设备上尚未
+    //    补齐的行每次都要重进 ChannelManager 慢路径，整体是 O(N²) 的主线程开销。放慢节奏
+    //    不减少总量，但把它摊平，避免首屏几秒内集中掉帧。
+    private static final int WARMUP_BATCH = 4;
+    private static final long WARMUP_INTERVAL_MS = 300L;
+    private int warmupGen = 0;
+    private boolean warmupRunning = false;
+    private String warmupSpaceId = null;
+    private List<WarmupTarget> warmupPending = null;
+    private int warmupOffset = 0;
+    // 本 Space 内已发过请求的 channel key。sortMsg 触发频率很高（预热拉回来的每个
+    // channel 都会触发 topChanged → sortMsg 再进来一次），没有这个集合的话，永远
+    // 拉不到的 channel（已解散 / 无权限）会在每次 sortMsg 被重复请求。
+    // Space 切换时清空，允许在新 Space 重新尝试。
+    private final Set<String> warmupAttempted = new HashSet<>();
+
+    /** 预热目标：只带 channelID + channelType，不持有会话 / 频道对象，避免跨线程读写。 */
+    private static final class WarmupTarget {
+        final String channelID;
+        final byte channelType;
+
+        WarmupTarget(String channelID, byte channelType) {
+            this.channelID = channelID;
+            this.channelType = channelType;
+        }
+    }
 
     /**
      *  · DiffUtil callback。
@@ -1430,7 +1470,11 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
             ChatConversationMsg item = source.get(i);
             if (item.isSectionHeader) continue;
             if (item.uiConversationMsg == null) continue;
-            if (item.uiConversationMsg.getWkChannel() != null && item.uiConversationMsg.getWkChannel().mute == 1)
+            // 取一次存局部变量：getWkChannel() 只在非 null 时回缓存，本地缺 channel 行的
+            // 会话每次调用都会重进 ChannelManager 慢路径（synchronized + 线性扫 + DB 查），
+            // 写两遍就查两遍库。本方法在每次 channel 刷新回调里都会全表跑一遍，是热路径。
+            WKChannel ch = item.uiConversationMsg.getWkChannel();
+            if (ch != null && ch.mute == 1)
                 continue;
             byte type = item.uiConversationMsg.channelType;
             if (type == WKChannelType.PERSONAL) {
@@ -1446,7 +1490,9 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
         // 子区未读（allThreadConversations 独立于 allConversations）
         for (ChatConversationMsg threadMsg : allThreadConversations) {
             if (threadMsg.uiConversationMsg == null) continue;
-            if (threadMsg.uiConversationMsg.getWkChannel() != null && threadMsg.uiConversationMsg.getWkChannel().mute == 1)
+            // 同上：取一次存局部变量，避免缺 channel 时重复走慢路径。
+            WKChannel threadCh = threadMsg.uiConversationMsg.getWkChannel();
+            if (threadCh != null && threadCh.mute == 1)
                 continue;
             long ts = threadMsg.uiConversationMsg.lastMsgTimestamp;
             if (ts <= 0) continue;
@@ -1471,7 +1517,9 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
                 ? chatConversationAdapter.getData() : allConversations;
         for (ChatConversationMsg item : source) {
             if (item.isSectionHeader || item.uiConversationMsg == null) continue;
-            if (item.uiConversationMsg.getWkChannel() != null && item.uiConversationMsg.getWkChannel().mute == 1)
+            // 同 setAllCount：取一次存局部变量，避免缺 channel 时重复走慢路径。
+            WKChannel ch = item.uiConversationMsg.getWkChannel();
+            if (ch != null && ch.mute == 1)
                 continue;
             String channelID = item.uiConversationMsg.channelID;
             byte channelType = item.uiConversationMsg.channelType;
@@ -1489,7 +1537,9 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
         long threeDaysAgoForFollow = System.currentTimeMillis() / 1000 - 3L * 24 * 60 * 60;
         for (ChatConversationMsg threadMsg : allThreadConversations) {
             if (threadMsg.uiConversationMsg == null) continue;
-            if (threadMsg.uiConversationMsg.getWkChannel() != null && threadMsg.uiConversationMsg.getWkChannel().mute == 1)
+            // 同上：取一次存局部变量，避免缺 channel 时重复走慢路径。
+            WKChannel threadCh = threadMsg.uiConversationMsg.getWkChannel();
+            if (threadCh != null && threadCh.mute == 1)
                 continue;
             long ts = threadMsg.uiConversationMsg.lastMsgTimestamp;
             if (ts <= 0 || ts <= threeDaysAgoForFollow) continue;
@@ -2197,6 +2247,140 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
     }
 
     /**
+     * 启动 channelInfo 后台预热链（幂等）。
+     *
+     * <p>注意与 {@link #prewarmChannelInfoCache(List)} 的区别：那个只把 <b>本地已有</b>
+     * 的 channel 从 DB 捞进内存 cache，省主线程 IO；本方法负责把 <b>本地根本没有</b>
+     * 的 channel 从网络拉回来，是置顶 / 免打扰 / 名称在新设备上能否生效的关键。
+     *
+     * <p>接入点只有 {@link #sortMsg(List)} 的 UI 收尾一处 —— 冷启动 getChatMsg、
+     * Space 切换、sync 完成重建三条路径最终都汇流到 sortMsg。
+     *
+     * <p>幂等（{@link #warmupRunning}）很关键：预热拉回 channel 会触发刷新监听里的
+     * topChanged 分支，那里又会调回 sortMsg。如果每次进来都重启链，链就会被自己
+     * 制造出来的刷新反复掐断，永远走不完。只有 Space 切换 / 销毁才通过自增
+     * {@link #warmupGen} 让在跑的链失效。
+     */
+    private void kickoffChannelInfoWarmup() {
+        if (warmupRunning) return;
+        // 主线程只做无 IO 的快照，判空(要查 DB)挪到 IO 线程。
+        final List<WarmupTarget> snapshot = new ArrayList<>(allConversations.size());
+        for (int i = 0, size = allConversations.size(); i < size; i++) {
+            ChatConversationMsg m = allConversations.get(i);
+            if (m == null || m.isSectionHeader || m.uiConversationMsg == null) continue;
+            String id = m.uiConversationMsg.channelID;
+            if (TextUtils.isEmpty(id)) continue;
+            byte type = m.uiConversationMsg.channelType;
+            if (warmupAttempted.contains(channelKey(id, type))) continue;
+            snapshot.add(new WarmupTarget(id, type));
+        }
+        if (snapshot.isEmpty()) return;
+        warmupRunning = true;
+        warmupSpaceId = MsgModel.getInstance().getCurrentSpaceId();
+        final int gen = warmupGen;
+        Schedulers.io().scheduleDirect(() -> {
+            final List<WarmupTarget> pending = new ArrayList<>();
+            try {
+                for (int i = 0, size = snapshot.size(); i < size; i++) {
+                    WarmupTarget t = snapshot.get(i);
+                    if (WKIM.getInstance().getChannelManager()
+                            .getChannel(t.channelID, t.channelType) == null) {
+                        pending.add(t);
+                    }
+                }
+            } catch (Throwable e) {
+                // 扫描失败不影响列表显示，退化回「滑到才拉」。
+                Log.w(TAG_WARMUP, "scan failed", e);
+            }
+            AndroidUtilities.runOnUIThread(() -> {
+                // gen 不匹配说明新一代已接管，warmupRunning 归新一代所有，这里不要动它。
+                if (gen != warmupGen) return;
+                if (pending.isEmpty()) {
+                    warmupRunning = false;
+                    warmupPending = null;
+                    return;
+                }
+                warmupPending = pending;
+                warmupOffset = 0;
+                warmupNextBatch(gen);
+            });
+        });
+    }
+
+    /**
+     * 预热链的一拍：发出至多 {@link #WARMUP_BATCH} 个 fetchChannelInfo，然后
+     * {@link #WARMUP_INTERVAL_MS} 后递归下一拍。
+     *
+     * <p>下一拍是 lambda，{@code removeCallbacks} 拿不到引用，所以收链一律靠
+     * {@code gen} 判定 —— 与 Space 切换 / onDestroy 的自增配合。
+     */
+    private void warmupNextBatch(int gen) {
+        // gen 不匹配说明新一代已接管，warmupRunning 归新一代所有，这里不要动它。
+        if (gen != warmupGen) return;
+        if (!isAdded() || getActivity() == null) {
+            warmupRunning = false;
+            warmupPending = null;
+            return;
+        }
+        String currentSpaceId = MsgModel.getInstance().getCurrentSpaceId();
+        // 注意：这里不能像"空 spaceId 直接 return"那样处理 —— 本项目有无 Space 模式
+        // （见 getChatMsg 的第二个分支），空 spaceId 是合法状态，直接 return 会让
+        // 该模式永远不预热。只比较「是否还是启动这条链时的那个 Space」。
+        if (!TextUtils.equals(currentSpaceId, warmupSpaceId)) {
+            warmupRunning = false;
+            warmupPending = null;
+            return;
+        }
+        if (warmupPending == null || warmupOffset >= warmupPending.size()) {
+            finishChannelInfoWarmup();
+            return;
+        }
+        int end = Math.min(warmupOffset + WARMUP_BATCH, warmupPending.size());
+        for (int i = warmupOffset; i < end; i++) {
+            WarmupTarget t = warmupPending.get(i);
+            // 这一拍之前如果别的路径（用户滑到该行 / 推送 / 好友同步）已经把 channel
+            // 填上了，就跳过，避免重复请求。
+            if (WKIM.getInstance().getChannelManager()
+                    .getChannel(t.channelID, t.channelType) != null) {
+                continue;
+            }
+            warmupAttempted.add(channelKey(t.channelID, t.channelType));
+            WKIM.getInstance().getChannelManager().fetchChannelInfo(t.channelID, t.channelType);
+        }
+        warmupOffset = end;
+        if (warmupOffset >= warmupPending.size()) {
+            finishChannelInfoWarmup();
+            return;
+        }
+        pingHandler.postDelayed(() -> warmupNextBatch(gen), WARMUP_INTERVAL_MS);
+    }
+
+    /**
+     * 收链。不在这里主动重启：预热拉回来的 channel 会触发 topChanged → sortMsg →
+     * {@link #kickoffChannelInfoWarmup()}，此时 running 已置回 false，新会话
+     * （如果有）会在那一次自然被扫到，已请求过的则被 warmupAttempted 挡住。
+     */
+    private void finishChannelInfoWarmup() {
+        warmupRunning = false;
+        warmupPending = null;
+    }
+
+    /**
+     * 让在跑的预热链失效。Space 切换（会话集换了一批，旧链继续拉毫无意义）和
+     * onDestroy（Fragment 没了）都要调。
+     *
+     * @param clearAttempted Space 切换传 true —— 新 Space 允许对同一个 channel 重新尝试；
+     *                       销毁传 false。
+     */
+    private void resetChannelInfoWarmup(boolean clearAttempted) {
+        warmupGen++;
+        warmupRunning = false;
+        warmupPending = null;
+        warmupOffset = 0;
+        if (clearAttempted) warmupAttempted.clear();
+    }
+
+    /**
      *  Fix C · 本地兜底合成缺失的系统 Bot（botfather）占位会话。
      *
      * <p>背景：botfather 跨 Space 共享，但后端 sync 在某些 Space 下不返回其 conversation
@@ -2369,6 +2553,10 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
         MsgModel.getInstance().setCurrentSpaceId(space.space_id, space.name);
         setSpaceSwitcherText(space.name);
         updateSpaceAvatar(space.name);
+        // 会话集整体换了一批，旧 Space 的预热链继续拉没有意义；清 attempted 让同一个
+        // channel 在新 Space 允许重新尝试。放在 setCurrentSpaceId 之后、tryBegin 之前，
+        // 保证被 debounce 提前 return 的那条路径也已经把旧链停掉。
+        resetChannelInfoWarmup(true);
 
         SpaceModel.getInstance().invalidateMembersCache();
         CategoryModel.getInstance().invalidateCache();
@@ -2647,6 +2835,9 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
             //  · 首帧 sortMsg 完成：如果 Space 切换 overlay 还在（sync 回调可能
             // 稍后到，或用户侧首次 DB 命中先于 sync），立刻隐藏给用户即时反馈。
             hideSpaceSwitchOverlay();
+            // 列表已装配完成 → 把本地缺 channel 的会话在后台补齐，否则新设备上
+            // 置顶 / 免打扰 / 名称要等用户滑到那一行才生效。
+            kickoffChannelInfoWarmup();
             if (BuildConfig.DEBUG) {
                 Trace.endSection();
                 Log.d("YUJ312", "adapter-setList-final done size=" + yuj312T10Size
@@ -4350,6 +4541,8 @@ public class ChatFragment extends WKBaseFragment<FragChatConversationLayoutBindi
         pingHandler.removeCallbacks(spaceResyncRunnable);
         //  · 清理 filterAndDisplay debounce handler，防止 Fragment 销毁后 Runnable 回调。
         filterDebounceHandler.removeCallbacks(filterRunnable);
+        // 预热链的下一拍是 lambda，removeCallbacks 拿不到引用，靠自增 gen 让它下次醒来自行收链。
+        resetChannelInfoWarmup(false);
         stopPingTimer();
     }
 

--- a/wkuikit/src/test/java/com/chat/uikit/fragment/ChannelInfoWarmupStateTest.java
+++ b/wkuikit/src/test/java/com/chat/uikit/fragment/ChannelInfoWarmupStateTest.java
@@ -123,7 +123,29 @@ public class ChannelInfoWarmupStateTest {
         ChannelInfoWarmupState s = new ChannelInfoWarmupState();
         s.tryBegin("space-a");
         assertFalse(s.onScanResult(s.generation(), new ArrayList<>()));
-        assertFalse("没有待办应当直接收链，否则运行标志会永久卡住", s.isRunning());
+        assertFalse("空扫描后必须能收链，否则运行标志会永久卡住",
+                s.finish(s.generation()));
+        assertFalse(s.isRunning());
+    }
+
+    @Test
+    public void onScanResult_empty_stillReportsSwallowedKickoff() {
+        // 锁住调用点所依赖的契约：空扫描之后 finish() 仍然要能把被吞掉的 kickoff
+        // 上报出来。
+        //
+        // 注意这个用例抓不住它对应的那个缺陷 —— 缺陷在调用点：空扫描路径上
+        // 「onScanResult 返回 false 就直接 return」，压根没人调 finish()，dirty
+        // 于是烂在里面，下一次 tryBegin 再把它重置掉。状态机本身一直是对的。
+        // ChatFragment 是 Fragment，这条路径 JVM 单测覆盖不到，只能靠「收链的唯一
+        // 出口是 finish()」这个约定 + 本用例守住契约的另一半。
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.tryBegin("space-a");
+        s.tryBegin("space-a");   // 扫描期间新会话进来 → 被吞 → dirty
+
+        assertFalse(s.onScanResult(s.generation(), new ArrayList<>()));
+        assertTrue("空扫描后 finish 必须仍能上报被吞掉的 kickoff", s.finish(s.generation()));
+        assertFalse(s.isRunning());
+        assertFalse(s.isDirty());
     }
 
     @Test
@@ -131,6 +153,7 @@ public class ChannelInfoWarmupStateTest {
         ChannelInfoWarmupState s = new ChannelInfoWarmupState();
         s.tryBegin("space-a");
         assertFalse(s.onScanResult(s.generation(), null));
+        assertFalse(s.finish(s.generation()));
         assertFalse(s.isRunning());
     }
 
@@ -271,6 +294,22 @@ public class ChannelInfoWarmupStateTest {
         assertFalse(s.isRunning());
         assertFalse(s.hasMore());
         assertTrue("中止后应能重新开链", s.tryBegin("space-a"));
+    }
+
+    @Test
+    public void abort_discardsDirtyRatherThanLeavingItDangling() {
+        // 「链已经不跑了、dirty 却还挂着」这种中间态一旦存在，下一次 tryBegin 会把
+        // 它悄悄重置掉，等于又开一条能漏掉 kickoff 的缝。中止的语义就是这一轮不要了，
+        // 所以要显式丢弃。不变式：dirty 只由 finish 消费，由 abort / reset 丢弃。
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.tryBegin("space-a");
+        s.tryBegin("space-a");   // 被吞 → dirty
+        assertTrue(s.isDirty());
+
+        s.abort(s.generation());
+
+        assertFalse(s.isRunning());
+        assertFalse("中止应当丢弃 dirty，不留悬挂状态", s.isDirty());
     }
 
     // ── 端到端序列 ────────────────────────────────────────────────────────

--- a/wkuikit/src/test/java/com/chat/uikit/fragment/ChannelInfoWarmupStateTest.java
+++ b/wkuikit/src/test/java/com/chat/uikit/fragment/ChannelInfoWarmupStateTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.uikit.fragment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * {@link ChannelInfoWarmupState} 的单测。
+ *
+ * <p>重点锁死三件容易写错、且一旦写错就静默失效的事：
+ * <ul>
+ *   <li>陈旧代际的回调绝不能清掉新代际的运行标志（清掉 = 新链永远不会真正跑起来）</li>
+ *   <li>链运行期间被吞掉的 kickoff 必须在收链时补回来（否则那段时间新进的会话永远不预热）</li>
+ *   <li>重起必须收敛 —— attempted 过滤保证不会自己跟自己打转</li>
+ * </ul>
+ */
+public class ChannelInfoWarmupStateTest {
+
+    private static ChannelInfoWarmupState.Target target(String id) {
+        return new ChannelInfoWarmupState.Target(id, (byte) 1);
+    }
+
+    private static List<ChannelInfoWarmupState.Target> targets(String... ids) {
+        List<ChannelInfoWarmupState.Target> list = new ArrayList<>();
+        for (String id : ids) list.add(target(id));
+        return list;
+    }
+
+    // ── 开链 / 幂等 ────────────────────────────────────────────────────────
+
+    @Test
+    public void tryBegin_firstCallTakesOwnership() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        assertTrue(s.tryBegin("space-a"));
+        assertTrue(s.isRunning());
+        assertFalse(s.isDirty());
+    }
+
+    @Test
+    public void tryBegin_whileRunning_isRejectedAndMarksDirty() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        assertTrue(s.tryBegin("space-a"));
+
+        assertFalse(s.tryBegin("space-a"));
+        assertTrue("被吞掉的 kickoff 必须记为 dirty", s.isDirty());
+        assertTrue(s.isRunning());
+    }
+
+    // ── 代际语义（最关键的不变式）──────────────────────────────────────────
+
+    @Test
+    public void staleScanResult_doesNotClearNewGenerationRunningFlag() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.tryBegin("space-a");
+        int staleGen = s.generation();
+
+        // Space 切换：代际推进，旧链作废
+        s.reset(true);
+        assertFalse(s.isRunning());
+
+        // 新一代开链
+        assertTrue(s.tryBegin("space-b"));
+        int freshGen = s.generation();
+        assertNotEquals(staleGen, freshGen);
+        assertTrue(s.isRunning());
+
+        // 旧一代的 IO 扫描结果姗姗来迟 —— 必须完全无副作用
+        assertFalse(s.onScanResult(staleGen, targets("a", "b")));
+        assertTrue("陈旧代际不得清掉新代际的 running", s.isRunning());
+    }
+
+    @Test
+    public void staleAbortAndFinish_areNoOps() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.tryBegin("space-a");
+        int staleGen = s.generation();
+        s.reset(false);
+        s.tryBegin("space-b");
+
+        s.abort(staleGen);
+        assertTrue("陈旧代际 abort 不得影响新代际", s.isRunning());
+
+        assertFalse(s.finish(staleGen));
+        assertTrue("陈旧代际 finish 不得影响新代际", s.isRunning());
+    }
+
+    @Test
+    public void isStale_tracksGeneration() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        int gen = s.generation();
+        assertFalse(s.isStale(gen));
+        s.reset(false);
+        assertTrue(s.isStale(gen));
+    }
+
+    // ── 扫描结果 ──────────────────────────────────────────────────────────
+
+    @Test
+    public void onScanResult_empty_closesChain() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.tryBegin("space-a");
+        assertFalse(s.onScanResult(s.generation(), new ArrayList<>()));
+        assertFalse("没有待办应当直接收链，否则运行标志会永久卡住", s.isRunning());
+    }
+
+    @Test
+    public void onScanResult_null_closesChain() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.tryBegin("space-a");
+        assertFalse(s.onScanResult(s.generation(), null));
+        assertFalse(s.isRunning());
+    }
+
+    // ── 分批 ──────────────────────────────────────────────────────────────
+
+    @Test
+    public void nextBatch_walksThroughPendingThenReportsNoMore() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.tryBegin("space-a");
+        s.onScanResult(s.generation(), targets("a", "b", "c", "d", "e"));
+
+        List<ChannelInfoWarmupState.Target> first = s.nextBatch(2);
+        assertEquals(2, first.size());
+        assertEquals("a", first.get(0).channelID);
+        assertTrue(s.hasMore());
+
+        assertEquals(2, s.nextBatch(2).size());
+        assertTrue(s.hasMore());
+
+        List<ChannelInfoWarmupState.Target> last = s.nextBatch(2);
+        assertEquals("最后一批不足 batchSize 时只返回剩余的", 1, last.size());
+        assertEquals("e", last.get(0).channelID);
+        assertFalse(s.hasMore());
+        assertTrue(s.nextBatch(2).isEmpty());
+    }
+
+    @Test
+    public void nextBatch_withoutPending_isEmpty() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        assertTrue(s.nextBatch(4).isEmpty());
+        assertFalse(s.hasMore());
+    }
+
+    // ── 收链 / 重起 ───────────────────────────────────────────────────────
+
+    @Test
+    public void finish_withoutDirty_doesNotRequestRestart() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.tryBegin("space-a");
+        s.onScanResult(s.generation(), targets("a"));
+        s.nextBatch(4);
+
+        assertFalse(s.finish(s.generation()));
+        assertFalse(s.isRunning());
+    }
+
+    @Test
+    public void finish_withDirty_requestsRestartExactlyOnce() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.tryBegin("space-a");
+        s.onScanResult(s.generation(), targets("a"));
+        s.tryBegin("space-a");   // 被吞 → dirty
+        s.nextBatch(4);
+
+        assertTrue("链运行期间被吞掉的 kickoff 必须在收链时补回来", s.finish(s.generation()));
+        assertFalse(s.isRunning());
+        assertFalse("dirty 只应消费一次", s.isDirty());
+
+        // 重起后若无新候选，不应再次要求重起 —— 保证收敛
+        s.tryBegin("space-a");
+        s.onScanResult(s.generation(), targets("b"));
+        s.nextBatch(4);
+        assertFalse(s.finish(s.generation()));
+    }
+
+    // ── attempted 过滤 ────────────────────────────────────────────────────
+
+    @Test
+    public void markAttempted_isKeyedByIdAndType() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.markAttempted(new ChannelInfoWarmupState.Target("c1", (byte) 1));
+
+        assertTrue(s.isAttempted("c1", (byte) 1));
+        assertFalse("同 id 不同 type 是不同频道", s.isAttempted("c1", (byte) 2));
+        assertFalse(s.isAttempted("c2", (byte) 1));
+    }
+
+    @Test
+    public void reset_clearsAttemptedOnlyWhenAsked() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.markAttempted(target("c1"));
+
+        s.reset(false);
+        assertTrue("单纯销毁不应清掉已尝试记录", s.isAttempted("c1", (byte) 1));
+
+        s.reset(true);
+        assertFalse("Space 切换应允许重新尝试", s.isAttempted("c1", (byte) 1));
+        assertEquals(0, s.attemptedCount());
+    }
+
+    @Test
+    public void clearAttempted_doesNotInterruptRunningChain() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.tryBegin("space-a");
+        s.onScanResult(s.generation(), targets("a", "b"));
+        int gen = s.generation();
+        s.markAttempted(target("a"));
+
+        s.clearAttempted();
+
+        assertFalse(s.isAttempted("a", (byte) 1));
+        assertTrue("网络恢复清 attempted 不应打断在跑的链", s.isRunning());
+        assertFalse("也不应推进代际", s.isStale(gen));
+        assertTrue(s.hasMore());
+    }
+
+    // ── Space 语义 ────────────────────────────────────────────────────────
+
+    @Test
+    public void spaceChanged_comparesAgainstSpaceAtBegin() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.tryBegin("space-a");
+
+        assertFalse(s.spaceChanged("space-a"));
+        assertTrue(s.spaceChanged("space-b"));
+        assertTrue(s.spaceChanged(null));
+    }
+
+    @Test
+    public void spaceChanged_treatsNullSpaceAsLegitimate() {
+        // 无 Space 模式：开链时就是 null，之后仍是 null 就不算变化。
+        // 写成「空就 return」会让该模式永远不预热。
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.tryBegin(null);
+
+        assertFalse(s.spaceChanged(null));
+        assertTrue(s.spaceChanged("space-a"));
+    }
+
+    @Test
+    public void abort_stopsChainAndAllowsFreshBegin() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        s.tryBegin("space-a");
+        s.onScanResult(s.generation(), targets("a", "b", "c"));
+
+        s.abort(s.generation());
+
+        assertFalse(s.isRunning());
+        assertFalse(s.hasMore());
+        assertTrue("中止后应能重新开链", s.tryBegin("space-a"));
+    }
+
+    // ── 端到端序列 ────────────────────────────────────────────────────────
+
+    @Test
+    public void fullLifecycle_convergesWithoutSpinning() {
+        ChannelInfoWarmupState s = new ChannelInfoWarmupState();
+        List<String> fetched = new ArrayList<>();
+
+        assertTrue(s.tryBegin("space-a"));
+        s.onScanResult(s.generation(), targets("a", "b", "c"));
+        // 链跑到一半时来了新会话 → kickoff 被吞
+        assertFalse(s.tryBegin("space-a"));
+
+        while (s.hasMore()) {
+            for (ChannelInfoWarmupState.Target t : s.nextBatch(2)) {
+                s.markAttempted(t);
+                fetched.add(t.channelID);
+            }
+        }
+        assertEquals(Arrays.asList("a", "b", "c"), fetched);
+
+        // 收链要求重起，第二轮把新会话补上
+        assertTrue(s.finish(s.generation()));
+        assertTrue(s.tryBegin("space-a"));
+        s.onScanResult(s.generation(), targets("d"));
+        for (ChannelInfoWarmupState.Target t : s.nextBatch(2)) {
+            s.markAttempted(t);
+            fetched.add(t.channelID);
+        }
+        assertFalse("第二轮没有再被吞的 kickoff，不应无限重起", s.finish(s.generation()));
+        assertEquals(Arrays.asList("a", "b", "c", "d"), fetched);
+        assertEquals(4, s.attemptedCount());
+    }
+}


### PR DESCRIPTION
Closes #145

## 问题

新设备（或清数据后）登录，已设置置顶的会话在列表里不生效；下滑到该会话时它才突然变成置顶并跳到顶部。

群聊和非好友单聊必现，好友单聊由 `syncFriends` 兜住所以大多看不出来。

## 根因

置顶标记 `top` 存在 **channel 表**，不在会话表：

1. 排序读的是 `getWkChannel().top`（`ChatFragment.sortMsg` 与 `buildRecentDisplayList`）。
2. `getWkChannel()` 只查内存 cache + 本地 DB，**永不发网络**（`WKUIConversationMsg:56-61` → `ChannelManager.getChannelSlowPath`）。新设备 channel 表为空 → 返回 null → 一律按未置顶排。
3. `/conversation/sync` 的响应 DTO `WKSyncRecent` 没有 top/mute/name 字段，会话同步补不了这些。
4. 已有的 `prewarmChannelInfoCache` 调的是 `getChannel()`（本地），只为省主线程 DB 查询，不负责补数据。
5. 唯一的网络拉取点在 adapter bind 里的 `fetchChannelInfo`（`ChatConversationAdapter` 的 4 处）—— 所以「滑到哪条哪条才置顶」。
6. 全局唯一批量写 channel 的地方是 `FriendModel.syncFriends`（带 `top`），**只覆盖好友单聊**；群聊没有任何批量 channel 同步（`GroupModel.getMyGroups` 不写 channel 表）。

同一根因还会让新设备首屏的头像/名称空白（`ChatConversationAdapter` 里同一个 null 分支显示「聊天」占位）。

## 方案

在列表装配完成后启动一条后台预热链，分批把本地缺失的 channel 拉回来。

拉回后走**既有**的 `saveOrUpdateChannel → setRefreshChannel → 刷新监听 → topChanged → 重排`链路收敛，**不新增任何刷新路径**；拉取失败就退化回原来的「滑到才拉」，不构成回归。

接入点只有 `sortMsg` 的 UI 收尾一处 —— 冷启动 `getChatMsg`、Space 切换、sync 完成重建三条路径最终都汇流到这里。

### 几个关键约束（都写进了代码注释）

- **幂等（`warmupRunning`）**：预热拉回 channel 会触发 `topChanged` 分支回调 `sortMsg`，不做幂等的话，链会被自己制造出来的刷新反复掐断，永远走不完。只有 Space 切换 / `onDestroy` 才通过自增 `warmupGen` 让在跑的链失效。
- **`warmupAttempted`**：`sortMsg` 触发频率很高，没有这个集合的话，永远拉不到的 channel（已解散 / 无权限）会在每次 `sortMsg` 被重复请求。Space 切换时清空，允许在新 Space 重新尝试。
- **空 spaceId 是合法状态**：本项目有无 Space 模式（`getChatMsg` 的第二个分支），守卫比较的是「是否还是启动这条链时的那个 Space」，不能写成「空就 return」，否则该模式永远不预热。
- **子区（`COMMUNITY_TOPIC`）不纳入**：其 channelInfo provider 走 `ThreadModel.getThreadDetail`，从不设置 `top`，纳入只会让请求量翻倍；子区名称/预览已有 `preloadAllThreadData` + `threadDataCache` 覆盖。

### 顺带处理预热带来的主线程压力

每个 channel 响应都会触发 `setAllCount()` 全表扫，而缺 channel 的行每次都会重进 `ChannelManager` 慢路径（`synchronized` + `CopyOnWriteArrayList` 线性扫 + SQLite 查询，且**没有负缓存**），整体是 O(N²)。这段开销本来就存在，原先靠用户滑动摊开、感知不到，预热会把它压缩成突发，所以一并处理：

- `setAllCount` / `computeFollowUnread` 的 4 处循环，把 `getWkChannel()` 从一行调两次改为取一次存局部变量。**语义等价**：非 null 时会回缓存返回同一实例；首次为 null 时原写法因短路本就不会调第二次。
- 预热批次从 `8 个/200ms` 调整为 `4 个/300ms`。取 4 是给用户主动触发的请求留一个 OkHttp host 并发槽位（`OkHttpUtils` 没有自定义 Dispatcher，走默认 `maxRequestsPerHost=5`）；放慢不减少总量，但把峰值摊平。

代价是预热收敛变慢，**不影响正确性** —— 用户滑到的行仍由 adapter bind 立即拉取，预热只兜屏幕外的行。

## 改动范围

单文件 `wkuikit/.../ChatFragment.java`，+197 / -4。那 4 行删除就是上面 `getWkChannel()` 去重被替换的既有行，除此之外全是新增，没有改动任何既有分支逻辑。

## 验证

- 真机（vivo V2464A）清数据后全新登录，**首屏不滑动**，置顶会话可自动生效，不再需要滑到该行才置顶。
- `:wkuikit` 编译通过，模块单测通过。