### PR TITLE
feat(summary): 新增群总结完成提示

### DIFF
--- a/wkbase/src/main/java/com/chat/base/msg/ChatAdapter.java
+++ b/wkbase/src/main/java/com/chat/base/msg/ChatAdapter.java
@@ -209,6 +209,9 @@ public class ChatAdapter extends BaseProviderMultiAdapter<WKUIChatMsgItemEntity>
         if (list.get(i).wkMsg.type == WKContentType.screenshot) {
             return WKContentType.screenshot;
         }
+        if (list.get(i).wkMsg.type == WKContentType.summaryNotify) {
+            return WKContentType.summaryNotify;
+        }
         return WKContentType.unknown_msg;
     }
 

--- a/wkbase/src/main/java/com/chat/base/msgitem/WKChatBaseProvider.kt
+++ b/wkbase/src/main/java/com/chat/base/msgitem/WKChatBaseProvider.kt
@@ -645,6 +645,7 @@ abstract class WKChatBaseProvider : BaseItemProvider<WKUIChatMsgItemEntity>() {
         }
         if (previousMsg != null && !TextUtils.isEmpty(previousMsg.fromUID)
             && previousMsg.type != WKContentType.screenshot
+            && previousMsg.type != WKContentType.summaryNotify
             && previousMsg.remoteExtra.revoke == 0 && !WKContentType.isSystemMsg(previousMsg.type)
         ) {
             prevUID = previousMsg.fromUID

--- a/wkbase/src/main/java/com/chat/base/msgitem/WKContentType.java
+++ b/wkbase/src/main/java/com/chat/base/msgitem/WKContentType.java
@@ -76,8 +76,24 @@ public class WKContentType extends WKMsgContentType {
     public final static int approveGroupMember = 1009;
     //截屏消息
     public final static int screenshot = 20;
+    /**
+     * 群总结完成提示（对齐 octo-web MessageContentTypeConst.summaryNotify）。
+     * <p>content 形如 {@code {from_uid, from_name}}，不在 1000-2000 系统号段内，
+     * 需要像 {@link #screenshot} 一样单独注册 provider 才能当系统提示渲染。
+     * <p>Web 自 octo-web d31a10c3 起改用 WK_TIP(2000) 发新消息（2000 走
+     * {@code isSystemMsg()} 通用路径，无需适配），此类型仅用于渲染存量历史消息。
+     */
+    public final static int summaryNotify = 21;
     //子区创建通知
     public final static int threadCreated = 1100;
+    /**
+     * 群总结完成提示（WK_TIP 号段，对齐 octo-web MessageContentTypeConst.summaryTip）。
+     * <p>content 形如 {@code {content:"{0}总结了群聊内容", extra:[{uid,name}]}}，落在
+     * 1000-2000 系统号段内，收端由 WKSystemProvider + StringUtils.getShowContent()
+     * 通用路径渲染，无需单独注册 provider；此常量供发送侧构造消息体使用。
+     * @see #summaryNotify 已废弃的自定义 type-21 旧协议
+     */
+    public final static int summaryTip = 2000;
 
     public static boolean isSystemMsg(int type) {
         return type >= 1000 && type <= 2000;

--- a/wkbase/src/main/java/com/chat/base/msgitem/WKMsgItemViewManager.java
+++ b/wkbase/src/main/java/com/chat/base/msgitem/WKMsgItemViewManager.java
@@ -56,6 +56,8 @@ public class WKMsgItemViewManager {
             }
             // 截屏消息（type=20）当作系统提示显示
             chatItemProviderList.put(WKContentType.screenshot, new WKScreenshotProvider());
+            // 群总结完成提示（type=21，Web 端发送）当作系统提示显示
+            chatItemProviderList.put(WKContentType.summaryNotify, new WKSummaryNotifyProvider());
         }
         chatItemProviderList.put(type, itemProvider);
         // 置顶消息的itemProvider
@@ -72,6 +74,7 @@ public class WKMsgItemViewManager {
                 pinnedChatItemProviderList.put(i, new WKSystemProvider(i));
             }
             pinnedChatItemProviderList.put(WKContentType.screenshot, new WKScreenshotProvider());
+            pinnedChatItemProviderList.put(WKContentType.summaryNotify, new WKSummaryNotifyProvider());
         }
         try {
             Object myObject = itemProvider.getClass().newInstance();

--- a/wkbase/src/main/java/com/chat/base/msgitem/WKSummaryNotifyProvider.kt
+++ b/wkbase/src/main/java/com/chat/base/msgitem/WKSummaryNotifyProvider.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chat.base.msgitem
+
+import android.content.Context
+import android.text.SpannableString
+import android.text.TextUtils
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import com.chad.library.adapter.base.viewholder.BaseViewHolder
+import com.chat.base.R
+import com.chat.base.config.WKConfig
+import com.chat.base.msg.ChatAdapter
+import com.chat.base.ui.components.SystemMsgBackgroundColorSpan
+import com.chat.base.utils.AndroidUtilities
+import com.xinbida.wukongim.entity.WKMsg
+import org.json.JSONObject
+
+/**
+ * 群总结完成提示 (type=21) 的系统提示渲染, 对齐 octo-web SummaryNotifyCell。
+ *
+ * 该类型由 Web 端在总结任务完成时发往来源群, content 形如
+ * `{from_uid, from_name}`, 不在 1000-2000 系统号段内 —— 未适配前会被
+ * [ChatAdapter.getItemType] 降级成 unknown_msg(-3) 显示 "未知消息"。
+ *
+ * 实现照搬 [WKScreenshotProvider]: 复用 chat_system_layout 居中灰底提示,
+ * 且刻意不调 addLongClick() —— 系统提示不该有长按菜单 (转发/回复/创建子区
+ * 对一条提示都不成立)。
+ *
+ * Web 自 octo-web d31a10c3 起改用 WK_TIP(2000) 发新消息, 2000 走
+ * [WKSystemProvider] 通用路径无需适配, 本 provider 只负责存量历史消息。
+ */
+class WKSummaryNotifyProvider : WKChatBaseProvider() {
+    override fun getChatViewItem(parentView: ViewGroup, from: WKChatIteMsgFromType): View? {
+        return null
+    }
+
+    override fun setData(
+        adapterPosition: Int,
+        parentView: View,
+        uiChatMsgItemEntity: WKUIChatMsgItemEntity,
+        from: WKChatIteMsgFromType
+    ) {
+    }
+
+    override val itemViewType: Int
+        get() = WKContentType.summaryNotify
+
+    override val layoutId: Int
+        get() = R.layout.chat_system_layout
+
+    override fun convert(helper: BaseViewHolder, item: WKUIChatMsgItemEntity) {
+        super.convert(helper, item)
+        helper.getView<View>(R.id.systemRootView).setOnClickListener {
+            val chatAdapter = getAdapter() as ChatAdapter
+            chatAdapter.conversationContext.hideSoftKeyboard()
+        }
+        val textView = helper.getView<TextView>(R.id.contentTv)
+        val content = showSummaryTip(context, item.wkMsg)
+        textView.setShadowLayer(AndroidUtilities.dp(5f).toFloat(), 0f, 0f, 0)
+        val str = SpannableString(content)
+        str.setSpan(
+            SystemMsgBackgroundColorSpan(
+                ContextCompat.getColor(context, R.color.colorSystemBg),
+                AndroidUtilities.dp(5f),
+                AndroidUtilities.dp((2 * 5).toFloat())
+            ), 0, content.length, 0
+        )
+        textView.text = str
+    }
+
+    companion object {
+        /**
+         * 生成 "xxx总结了群聊内容" 文案。聊天页气泡与会话列表预览共用一份,
+         * 沿用 [WKRevokeProvider.showRevokeMsg] 的既有模式。
+         */
+        @JvmStatic
+        fun showSummaryTip(context: Context, msg: WKMsg): String {
+            return String.format(context.getString(R.string.summary_notify_tip), resolveName(context, msg))
+        }
+
+        /**
+         * 显示名优先级: 前四级复用 [WKChatBaseProvider.setFromName] 的群内显示名口径,
+         * 末两级对齐 Web SummaryNotifyContent.tipForSender()。
+         *
+         * from_name 排在本地资料之后 —— 与 Web 注释同口径: 身份以信封 uid 为准,
+         * from_name 只是本地资料拿不到时的尽力兜底。
+         */
+        private fun resolveName(context: Context, msg: WKMsg): String {
+            if (!TextUtils.isEmpty(msg.fromUID) && msg.fromUID == WKConfig.getInstance().uid) {
+                return context.getString(R.string.summary_notify_you)
+            }
+            var name = msg.from?.channelRemark
+            if (TextUtils.isEmpty(name)) {
+                name = msg.memberOfFrom?.remark
+            }
+            if (TextUtils.isEmpty(name)) {
+                name = msg.memberOfFrom?.memberRemark
+            }
+            if (TextUtils.isEmpty(name)) {
+                name = msg.from?.channelName
+            }
+            if (TextUtils.isEmpty(name)) {
+                name = msg.memberOfFrom?.memberName
+            }
+            if (TextUtils.isEmpty(name)) {
+                name = fromNameOf(msg.content)
+            }
+            return if (TextUtils.isEmpty(name)) {
+                context.getString(R.string.summary_notify_unknown)
+            } else {
+                name!!
+            }
+        }
+
+        private fun fromNameOf(contentJson: String?): String {
+            if (TextUtils.isEmpty(contentJson)) return ""
+            return try {
+                JSONObject(contentJson!!).optString("from_name", "")
+            } catch (_: Exception) {
+                ""
+            }
+        }
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/msgitem/WKSystemProvider.kt
+++ b/wkbase/src/main/java/com/chat/base/msgitem/WKSystemProvider.kt
@@ -56,8 +56,14 @@ class WKSystemProvider(val type: Int) : WKChatBaseProvider() {
             chatAdapter.conversationContext.hideSoftKeyboard()
         }
         val textView = helper.getView<TextView>(R.id.contentTv)
-        val content: String? = if (type == WKContentType.msgPromptTime) item.wkMsg.content else {
-            getShowContent(item.wkMsg.content)
+        val content: String? = when (type) {
+            WKContentType.msgPromptTime -> item.wkMsg.content
+            // 总结提示不走通用的"uid==自己显示你"替换 —— 无论是不是本机自己发起的,
+            // 群里都要显示发起人姓名本身, 见 SummaryTipContent.resolveDisplayContent。
+            WKContentType.summaryTip ->
+                com.chat.base.summary.notify.SummaryTipContent.resolveDisplayContent(item.wkMsg.content)
+                    ?: getShowContent(item.wkMsg.content)
+            else -> getShowContent(item.wkMsg.content)
         }
         textView.setShadowLayer(AndroidUtilities.dp(5f).toFloat(), 0f, 0f, 0)
         val str = SpannableString(content)

--- a/wkbase/src/main/java/com/chat/base/summary/api/SummaryApiService.kt
+++ b/wkbase/src/main/java/com/chat/base/summary/api/SummaryApiService.kt
@@ -48,6 +48,9 @@ interface SummaryApiService {
     @GET("summaries/{id}")
     suspend fun getSummaryDetail(@Path("id") taskId: Long): Response<JSONObject>
 
+    @GET("summaries/{id}")
+    suspend fun getSummaryDetailByNo(@Path("id", encoded = true) taskNo: String): Response<JSONObject>
+
     @DELETE("summaries/{id}")
     suspend fun deleteSummary(@Path("id") taskId: Long): Response<JSONObject>
 

--- a/wkbase/src/main/java/com/chat/base/summary/model/SummaryModels.kt
+++ b/wkbase/src/main/java/com/chat/base/summary/model/SummaryModels.kt
@@ -313,6 +313,8 @@ data class SummaryDetail(
     val result: SummaryResult?,
     val errorMessage: String?,
     val scheduleId: Long?,
+    /** 创建者 uid. 群总结完成提示只由创建者所在端发出, 见 SummaryNotifyCoordinator. */
+    val creatorId: String?,
     val originChannelId: String?,
     val originChannelType: Int,
     val createdAt: String?,
@@ -341,6 +343,11 @@ data class SummaryDetail(
                 result = SummaryResult.fromJson(json.objOf("result")),
                 errorMessage = json.nstrOf("error_message"),
                 scheduleId = (schedRaw as? Number)?.toLong(),
+                // creator_id 在后端契约里是可选的 (对齐 octo-web types/summary.ts 的
+                // `creator_id?: string`)。fastjson 的 getString 对缺失 key 返回 null 而非
+                // 抛异常, 所以 nstrOf 天然降级成 null —— 缺字段只会让"谁创建谁发提示"
+                // 退化成不发, 不影响详情页加载。
+                creatorId = json.nstrOf("creator_id"),
                 originChannelId = json.nstrOf("origin_channel_id"),
                 originChannelType = json.intOf("origin_channel_type"),
                 createdAt = json.nstrOf("created_at"),

--- a/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyCoordinator.kt
+++ b/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyCoordinator.kt
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.base.summary.notify
+
+import com.chat.base.config.WKConfig
+import com.chat.base.msgitem.WKContentType
+import com.chat.base.summary.SummaryDeps
+import com.chat.base.summary.model.SourceType
+import com.chat.base.summary.model.SummaryDetail
+import com.chat.base.summary.model.TaskStatus
+import com.chat.base.summary.repository.SummaryRepository
+import com.xinbida.wukongim.WKIM
+import com.xinbida.wukongim.entity.WKChannel
+import com.xinbida.wukongim.entity.WKChannelType
+import com.xinbida.wukongim.utils.DateUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * 群总结完成后往来源群发一条系统提示, 补上 "App 发起的总结群里没有任何提示" 这个缺口。
+ *
+ * ## 为什么是客户端发, 以及它的代价
+ *
+ * 这条提示在 octo-web 里是**客户端发**的 (SummaryDetailPage.notifyGroupsOnCompletion →
+ * WKSDK.chatManager.send), 服务端不参与。Web 只在总结详情页挂载着、且亲眼看到
+ * processing→completed 状态沿时才发 —— 所以 App 发起的总结, 只要用户没在 Web 上打开
+ * 那条总结的详情页, 群里就一条提示都没有。本类补的就是这个缺口。
+ *
+ * **这与项目其它同类场景的做法不一致**: 子区创建 (type=1100)、群成员变更 (1002/1003)
+ * 都是客户端调 REST、由服务端往频道发系统消息, 去重责任在服务端。本类是这个代码库里
+ * 第一例 "多端可能同时产生同一条消息, 靠客户端自行协调"。之所以这么做, 是因为当前既
+ * 改不了 Web 也排不上后端。**后端一旦支持在任务完成时直接下发这条提示, 本类应整个删除。**
+ *
+ * ## 不变量: 谁创建, 谁负责发
+ *
+ * [SummaryNotifyStore] 只登记**本机发起**的任务 (创建 / 重新生成), 加上 [handleCompleted]
+ * 里的 `creatorId == 自己` 双保险。绝对不要改成 "启动时把自己创建的所有在途任务都跟上" ——
+ * 那样多台设备会同时跟同一条任务, 必然重复。
+ *
+ * ## 与 Web 的重复怎么防
+ *
+ * 去重账本存在各端本地 (Web 在 localStorage, 这里在 SP), 互相看不见, 所以没法靠账本
+ * 协调。但**提示本身就是一条落库的群消息, 两端都看得见** —— 用频道当共享状态:
+ * 观测到完成后先等 [PEER_TIP_GRACE_MILLIS], 再查本地库看这个群里是不是已经有本人发出的
+ * 总结提示了; 有就不发。
+ *
+ * 延时取 8s 的依据 (Web 从任务完成到消息落到本机的耗时):
+ *   - SSE 推送路径 (按人总结): 亚秒级
+ *   - 列表页 2s 轮询广播: ≤2s
+ *   - 详情页兜底轮询: 5s 延迟启动 + 15s 间隔, 最坏 ~17s  ← **不覆盖**
+ * 再叠加本类 [POLL_INTERVAL_MILLIS]=10s 的轮询本身就比 Web 晚 0~10s 发现完成, 实际
+ * 判定点落在完成后 8~18s, 前两条主路径留了足够余量。第三条长尾 (只开详情页 + 非按人
+ * 模式 + 同一总结手机也发起了) 概率极低, 接受偶发重复。
+ *
+ * 这是概率性防护不是锁: 两端的"检查"和"发送"之间没有原子性。Android 单方面做不到消除,
+ * 消除需要 Web 也遵守某种协议 (例如只发本浏览器创建的任务) 或干脆由服务端下发。
+ */
+object SummaryNotifyCoordinator {
+
+    // TODO(排查完成后删除): 临时诊断日志, 定位"停在群聊页面也不发提示"这个问题
+    // 具体卡在 handleCompleted 的哪一步。
+    private const val TAG = "SummaryNotify"
+
+    /** 轮询在途任务的间隔。比 Web 慢一拍是刻意的, 见类注释里的延时依据。 */
+    private const val POLL_INTERVAL_MILLIS = 10_000L
+
+    /** 观测到完成后, 留给 Web 的提示送达本机的宽限期。 */
+    private const val PEER_TIP_GRACE_MILLIS = 8_000L
+
+    /** 扫描频道内提示消息的条数上限。提示很稀疏, 20 条足够覆盖回溯窗口。 */
+    private const val PEER_TIP_SCAN_LIMIT = 20
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val repository: SummaryRepository get() = SummaryDeps.repository
+
+    private var loopJob: Job? = null
+
+    /**
+     * [track] 在写完 SP 之后置位, [pollLoop] 在读 SP 之前清位。
+     *
+     * 这个顺序保证了 "loop 正要因为 pending 空而退出" 与 "track 刚登记了新任务" 撞车时,
+     * loop 一定能看到置位从而不退出 —— 否则新登记的任务会永远没人轮询。
+     */
+    private val pendingChanged = AtomicBoolean(false)
+
+    /** 正在处理完成事件的 taskId, 防止同一任务被并发处理两次。 */
+    private val handling: MutableSet<Long> = Collections.newSetFromMap(ConcurrentHashMap())
+
+    /**
+     * 应用启动时调一次, 从 SP 恢复上次没跟完的任务 (进程被杀过)。幂等。
+     *
+     * 未登录时 [pollLoop] 会立刻退出, 登录后由 [track] 再拉起, 所以不需要监听登录态。
+     */
+    @JvmStatic
+    fun start() {
+        ensureLoopRunning()
+    }
+
+    /** 本机发起了一次总结 (创建 / 重新生成) 时登记。见类注释里的"谁创建谁发"不变量。 */
+    @JvmStatic
+    fun track(taskId: Long) {
+        if (taskId <= 0L) return
+        android.util.Log.i(TAG, "track taskId=$taskId")
+        SummaryNotifyStore.addPending(taskId, System.currentTimeMillis())
+        pendingChanged.set(true)
+        ensureLoopRunning()
+    }
+
+    @Synchronized
+    private fun ensureLoopRunning() {
+        if (loopJob?.isActive == true) return
+        loopJob = scope.launch { pollLoop() }
+    }
+
+    /**
+     * 尝试结束轮询循环。返回 true 表示调用方可以安全退出。
+     *
+     * "判定该退出"和"清掉 loopJob"必须在同一个临界区里完成, 否则有这条竞态:
+     * 循环判定 pending 为空决定退出 → [track] 抢在 loopJob 被清掉之前调
+     * [ensureLoopRunning], 看到 job 还 active 于是 no-op → 循环退出并清掉 job →
+     * 新登记的任务永远没人轮询。把 [pendingChanged] 的检查也挪进锁内就没有这个窗口了。
+     *
+     * 不需要 finally 兜底清 loopJob: [ensureLoopRunning] 判的是 `isActive`, 循环若因
+     * 异常终止, 那个 job 已经 inactive, 下次 track 会正常重启。
+     */
+    @Synchronized
+    private fun finishLoopIfIdle(): Boolean {
+        if (pendingChanged.get()) return false
+        loopJob = null
+        return true
+    }
+
+    private suspend fun pollLoop() {
+        android.util.Log.i(TAG, "pollLoop started")
+        while (currentCoroutineContext().isActive) {
+            pendingChanged.set(false)
+
+            // 未登录: 停掉循环, 登录后由 track 拉起。SP 键按 uid 隔离, 不会串账。
+            if (WKConfig.getInstance().uid.isNullOrEmpty()) {
+                android.util.Log.i(TAG, "pollLoop: not logged in, idling")
+                if (finishLoopIfIdle()) return
+                delay(POLL_INTERVAL_MILLIS)
+                continue
+            }
+
+            val pending = SummaryNotifyStore.activePendingTaskIds(System.currentTimeMillis())
+            android.util.Log.i(TAG, "pollLoop tick pending=$pending")
+            if (pending.isEmpty()) {
+                if (finishLoopIfIdle()) return
+                delay(POLL_INTERVAL_MILLIS)
+                continue
+            }
+
+            val batch = repository.batchStatus(pending)
+            android.util.Log.i(TAG, "batchStatus result=$batch")
+            batch.getOrNull()?.forEach { item ->
+                when (item.status) {
+                    TaskStatus.Completed -> {
+                        android.util.Log.i(TAG, "taskId=${item.taskId} completed, handling")
+                        // 先摘出 pending 再异步处理: 处理链路里有 8s 等待, 不能占着轮询。
+                        SummaryNotifyStore.removePending(item.taskId)
+                        launchCompletionHandling(item.taskId)
+                    }
+                    TaskStatus.Failed, TaskStatus.Cancelled -> {
+                        android.util.Log.i(TAG, "taskId=${item.taskId} terminal status=${item.status}, dropping")
+                        SummaryNotifyStore.removePending(item.taskId)
+                    }
+                    else -> Unit
+                }
+            }
+
+            delay(POLL_INTERVAL_MILLIS)
+        }
+    }
+
+    private fun launchCompletionHandling(taskId: Long) {
+        if (!handling.add(taskId)) return
+        scope.launch {
+            try {
+                handleCompleted(taskId)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                // 结构化并发: cancel 信号必须往上传, 不能当成"一条提示发失败"吞掉。
+                throw e
+            } catch (_: Throwable) {
+                // 提示是尽力而为: 其余异常都只损失一条提示, 不能影响轮询循环。
+            } finally {
+                handling.remove(taskId)
+            }
+        }
+    }
+
+    private suspend fun handleCompleted(taskId: Long) {
+        val uid = WKConfig.getInstance().uid.orEmpty()
+        if (uid.isEmpty()) {
+            android.util.Log.i(TAG, "handleCompleted taskId=$taskId: no uid, abort")
+            return
+        }
+
+        val detailResult = repository.getSummaryDetail(taskId)
+        android.util.Log.i(TAG, "handleCompleted taskId=$taskId: detail=$detailResult")
+        val detail = detailResult.getOrNull() ?: return
+        android.util.Log.i(
+            TAG,
+            "handleCompleted taskId=$taskId: creatorId=${detail.creatorId} uid=$uid " +
+                "sources=${detail.sources} originChannelId=${detail.originChannelId} " +
+                "originChannelType=${detail.originChannelType}",
+        )
+        // 双保险: SP 只登记本机发起的任务, 这里再按服务端权威字段确认一次创建者身份。
+        // creatorId 缺失时按"不是我"处理 —— 宁可漏发。
+        if (detail.creatorId.isNullOrEmpty() || detail.creatorId != uid) {
+            android.util.Log.i(TAG, "handleCompleted taskId=$taskId: creatorId mismatch, abort")
+            return
+        }
+
+        val channels = groupSourceIds(detail)
+        android.util.Log.i(TAG, "handleCompleted taskId=$taskId: groupChannels=$channels")
+        if (channels.isEmpty()) return
+
+        val notified = SummaryNotifyStore.notifiedChannels(taskId)
+        val targets = channels.filterNot { notified.contains(it) }
+        android.util.Log.i(TAG, "handleCompleted taskId=$taskId: notified=$notified targets=$targets")
+        if (targets.isEmpty()) return
+
+        // 宽限期只等一次, 不是每个群各等一次 —— 多群来源时不该把提示拖成 N × 8s。
+        // "开始等待"这一刻的时间戳是 peerTipExists 的判定基准, 见该函数注释里的踩坑记录。
+        val waitStartedAtSeconds = DateUtils.getInstance().currentSeconds
+        delay(PEER_TIP_GRACE_MILLIS)
+
+        val name = selfDisplayName(uid)
+        for (channelId in targets) {
+            if (peerTipExists(channelId, uid, waitStartedAtSeconds)) {
+                android.util.Log.i(TAG, "handleCompleted taskId=$taskId channel=$channelId: peer tip exists, skip")
+                // Web 已经发过了。同样记账, 免得下次任务重试时又白等一轮宽限期。
+                SummaryNotifyStore.markNotified(taskId, channelId)
+                continue
+            }
+            android.util.Log.i(TAG, "handleCompleted taskId=$taskId channel=$channelId: sending, name=$name")
+            // claim-before-send: 先记账再发。SDK 的 send 是 fire-and-forget (void, 无回调),
+            // 拿不到发送结果, 所以没有回滚 —— 与"宁可漏发也不重发"的取舍一致。
+            SummaryNotifyStore.markNotified(taskId, channelId)
+            WKIM.getInstance().msgManager.send(
+                SummaryTipContent(uid, name),
+                WKChannel(channelId, WKChannelType.GROUP),
+            )
+        }
+    }
+
+    /**
+     * 这个群里是不是已经有本人发出的总结提示了 —— 只看**宽限期等待开始之后**才出现的。
+     *
+     * 同时匹配 [WKContentType.summaryTip] (2000, 新) 与 [WKContentType.summaryNotify]
+     * (21, Web 旧版本), 因为线上 Web 可能还没升到 2000。
+     *
+     * ## 踩过的坑: 曾经用固定回溯窗口 (10 分钟), 把"自己上一次总结"当成了"Web 抢发"
+     *
+     * 提示消息体里**不带 task_id**, 只能按 (频道 + 发送人 + 类型 + 时间) 匹配, 天生无法
+     * 区分"这条提示属于哪次总结"。固定回溯窗口的问题: 连续对同一个群做两次总结, 只要
+     * 间隔小于窗口, 第二次的检查会把第一次自己发的提示误判成"Web 已经发过了", 直接跳过
+     * 发送 —— 真机复现: 两次总结间隔 94 秒, 10 分钟窗口下第二条被吞。
+     *
+     * 改成以 [waitStartedAtSeconds] (进入宽限期那一刻的时间戳) 为下界: 宽限期开始之前
+     * 就存在的消息 (不管是自己上次发的还是 Web 更早发的) 一律不算数, 只有等待期间
+     * **新出现**的才可能是 Web 这次抢发的。
+     *
+     * 仍然无法区分"宽限期内新出现的这条是不是恰好也是自己另一台设备刚发的" —— 但那本来
+     * 就是 [SummaryNotifyStore] 记账要防的范畴, 不是本函数的职责; 本函数只负责"和 Web
+     * 撞车"这一种情况。
+     */
+    private fun peerTipExists(channelId: String, uid: String, waitStartedAtSeconds: Long): Boolean {
+        val msgs = WKIM.getInstance().msgManager.searchMsgWithChannelAndContentTypes(
+            channelId,
+            WKChannelType.GROUP,
+            0,
+            PEER_TIP_SCAN_LIMIT,
+            intArrayOf(WKContentType.summaryTip, WKContentType.summaryNotify),
+        ) ?: return false
+        return msgs.any { it != null && it.fromUID == uid && it.timestamp >= waitStartedAtSeconds }
+    }
+
+    /** 对齐 octo-web collectGroupSourceIds(): 群聊来源; sources 为空时退回 origin channel。 */
+    private fun groupSourceIds(detail: SummaryDetail): List<String> {
+        val ids = LinkedHashSet<String>()
+        for (source in detail.sources) {
+            if (source.sourceType != SourceType.GroupChat) continue
+            source.sourceId.trim().takeIf { it.isNotEmpty() }?.let(ids::add)
+        }
+        if (detail.sources.isEmpty() && detail.originChannelType == SourceType.GroupChat.raw) {
+            detail.originChannelId?.trim()?.takeIf { it.isNotEmpty() }?.let(ids::add)
+        }
+        return ids.toList()
+    }
+
+    /**
+     * 写进提示消息体的显示名, 对齐 Web 的 selfDisplayName() || name || uid。
+     *
+     * 收端优先用本地资料渲染 (见 WKSummaryNotifyProvider), 这里的名字只是本地资料
+     * 缺失时的兜底, 所以不必追求精确。
+     */
+    private fun selfDisplayName(uid: String): String {
+        val fromUserInfo = WKConfig.getInstance().userInfo?.name?.trim()
+        if (!fromUserInfo.isNullOrEmpty()) return fromUserInfo
+        val fromConfig = WKConfig.getInstance().userName?.trim()
+        if (!fromConfig.isNullOrEmpty()) return fromConfig
+        return uid
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyCoordinator.kt
+++ b/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyCoordinator.kt
@@ -11,7 +11,6 @@
 package com.chat.base.summary.notify
 
 import com.chat.base.config.WKConfig
-import com.chat.base.msgitem.WKContentType
 import com.chat.base.summary.SummaryDeps
 import com.chat.base.summary.model.SourceType
 import com.chat.base.summary.model.SummaryDetail
@@ -20,7 +19,6 @@ import com.chat.base.summary.repository.SummaryRepository
 import com.xinbida.wukongim.WKIM
 import com.xinbida.wukongim.entity.WKChannel
 import com.xinbida.wukongim.entity.WKChannelType
-import com.xinbida.wukongim.utils.DateUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -54,38 +52,21 @@ import java.util.concurrent.atomic.AtomicBoolean
  * 里的 `creatorId == 自己` 双保险。绝对不要改成 "启动时把自己创建的所有在途任务都跟上" ——
  * 那样多台设备会同时跟同一条任务, 必然重复。
  *
- * ## 与 Web 的重复怎么防
+ * ## 与 Web 的重复: 当前不做防护
  *
- * 去重账本存在各端本地 (Web 在 localStorage, 这里在 SP), 互相看不见, 所以没法靠账本
- * 协调。但**提示本身就是一条落库的群消息, 两端都看得见** —— 用频道当共享状态:
- * 观测到完成后先等 [PEER_TIP_GRACE_MILLIS], 再查本地库看这个群里是不是已经有本人发出的
- * 总结提示了; 有就不发。
+ * 完成即发, 不等待、不检查频道内是否已有 Web 发出的同款提示。
  *
- * 延时取 8s 的依据 (Web 从任务完成到消息落到本机的耗时):
- *   - SSE 推送路径 (按人总结): 亚秒级
- *   - 列表页 2s 轮询广播: ≤2s
- *   - 详情页兜底轮询: 5s 延迟启动 + 15s 间隔, 最坏 ~17s  ← **不覆盖**
- * 再叠加本类 [POLL_INTERVAL_MILLIS]=10s 的轮询本身就比 Web 晚 0~10s 发现完成, 实际
- * 判定点落在完成后 8~18s, 前两条主路径留了足够余量。第三条长尾 (只开详情页 + 非按人
- * 模式 + 同一总结手机也发起了) 概率极低, 接受偶发重复。
- *
- * 这是概率性防护不是锁: 两端的"检查"和"发送"之间没有原子性。Android 单方面做不到消除,
- * 消除需要 Web 也遵守某种协议 (例如只发本浏览器创建的任务) 或干脆由服务端下发。
+ * 代价: 手机发起总结 + Web 同时开着这条总结的详情页停留到完成, 两端都会各发一条,
+ * 群里出现两条一样的提示。这是已知且当前接受的取舍 —— 曾经实现过"等 8s 宽限期 +
+ * 查本地库确认 Web 没抢发"的门禁 (2721d832), 但去重判断天生不精确 (提示消息体不带
+ * task_id, 只能按频道+发送人+时间窗匹配), 真机复现过它把"自己上一次总结的提示"
+ * 误判成"Web 已经发过", 平白吞掉一条本该发的提示。两害相权, 选择了更简单可预测的
+ * "完成即发", 接受偶发的跨端重复。
  */
 object SummaryNotifyCoordinator {
 
-    // TODO(排查完成后删除): 临时诊断日志, 定位"停在群聊页面也不发提示"这个问题
-    // 具体卡在 handleCompleted 的哪一步。
-    private const val TAG = "SummaryNotify"
-
-    /** 轮询在途任务的间隔。比 Web 慢一拍是刻意的, 见类注释里的延时依据。 */
+    /** 轮询在途任务的间隔。 */
     private const val POLL_INTERVAL_MILLIS = 10_000L
-
-    /** 观测到完成后, 留给 Web 的提示送达本机的宽限期。 */
-    private const val PEER_TIP_GRACE_MILLIS = 8_000L
-
-    /** 扫描频道内提示消息的条数上限。提示很稀疏, 20 条足够覆盖回溯窗口。 */
-    private const val PEER_TIP_SCAN_LIMIT = 20
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -118,7 +99,6 @@ object SummaryNotifyCoordinator {
     @JvmStatic
     fun track(taskId: Long) {
         if (taskId <= 0L) return
-        android.util.Log.i(TAG, "track taskId=$taskId")
         SummaryNotifyStore.addPending(taskId, System.currentTimeMillis())
         pendingChanged.set(true)
         ensureLoopRunning()
@@ -149,20 +129,17 @@ object SummaryNotifyCoordinator {
     }
 
     private suspend fun pollLoop() {
-        android.util.Log.i(TAG, "pollLoop started")
         while (currentCoroutineContext().isActive) {
             pendingChanged.set(false)
 
             // 未登录: 停掉循环, 登录后由 track 拉起。SP 键按 uid 隔离, 不会串账。
             if (WKConfig.getInstance().uid.isNullOrEmpty()) {
-                android.util.Log.i(TAG, "pollLoop: not logged in, idling")
                 if (finishLoopIfIdle()) return
                 delay(POLL_INTERVAL_MILLIS)
                 continue
             }
 
             val pending = SummaryNotifyStore.activePendingTaskIds(System.currentTimeMillis())
-            android.util.Log.i(TAG, "pollLoop tick pending=$pending")
             if (pending.isEmpty()) {
                 if (finishLoopIfIdle()) return
                 delay(POLL_INTERVAL_MILLIS)
@@ -170,17 +147,14 @@ object SummaryNotifyCoordinator {
             }
 
             val batch = repository.batchStatus(pending)
-            android.util.Log.i(TAG, "batchStatus result=$batch")
             batch.getOrNull()?.forEach { item ->
                 when (item.status) {
                     TaskStatus.Completed -> {
-                        android.util.Log.i(TAG, "taskId=${item.taskId} completed, handling")
-                        // 先摘出 pending 再异步处理: 处理链路里有 8s 等待, 不能占着轮询。
+                        // 先摘出 pending 再异步处理: 结果未知前不占着轮询继续跑。
                         SummaryNotifyStore.removePending(item.taskId)
                         launchCompletionHandling(item.taskId)
                     }
                     TaskStatus.Failed, TaskStatus.Cancelled -> {
-                        android.util.Log.i(TAG, "taskId=${item.taskId} terminal status=${item.status}, dropping")
                         SummaryNotifyStore.removePending(item.taskId)
                     }
                     else -> Unit
@@ -210,49 +184,26 @@ object SummaryNotifyCoordinator {
     private suspend fun handleCompleted(taskId: Long) {
         val uid = WKConfig.getInstance().uid.orEmpty()
         if (uid.isEmpty()) {
-            android.util.Log.i(TAG, "handleCompleted taskId=$taskId: no uid, abort")
             return
         }
 
         val detailResult = repository.getSummaryDetail(taskId)
-        android.util.Log.i(TAG, "handleCompleted taskId=$taskId: detail=$detailResult")
         val detail = detailResult.getOrNull() ?: return
-        android.util.Log.i(
-            TAG,
-            "handleCompleted taskId=$taskId: creatorId=${detail.creatorId} uid=$uid " +
-                "sources=${detail.sources} originChannelId=${detail.originChannelId} " +
-                "originChannelType=${detail.originChannelType}",
-        )
         // 双保险: SP 只登记本机发起的任务, 这里再按服务端权威字段确认一次创建者身份。
         // creatorId 缺失时按"不是我"处理 —— 宁可漏发。
         if (detail.creatorId.isNullOrEmpty() || detail.creatorId != uid) {
-            android.util.Log.i(TAG, "handleCompleted taskId=$taskId: creatorId mismatch, abort")
             return
         }
 
         val channels = groupSourceIds(detail)
-        android.util.Log.i(TAG, "handleCompleted taskId=$taskId: groupChannels=$channels")
         if (channels.isEmpty()) return
 
         val notified = SummaryNotifyStore.notifiedChannels(taskId)
         val targets = channels.filterNot { notified.contains(it) }
-        android.util.Log.i(TAG, "handleCompleted taskId=$taskId: notified=$notified targets=$targets")
         if (targets.isEmpty()) return
-
-        // 宽限期只等一次, 不是每个群各等一次 —— 多群来源时不该把提示拖成 N × 8s。
-        // "开始等待"这一刻的时间戳是 peerTipExists 的判定基准, 见该函数注释里的踩坑记录。
-        val waitStartedAtSeconds = DateUtils.getInstance().currentSeconds
-        delay(PEER_TIP_GRACE_MILLIS)
 
         val name = selfDisplayName(uid)
         for (channelId in targets) {
-            if (peerTipExists(channelId, uid, waitStartedAtSeconds)) {
-                android.util.Log.i(TAG, "handleCompleted taskId=$taskId channel=$channelId: peer tip exists, skip")
-                // Web 已经发过了。同样记账, 免得下次任务重试时又白等一轮宽限期。
-                SummaryNotifyStore.markNotified(taskId, channelId)
-                continue
-            }
-            android.util.Log.i(TAG, "handleCompleted taskId=$taskId channel=$channelId: sending, name=$name")
             // claim-before-send: 先记账再发。SDK 的 send 是 fire-and-forget (void, 无回调),
             // 拿不到发送结果, 所以没有回滚 —— 与"宁可漏发也不重发"的取舍一致。
             SummaryNotifyStore.markNotified(taskId, channelId)
@@ -261,38 +212,6 @@ object SummaryNotifyCoordinator {
                 WKChannel(channelId, WKChannelType.GROUP),
             )
         }
-    }
-
-    /**
-     * 这个群里是不是已经有本人发出的总结提示了 —— 只看**宽限期等待开始之后**才出现的。
-     *
-     * 同时匹配 [WKContentType.summaryTip] (2000, 新) 与 [WKContentType.summaryNotify]
-     * (21, Web 旧版本), 因为线上 Web 可能还没升到 2000。
-     *
-     * ## 踩过的坑: 曾经用固定回溯窗口 (10 分钟), 把"自己上一次总结"当成了"Web 抢发"
-     *
-     * 提示消息体里**不带 task_id**, 只能按 (频道 + 发送人 + 类型 + 时间) 匹配, 天生无法
-     * 区分"这条提示属于哪次总结"。固定回溯窗口的问题: 连续对同一个群做两次总结, 只要
-     * 间隔小于窗口, 第二次的检查会把第一次自己发的提示误判成"Web 已经发过了", 直接跳过
-     * 发送 —— 真机复现: 两次总结间隔 94 秒, 10 分钟窗口下第二条被吞。
-     *
-     * 改成以 [waitStartedAtSeconds] (进入宽限期那一刻的时间戳) 为下界: 宽限期开始之前
-     * 就存在的消息 (不管是自己上次发的还是 Web 更早发的) 一律不算数, 只有等待期间
-     * **新出现**的才可能是 Web 这次抢发的。
-     *
-     * 仍然无法区分"宽限期内新出现的这条是不是恰好也是自己另一台设备刚发的" —— 但那本来
-     * 就是 [SummaryNotifyStore] 记账要防的范畴, 不是本函数的职责; 本函数只负责"和 Web
-     * 撞车"这一种情况。
-     */
-    private fun peerTipExists(channelId: String, uid: String, waitStartedAtSeconds: Long): Boolean {
-        val msgs = WKIM.getInstance().msgManager.searchMsgWithChannelAndContentTypes(
-            channelId,
-            WKChannelType.GROUP,
-            0,
-            PEER_TIP_SCAN_LIMIT,
-            intArrayOf(WKContentType.summaryTip, WKContentType.summaryNotify),
-        ) ?: return false
-        return msgs.any { it != null && it.fromUID == uid && it.timestamp >= waitStartedAtSeconds }
     }
 
     /** 对齐 octo-web collectGroupSourceIds(): 群聊来源; sources 为空时退回 origin channel。 */

--- a/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyCoordinator.kt
+++ b/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyCoordinator.kt
@@ -10,211 +10,185 @@
 
 package com.chat.base.summary.notify
 
+import android.net.Uri
 import com.chat.base.config.WKConfig
-import com.chat.base.summary.SummaryDeps
 import com.chat.base.summary.model.SourceType
 import com.chat.base.summary.model.SummaryDetail
 import com.chat.base.summary.model.TaskStatus
-import com.chat.base.summary.repository.SummaryRepository
 import com.xinbida.wukongim.WKIM
 import com.xinbida.wukongim.entity.WKChannel
 import com.xinbida.wukongim.entity.WKChannelType
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import java.util.Collections
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * 群总结完成后往来源群发一条系统提示, 补上 "App 发起的总结群里没有任何提示" 这个缺口。
  *
- * ## 为什么是客户端发, 以及它的代价
+ * ## 触发方式: 挂在详情页自身的轮询节奏上, 不用独立常驻协程
  *
- * 这条提示在 octo-web 里是**客户端发**的 (SummaryDetailPage.notifyGroupsOnCompletion →
- * WKSDK.chatManager.send), 服务端不参与。Web 只在总结详情页挂载着、且亲眼看到
- * processing→completed 状态沿时才发 —— 所以 App 发起的总结, 只要用户没在 Web 上打开
- * 那条总结的详情页, 群里就一条提示都没有。本类补的就是这个缺口。
+ * 由 [com.chat.uikit.summary.detail.SmartSummaryDetailViewModel] 自身已有的 8s 轮询
+ * (`loadDetail`/`schedulePollIfNeeded`) 在观测到 "非完成 → Completed" 状态跃变时调
+ * [notifyIfNeeded]。通知助手卡片的 "/s/STxxx?sp=..." 深链点击也会在打开 WebView 前
+ * 做一次同样的判定。
  *
- * **这与项目其它同类场景的做法不一致**: 子区创建 (type=1100)、群成员变更 (1002/1003)
- * 都是客户端调 REST、由服务端往频道发系统消息, 去重责任在服务端。本类是这个代码库里
- * 第一例 "多端可能同时产生同一条消息, 靠客户端自行协调"。之所以这么做, 是因为当前既
- * 改不了 Web 也排不上后端。**后端一旦支持在任务完成时直接下发这条提示, 本类应整个删除。**
+ * ## 不变量: 谁创建, 谁负责发 —— 且判定权只归 eligible 账本
  *
- * ## 不变量: 谁创建, 谁负责发
- *
- * [SummaryNotifyStore] 只登记**本机发起**的任务 (创建 / 重新生成), 加上 [handleCompleted]
- * 里的 `creatorId == 自己` 双保险。绝对不要改成 "启动时把自己创建的所有在途任务都跟上" ——
- * 那样多台设备会同时跟同一条任务, 必然重复。
+ * [SummaryNotifyStore] 的 eligible 集合只在**本机发起**任务 (创建 / 重新生成) 时登记,
+ * [notifyIfNeeded] 放行的唯一依据就是 taskId 命中这份账本, 不受"是否观测到状态跃变"
+ * 影响 —— 同一个人可能在 Web 创建总结、又在手机上打开原生详情页停留到完成, 这台
+ * 手机确实会亲眼看到 "Processing → Completed" 的跃变, 但因为它从未 `track()` 过这个
+ * taskId, 依然不会发。`creatorId == 自己` 只是双保险, 不是唯一防线 —— 同一账号跨端
+ * 登录时 creatorId 恒等于自己, 单靠它挡不住这类跨端重复。
  *
  * ## 与 Web 的重复: 当前不做防护
  *
  * 完成即发, 不等待、不检查频道内是否已有 Web 发出的同款提示。
- *
  * 代价: 手机发起总结 + Web 同时开着这条总结的详情页停留到完成, 两端都会各发一条,
- * 群里出现两条一样的提示。这是已知且当前接受的取舍 —— 曾经实现过"等 8s 宽限期 +
- * 查本地库确认 Web 没抢发"的门禁 (2721d832), 但去重判断天生不精确 (提示消息体不带
- * task_id, 只能按频道+发送人+时间窗匹配), 真机复现过它把"自己上一次总结的提示"
- * 误判成"Web 已经发过", 平白吞掉一条本该发的提示。两害相权, 选择了更简单可预测的
- * "完成即发", 接受偶发的跨端重复。
+ * 群里出现两条一样的提示。这是已知且当前接受的取舍。
  */
 object SummaryNotifyCoordinator {
 
-    /** 轮询在途任务的间隔。 */
-    private const val POLL_INTERVAL_MILLIS = 10_000L
+    private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val repository: com.chat.base.summary.repository.SummaryRepository
+        get() = com.chat.base.summary.SummaryDeps.repository
 
-    private val repository: SummaryRepository get() = SummaryDeps.repository
-
-    private var loopJob: Job? = null
-
-    /**
-     * [track] 在写完 SP 之后置位, [pollLoop] 在读 SP 之前清位。
-     *
-     * 这个顺序保证了 "loop 正要因为 pending 空而退出" 与 "track 刚登记了新任务" 撞车时,
-     * loop 一定能看到置位从而不退出 —— 否则新登记的任务会永远没人轮询。
-     */
-    private val pendingChanged = AtomicBoolean(false)
-
-    /** 正在处理完成事件的 taskId, 防止同一任务被并发处理两次。 */
-    private val handling: MutableSet<Long> = Collections.newSetFromMap(ConcurrentHashMap())
-
-    /**
-     * 应用启动时调一次, 从 SP 恢复上次没跟完的任务 (进程被杀过)。幂等。
-     *
-     * 未登录时 [pollLoop] 会立刻退出, 登录后由 [track] 再拉起, 所以不需要监听登录态。
-     */
-    @JvmStatic
-    fun start() {
-        ensureLoopRunning()
-    }
-
-    /** 本机发起了一次总结 (创建 / 重新生成) 时登记。见类注释里的"谁创建谁发"不变量。 */
+    /** 本机发起了一次总结 (创建 / 重新生成) 时登记, 是"谁创建谁发"的唯一判据。 */
     @JvmStatic
     fun track(taskId: Long) {
-        if (taskId <= 0L) return
-        SummaryNotifyStore.addPending(taskId, System.currentTimeMillis())
-        pendingChanged.set(true)
-        ensureLoopRunning()
+        SummaryNotifyStore.markEligible(taskId)
     }
 
-    @Synchronized
-    private fun ensureLoopRunning() {
-        if (loopJob?.isActive == true) return
-        loopJob = scope.launch { pollLoop() }
+    /** 数字 taskId 入口 (原生详情页跃变路径不会走这里; 保留给其他 fire-and-forget 入口)。 */
+    @JvmStatic
+    fun notifyByTaskIdIfEligible(taskId: Long) {
+        if (taskId <= 0L) return
+        appScope.launch {
+            try {
+                val detail = repository.getSummaryDetail(taskId).getOrNull() ?: return@launch
+                notifyIfNeeded(detail)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Throwable) {
+                // 提示是尽力而为: 异常不影响主流程
+            }
+        }
     }
 
     /**
-     * 尝试结束轮询循环。返回 true 表示调用方可以安全退出。
-     *
-     * "判定该退出"和"清掉 loopJob"必须在同一个临界区里完成, 否则有这条竞态:
-     * 循环判定 pending 为空决定退出 → [track] 抢在 loopJob 被清掉之前调
-     * [ensureLoopRunning], 看到 job 还 active 于是 no-op → 循环退出并清掉 job →
-     * 新登记的任务永远没人轮询。把 [pendingChanged] 的检查也挪进锁内就没有这个窗口了。
-     *
-     * 不需要 finally 兜底清 loopJob: [ensureLoopRunning] 判的是 `isActive`, 循环若因
-     * 异常终止, 那个 job 已经 inactive, 下次 track 会正常重启。
+     * 通过 task_no (ST 开头字符串, 通知助手卡片深链 "/s/STxxx?sp=..." 的格式) 触发判定。
+     * 后端详情接口 GET /summaries/{id} 同时接受数字 taskId 和字符串 taskNo 作为路径参数
+     * (resolveSummaryTaskParam 会在 ParseInt 失败时按 task_no 反查)。
      */
-    @Synchronized
-    private fun finishLoopIfIdle(): Boolean {
-        if (pendingChanged.get()) return false
-        loopJob = null
-        return true
-    }
-
-    private suspend fun pollLoop() {
-        while (currentCoroutineContext().isActive) {
-            pendingChanged.set(false)
-
-            // 未登录: 停掉循环, 登录后由 track 拉起。SP 键按 uid 隔离, 不会串账。
-            if (WKConfig.getInstance().uid.isNullOrEmpty()) {
-                if (finishLoopIfIdle()) return
-                delay(POLL_INTERVAL_MILLIS)
-                continue
-            }
-
-            val pending = SummaryNotifyStore.activePendingTaskIds(System.currentTimeMillis())
-            if (pending.isEmpty()) {
-                if (finishLoopIfIdle()) return
-                delay(POLL_INTERVAL_MILLIS)
-                continue
-            }
-
-            val batch = repository.batchStatus(pending)
-            batch.getOrNull()?.forEach { item ->
-                when (item.status) {
-                    TaskStatus.Completed -> {
-                        // 先摘出 pending 再异步处理: 结果未知前不占着轮询继续跑。
-                        SummaryNotifyStore.removePending(item.taskId)
-                        launchCompletionHandling(item.taskId)
-                    }
-                    TaskStatus.Failed, TaskStatus.Cancelled -> {
-                        SummaryNotifyStore.removePending(item.taskId)
-                    }
-                    else -> Unit
-                }
-            }
-
-            delay(POLL_INTERVAL_MILLIS)
-        }
-    }
-
-    private fun launchCompletionHandling(taskId: Long) {
-        if (!handling.add(taskId)) return
-        scope.launch {
+    @JvmStatic
+    fun notifyByTaskNoIfEligible(taskNo: String) {
+        val key = taskNo.trim()
+        if (key.isEmpty()) return
+        appScope.launch {
             try {
-                handleCompleted(taskId)
-            } catch (e: kotlinx.coroutines.CancellationException) {
-                // 结构化并发: cancel 信号必须往上传, 不能当成"一条提示发失败"吞掉。
+                val detail = repository.getSummaryDetailByNo(key).getOrNull() ?: return@launch
+                notifyIfNeeded(detail)
+            } catch (e: CancellationException) {
                 throw e
             } catch (_: Throwable) {
-                // 提示是尽力而为: 其余异常都只损失一条提示, 不能影响轮询循环。
-            } finally {
-                handling.remove(taskId)
+                // 提示是尽力而为: 异常不影响主流程
             }
         }
     }
 
-    private suspend fun handleCompleted(taskId: Long) {
-        val uid = WKConfig.getInstance().uid.orEmpty()
-        if (uid.isEmpty()) {
-            return
+    /**
+     * 识别"总结详情页"URL, 返回用于查找详情的 key 类型和值。支持两种格式:
+     *   - "/summary/detail?taskId=<数字>" (octo-web 内部路由)
+     *   - "/s/<segment>" (通知助手卡片深链, 单段路径, 纯数字按 taskId 否则按 taskNo)
+     *
+     * 匹配失败返回 null。
+     */
+    @JvmStatic
+    fun extractSummaryLookup(url: String): SummaryLookup? {
+        if (url.isBlank()) return null
+        return try {
+            val uri = Uri.parse(url)
+            val rawPath = (uri.path ?: return null).trimEnd('/')
+            val path = if (rawPath.contains('#')) {
+                rawPath.substringAfterLast('#').trimEnd('/')
+            } else {
+                rawPath
+            }
+            when {
+                path.endsWith("/summary/detail") -> {
+                    val tid = uri.getQueryParameter("taskId")?.trim()
+                    val id = tid?.toLongOrNull()?.takeIf { it > 0L } ?: return null
+                    SummaryLookup.ById(id)
+                }
+                path.matches(Regex("^/s/[^/]+$")) -> {
+                    val segment = path.removePrefix("/s/")
+                    val id = segment.toLongOrNull()
+                    if (id != null && id > 0L) SummaryLookup.ById(id)
+                    else SummaryLookup.ByNo(segment)
+                }
+                else -> null
+            }
+        } catch (_: Exception) {
+            null
         }
+    }
 
-        val detailResult = repository.getSummaryDetail(taskId)
-        val detail = detailResult.getOrNull() ?: return
-        // 双保险: SP 只登记本机发起的任务, 这里再按服务端权威字段确认一次创建者身份。
-        // creatorId 缺失时按"不是我"处理 —— 宁可漏发。
-        if (detail.creatorId.isNullOrEmpty() || detail.creatorId != uid) {
-            return
-        }
+    /** 标识一次卡片/URL 点击对应的查找 key 类型。 */
+    sealed class SummaryLookup {
+        data class ById(val taskId: Long) : SummaryLookup()
+        data class ByNo(val taskNo: String) : SummaryLookup()
+    }
+
+    /**
+     * 详情页 `loadDetail` 拿到 [detail] 后调用, 通知助手卡片点击也走这里。
+     *
+     * 放行条件唯一: taskId 命中 [SummaryNotifyStore.isEligible] (本机 [track] 过)。
+     * 状态跃变 / 首次加载即终态都只是"什么时候来检查"的触发时机, 不参与放行判断本身——
+     * 这样跨端同账号登录时, 另一端创建的任务不会因为这台设备恰好观测到了完成跃变就被放行。
+     */
+    @JvmStatic
+    suspend fun notifyIfNeeded(detail: SummaryDetail) {
+        val taskId = detail.taskId
+        if (detail.status != TaskStatus.Completed) return
+        if (!SummaryNotifyStore.isEligible(taskId)) return
+        handleCompleted(detail)
+    }
+
+    private suspend fun handleCompleted(detail: SummaryDetail) {
+        val taskId = detail.taskId
+        val uid = WKConfig.getInstance().uid.orEmpty()
+        if (uid.isEmpty()) return
+
+        // 双保险: eligible 账本只登记本机发起的任务, 这里再按服务端权威字段确认一次创建者
+        // 身份。creatorId 缺失时按"不是我"处理 —— 宁可漏发。
+        if (detail.creatorId.isNullOrEmpty() || detail.creatorId != uid) return
 
         val channels = groupSourceIds(detail)
         if (channels.isEmpty()) return
 
-        val notified = SummaryNotifyStore.notifiedChannels(taskId)
-        val targets = channels.filterNot { notified.contains(it) }
+        // 原子 claim: read-未通知 + 记账合并到一次 synchronized 调用, 避免两个协程
+        // (详情页跃变判定 / 通知助手卡片点击) 几乎同时命中同一 taskId 时, 分别读到
+        // 空集合、各自把同一批 channelId 判定为"未通知"而重复发送。
+        val targets = SummaryNotifyStore.claimUnnotifiedChannels(taskId, channels)
         if (targets.isEmpty()) return
 
         val name = selfDisplayName(uid)
         for (channelId in targets) {
-            // claim-before-send: 先记账再发。SDK 的 send 是 fire-and-forget (void, 无回调),
-            // 拿不到发送结果, 所以没有回滚 —— 与"宁可漏发也不重发"的取舍一致。
-            SummaryNotifyStore.markNotified(taskId, channelId)
+            // SDK 的 send 是 fire-and-forget (void, 无回调), 拿不到发送结果, 所以没有回滚
+            // —— 与"宁可漏发也不重发"的取舍一致 (记账已经在 claimUnnotifiedChannels 里完成)。
             WKIM.getInstance().msgManager.send(
                 SummaryTipContent(uid, name),
                 WKChannel(channelId, WKChannelType.GROUP),
             )
         }
+        // 这次该发的都发完了, 这个 taskId 不会再产生提示需求 (状态已经是终态 Completed),
+        // 从 eligible 账本移除, 避免长期占位。
+        SummaryNotifyStore.clearEligible(taskId)
     }
 
-    /** 对齐 octo-web collectGroupSourceIds(): 群聊来源; sources 为空时退回 origin channel。 */
     private fun groupSourceIds(detail: SummaryDetail): List<String> {
         val ids = LinkedHashSet<String>()
         for (source in detail.sources) {
@@ -227,12 +201,6 @@ object SummaryNotifyCoordinator {
         return ids.toList()
     }
 
-    /**
-     * 写进提示消息体的显示名, 对齐 Web 的 selfDisplayName() || name || uid。
-     *
-     * 收端优先用本地资料渲染 (见 WKSummaryNotifyProvider), 这里的名字只是本地资料
-     * 缺失时的兜底, 所以不必追求精确。
-     */
     private fun selfDisplayName(uid: String): String {
         val fromUserInfo = WKConfig.getInstance().userInfo?.name?.trim()
         if (!fromUserInfo.isNullOrEmpty()) return fromUserInfo

--- a/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyCoordinator.kt
+++ b/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyCoordinator.kt
@@ -27,12 +27,25 @@ import kotlinx.coroutines.launch
 /**
  * 群总结完成后往来源群发一条系统提示, 补上 "App 发起的总结群里没有任何提示" 这个缺口。
  *
- * ## 触发方式: 挂在详情页自身的轮询节奏上, 不用独立常驻协程
+ * ## 触发方式: 挂在详情页/列表页自身的轮询节奏上, 不用独立常驻协程
  *
- * 由 [com.chat.uikit.summary.detail.SmartSummaryDetailViewModel] 自身已有的 8s 轮询
- * (`loadDetail`/`schedulePollIfNeeded`) 在观测到 "非完成 → Completed" 状态跃变时调
- * [notifyIfNeeded]。通知助手卡片的 "/s/STxxx?sp=..." 深链点击也会在打开 WebView 前
- * 做一次同样的判定。
+ * 对齐 octo-web `SummaryDetailPage.notifyGroupsOnCompletion` 的设计: Web 同样只在
+ * 总结详情页挂载着、且亲眼看到 processing→completed 状态沿时才发, 没有应用级/后台
+ * 常驻机制统一兜底。Android 侧同一设计落地为三个触发点:
+ *   - [com.chat.uikit.summary.detail.SmartSummaryDetailViewModel] 自身已有的 8s 轮询
+ *     (`loadDetail`/`schedulePollIfNeeded`) 在观测到 "非完成 → Completed" 状态跃变时调
+ *     [notifyIfNeeded]。
+ *   - [com.chat.uikit.summary.list.SmartSummaryListViewModel] 的列表 5s 轮询
+ *     (`applyStatusChanges`) 观测到同样的跃变时调 [notifyByTaskIdIfEligible] —— 覆盖
+ *     "在列表页点重新生成、不进详情页" 这条路径, 否则 `track()` 登记的 eligible 标记
+ *     没有消费者, 永远发不出去。
+ *   - 通知助手卡片的 "/s/STxxx?sp=..." 深链点击, 在打开 WebView 前做一次同样的判定。
+ *
+ * 与 Web 同口径的代价: 创建/重新生成后, 如果这台设备上"详情页"和"列表页"都没有在
+ * 任务完成时刻挂载着 (例如创建后立刻退出详情页、且此后再也不重新打开这个任务的
+ * 详情页/列表页), 这条提示就不会被发出——账本里的 eligible 标记会一直留着, 直到
+ * 某次重新打开触发一次检查才补发, 但如果永远不再打开就永远不发。这是与 Web
+ * 一致的行为, 不是本实现独有的缺陷。
  *
  * ## 不变量: 谁创建, 谁负责发 —— 且判定权只归 eligible 账本
  *
@@ -101,7 +114,8 @@ object SummaryNotifyCoordinator {
 
     /**
      * 识别"总结详情页"URL, 返回用于查找详情的 key 类型和值。支持两种格式:
-     *   - "/summary/detail?taskId=<数字>" (octo-web 内部路由)
+     *   - "/summary/detail?taskId=<数字>" (octo-web 内部路由, 也支持 hash 路由形态
+     *     "…/#/summary/detail?taskId=<数字>")
      *   - "/s/<segment>" (通知助手卡片深链, 单段路径, 纯数字按 taskId 否则按 taskNo)
      *
      * 匹配失败返回 null。
@@ -111,15 +125,19 @@ object SummaryNotifyCoordinator {
         if (url.isBlank()) return null
         return try {
             val uri = Uri.parse(url)
-            val rawPath = (uri.path ?: return null).trimEnd('/')
-            val path = if (rawPath.contains('#')) {
-                rawPath.substringAfterLast('#').trimEnd('/')
-            } else {
-                rawPath
-            }
+            // hash 路由 (SPA 常见形态, 例如 "https://host/#/summary/detail?taskId=42"):
+            // 真正的路径和 query 整体被塞进了 fragment 里, 不能指望它们出现在 uri.path /
+            // uri.getQueryParameter 上——Android Uri.parse 遵循 RFC 3986, 在解析阶段就把
+            // '#' 之后的全部内容切给 fragment 组件, path 组件本身永远不可能包含字面的
+            // '#' 字符 (旧实现里 `rawPath.contains('#')` 因此恒为 false, 处理 hash 路由
+            // 的分支是死代码, 这类 URL 一律被 uri.path=="/" 兜底成 null)。这里改为显式
+            // 取 fragment, 非空就当作一个独立的相对 URI 重新解析一次 (Uri.parse 能正确
+            // 把 "/summary/detail?taskId=42" 这样的字符串再拆出 path 和 query)。
+            val effectiveUri = uri.fragment?.let { Uri.parse(it) } ?: uri
+            val path = (effectiveUri.path ?: return null).trimEnd('/')
             when {
                 path.endsWith("/summary/detail") -> {
-                    val tid = uri.getQueryParameter("taskId")?.trim()
+                    val tid = effectiveUri.getQueryParameter("taskId")?.trim()
                     val id = tid?.toLongOrNull()?.takeIf { it > 0L } ?: return null
                     SummaryLookup.ById(id)
                 }

--- a/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyCoordinator.kt
+++ b/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyCoordinator.kt
@@ -184,13 +184,21 @@ object SummaryNotifyCoordinator {
         // 身份。creatorId 缺失时按"不是我"处理 —— 宁可漏发。
         if (detail.creatorId.isNullOrEmpty() || detail.creatorId != uid) return
 
+        // 去重记账必须带 version, 不能只用 taskId —— 后端 regenerate 是原地复用同一
+        // taskId 的 UPDATE (见 SummaryNotifyStore 类文档), 只按 taskId 记账会让重新
+        // 生成完成后的提示被上一轮的"已通知"记录误判成重复而直接跳过。status==Completed
+        // 时 result/version 按服务端事务顺序必然已落库 (saveLatestResultAndCompleteTask
+        // 先写 SummaryResult 再改状态), 这里仍防御性判空 —— 真拿不到就宁可漏发这一次,
+        // 不猜一个假版本号出来记账。
+        val version = detail.result?.version ?: return
+
         val channels = groupSourceIds(detail)
         if (channels.isEmpty()) return
 
         // 原子 claim: read-未通知 + 记账合并到一次 synchronized 调用, 避免两个协程
         // (详情页跃变判定 / 通知助手卡片点击) 几乎同时命中同一 taskId 时, 分别读到
         // 空集合、各自把同一批 channelId 判定为"未通知"而重复发送。
-        val targets = SummaryNotifyStore.claimUnnotifiedChannels(taskId, channels)
+        val targets = SummaryNotifyStore.claimUnnotifiedChannels(taskId, version, channels)
         if (targets.isEmpty()) return
 
         val name = selfDisplayName(uid)

--- a/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyStore.kt
+++ b/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyStore.kt
@@ -15,74 +15,72 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 /**
- * 群总结完成提示的持久化去重账本, 对齐 octo-web groupSummaryNotify.ts 的 localStorage 部分。
+ * 群总结完成提示的持久化去重账本。
  *
  * 两份数据:
- *   - [PENDING_KEY]  taskId → 登记时间戳。**只登记本机发起的任务** (创建 / 重新生成),
- *     这是"谁创建谁负责发"这条不变量的载体 —— 一旦改成"把自己创建的所有在途任务都跟上",
- *     多台设备会同时跟同一条任务, 立刻退化成必然重复。
+ *   - [ELIGIBLE_KEY] 本机 [track] 过的 taskId 集合。**只登记本机发起的任务**
+ *     (创建 / 重新生成), 这是"谁创建谁负责发"这条不变量唯一的判据 —— 不管观测到
+ *     完成是靠状态跃变还是首次加载就是终态, 放行前都必须查这份账本命中。没有
+ *     TTL: 同一个人在多端登录时, "任务处理超过 N 分钟" 不该变成"这台设备突然
+ *     又发不出本该由它发的提示", 生命周期完全交给 [markEligible]/[clearEligible]
+ *     显式管理, 不靠时间推断。
  *   - [SENT_KEY]     taskId → 已通知过的 channelId 集合。claim-before-send 的记账处。
  *
  * 全部走 [WKSharedPreferencesUtil.putSPWithUID] 按 uid 隔离, 多账号切换不串台。
  * App 实质单进程 (只有腾讯 X5 的 :dexopt service 是独立进程, 不碰 SP), MODE_PRIVATE 够用。
  *
- * 写入是 best-effort: SP 异常时宁可漏发也不重发 —— 与 Web 同口径, 群里刷两条一样的
+ * 写入是 best-effort: SP 异常时宁可漏发也不重发 —— 群里刷两条一样的
  * 提示比偶尔少一条难受得多。
  */
 internal object SummaryNotifyStore {
 
-    // 所有读改写方法都 @Synchronized: 轮询循环与多个 handleCompleted 协程跑在
-    // Dispatchers.IO 的不同线程上, 会并发读改写同一份 SP JSON。不加锁时两个任务同时
-    // markNotified 会丢更新 (各自读到旧集合、各自覆盖写回), 结果就是重复发送。
+    // 所有读改写方法都 @Synchronized: 详情页 ViewModel 的 loadDetail 协程、通知助手卡片点击
+    // 判定等入口都可能并发读改写同一份 SP JSON。[claimUnnotifiedChannels] 把 read + write
+    // 合并到同一临界区, 避免两个调用者各自读到旧集合、各自覆盖写回导致的重复发送。
 
-    private const val PENDING_KEY = "summary_tip_pending_v1"
+    private const val ELIGIBLE_KEY = "summary_tip_eligible_v2"
     private const val SENT_KEY = "summary_tip_sent_v1"
 
-    /**
-     * 登记后超过这个时长仍未观测到完成, 直接丢弃不再发。
-     *
-     * 覆盖 "App 被杀 → 几小时后重启 → 翻出一条早已完成的旧任务" 这种场景: 那时再往群里
-     * 补一条提示只会让人莫名其妙。Web 的同类标记是 10 分钟, 这里放宽到 30 分钟, 因为
-     * Android 端更容易被切后台 / 回收, 需要更长的续跟窗口。
-     */
-    private const val PENDING_TTL_MILLIS = 30 * 60 * 1000L
+    /** eligible 账本保留的任务数上限, 防止 [clearEligible] 漏调时 SP 无限增长。 */
+    private const val MAX_ELIGIBLE_TASKS = 100
 
     /** 已通知账本保留的任务数上限, 防止 SP 无限增长。 */
     private const val MAX_SENT_TASKS = 100
 
-    // ===== pending =====
+    // ===== eligible (本机发起过创建/重新生成的 taskId, "谁创建谁发" 的唯一判据) =====
 
-    /** 返回仍在 TTL 内的 pending taskId; 顺手把过期项清掉。 */
+    /** 本机发起 (创建 / 重新生成) 成功时登记。 */
     @Synchronized
-    fun activePendingTaskIds(nowMillis: Long): List<Long> {
-        val json = readObject(PENDING_KEY)
-        val alive = JSONObject()
-        val ids = ArrayList<Long>()
-        for (key in json.keys()) {
-            val trackedAt = json.optLong(key, 0L)
-            val taskId = key.toLongOrNull() ?: continue
-            if (trackedAt <= 0L || nowMillis - trackedAt > PENDING_TTL_MILLIS) continue
-            alive.put(key, trackedAt)
-            ids.add(taskId)
-        }
-        if (alive.length() != json.length()) writeObject(PENDING_KEY, alive)
-        return ids
-    }
-
-    @Synchronized
-    fun addPending(taskId: Long, nowMillis: Long) {
+    fun markEligible(taskId: Long) {
         if (taskId <= 0L) return
-        val json = readObject(PENDING_KEY)
-        json.put(taskId.toString(), nowMillis)
-        writeObject(PENDING_KEY, json)
+        val json = readObject(ELIGIBLE_KEY)
+        json.put(taskId.toString(), true)
+        writeObject(ELIGIBLE_KEY, trimToCap(json, MAX_ELIGIBLE_TASKS))
     }
 
+    /**
+     * 只读检查: taskId 是否是本机登记过的。跃变路径每一拍轮询都可能调用, 不消费——
+     * 消费 (从账本移除) 是 [clearEligible] 的职责, 由调用方在真正不再需要这条登记时
+     * (发送完成 / 任务进入非 Completed 终态) 显式调用。
+     */
     @Synchronized
-    fun removePending(taskId: Long) {
-        val json = readObject(PENDING_KEY)
-        if (!json.has(taskId.toString())) return
-        json.remove(taskId.toString())
-        writeObject(PENDING_KEY, json)
+    fun isEligible(taskId: Long): Boolean {
+        if (taskId <= 0L) return false
+        return readObject(ELIGIBLE_KEY).has(taskId.toString())
+    }
+
+    /**
+     * 这个 taskId 不再需要跟踪 (提示已经发出去, 或任务确认不会再产生提示需求) 时
+     * 显式移除登记。不调用也不会错发 —— 只是账本多留一条, 靠 [MAX_ELIGIBLE_TASKS]
+     * 兜底防止无限增长。
+     */
+    @Synchronized
+    fun clearEligible(taskId: Long) {
+        val json = readObject(ELIGIBLE_KEY)
+        val key = taskId.toString()
+        if (!json.has(key)) return
+        json.remove(key)
+        writeObject(ELIGIBLE_KEY, json)
     }
 
     // ===== sent =====
@@ -97,37 +95,39 @@ internal object SummaryNotifyStore {
         return set
     }
 
-    /** claim: 发送**之前**先记账。失败再调 [unmarkNotified] 回滚。 */
+    /**
+     * 原子版"读未通知 + 记账"：把 [notifiedChannels] 读取和记账写入合并到同一个
+     * synchronized 临界区里, 避免调用方先 read 再逐个 write 时中间被并发调用者插入
+     * 导致的 TOCTOU —— 两个协程 (例如详情页跃变判定 + 通知助手卡片点击几乎同时
+     * 命中同一 taskId) 分别 read 到空集合、各自算出相同 targets、都发一遍, 就会在群里
+     * 出现重复提示, 与"claim-before-send: 同 taskId 同群不重发"这条不变量矛盾。
+     *
+     * 返回值是这次真正抢到、且已经记账过的 channelId 子集 —— 调用方对这些 id 发送即可。
+     * 无回滚: SDK 的 send 是 fire-and-forget, 拿不到发送结果, 与"宁可漏发也不重发"一致。
+     */
     @Synchronized
-    fun markNotified(taskId: Long, channelId: String) {
+    fun claimUnnotifiedChannels(taskId: Long, candidates: List<String>): List<String> {
+        val already = notifiedChannels(taskId)
+        val claimed = candidates.filterNot { already.contains(it) }
+        if (claimed.isEmpty()) return claimed
         val json = readObject(SENT_KEY)
-        val channels = notifiedChannels(taskId).toMutableSet()
-        if (!channels.add(channelId)) return
-        json.put(taskId.toString(), JSONArray(channels.toList()))
-        writeObject(SENT_KEY, trimToCap(json))
-    }
-
-    @Synchronized
-    fun unmarkNotified(taskId: Long, channelId: String) {
-        val json = readObject(SENT_KEY)
-        val channels = notifiedChannels(taskId).toMutableSet()
-        if (!channels.remove(channelId)) return
-        if (channels.isEmpty()) json.remove(taskId.toString())
-        else json.put(taskId.toString(), JSONArray(channels.toList()))
-        writeObject(SENT_KEY, json)
+        val merged = (already + claimed).toMutableSet()
+        json.put(taskId.toString(), JSONArray(merged.toList()))
+        writeObject(SENT_KEY, trimToCap(json, MAX_SENT_TASKS))
+        return claimed
     }
 
     // ===== io =====
 
     /**
      * 超出上限时按 taskId 从小到大丢弃 —— taskId 由后端自增, 数值小即更早创建,
-     * 这等价于"丢最旧的", 且不需要额外存时间戳。
+     * 这等价于"丢最旧的", 且不需要额外存时间戳。两份账本 (eligible / sent) 共用。
      */
-    private fun trimToCap(json: JSONObject): JSONObject {
-        if (json.length() <= MAX_SENT_TASKS) return json
+    private fun trimToCap(json: JSONObject, cap: Int): JSONObject {
+        if (json.length() <= cap) return json
         val ordered = json.keys().asSequence().toList()
             .sortedByDescending { it.toLongOrNull() ?: 0L }
-            .take(MAX_SENT_TASKS)
+            .take(cap)
         val trimmed = JSONObject()
         for (key in ordered) trimmed.put(key, json.get(key))
         return trimmed

--- a/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyStore.kt
+++ b/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyStore.kt
@@ -23,8 +23,20 @@ import org.json.JSONObject
  *     完成是靠状态跃变还是首次加载就是终态, 放行前都必须查这份账本命中。没有
  *     TTL: 同一个人在多端登录时, "任务处理超过 N 分钟" 不该变成"这台设备突然
  *     又发不出本该由它发的提示", 生命周期完全交给 [markEligible]/[clearEligible]
- *     显式管理, 不靠时间推断。
- *   - [SENT_KEY]     taskId → 已通知过的 channelId 集合。claim-before-send 的记账处。
+ *     显式管理, 不靠时间推断。仍然只按 taskId 记, 不需要区分版本 —— 它的语义是
+ *     "这个任务是不是本机发起的", 跟"这次具体是第几次生成"无关。
+ *   - [SENT_KEY]     "taskId:version" → 已通知过的 channelId 集合。claim-before-send
+ *     的记账处。键必须带 [SummaryResult.version] 而不是只用 taskId —— 后端
+ *     `POST /summaries/{id}/regenerate` 是原地复用同一个 taskId 的 UPDATE, 不产生
+ *     新 task_id (已用 octo-smart-summary internal/api/handler/task.go 的 Regenerate
+ *     handler 源码确认: 返回体里的 task_id 恒等于请求时传入的 taskId)。若只按
+ *     taskId 记账, 第一次生成完成发过的提示会让"已通知"集合永久非空, 重新生成
+ *     完成后 claimUnnotifiedChannels 会把同一批 channelId 全部判定为"已通知"而
+ *     直接跳过, 提示永远发不出第二次。version 取自服务端 saveLatestResultAndCompleteTask
+ *     事务里维护的单调递增列 (GetNextVersion), 且该事务保证"新 SummaryResult 落库"
+ *     严格先于"任务状态改为 Completed"提交, 所以客户端读到 status=Completed 时
+ *     result.version 必然存在且是这一轮生成的权威版本号, 不会有"完成了但 version
+ *     还没写好"的窗口。
  *
  * 全部走 [WKSharedPreferencesUtil.putSPWithUID] 按 uid 隔离, 多账号切换不串台。
  * App 实质单进程 (只有腾讯 X5 的 :dexopt service 是独立进程, 不碰 SP), MODE_PRIVATE 够用。
@@ -39,7 +51,7 @@ internal object SummaryNotifyStore {
     // 合并到同一临界区, 避免两个调用者各自读到旧集合、各自覆盖写回导致的重复发送。
 
     private const val ELIGIBLE_KEY = "summary_tip_eligible_v2"
-    private const val SENT_KEY = "summary_tip_sent_v1"
+    private const val SENT_KEY = "summary_tip_sent_v2"
 
     /** eligible 账本保留的任务数上限, 防止 [clearEligible] 漏调时 SP 无限增长。 */
     private const val MAX_ELIGIBLE_TASKS = 100
@@ -85,9 +97,12 @@ internal object SummaryNotifyStore {
 
     // ===== sent =====
 
+    /** "taskId:version" 复合键, 见类文档 [SENT_KEY] 部分。 */
+    private fun sentKeyOf(taskId: Long, version: Int): String = "$taskId:$version"
+
     @Synchronized
-    fun notifiedChannels(taskId: Long): Set<String> {
-        val arr = readObject(SENT_KEY).optJSONArray(taskId.toString()) ?: return emptySet()
+    fun notifiedChannels(taskId: Long, version: Int): Set<String> {
+        val arr = readObject(SENT_KEY).optJSONArray(sentKeyOf(taskId, version)) ?: return emptySet()
         val set = HashSet<String>(arr.length())
         for (i in 0 until arr.length()) {
             arr.optString(i).takeIf { it.isNotEmpty() }?.let(set::add)
@@ -100,20 +115,23 @@ internal object SummaryNotifyStore {
      * synchronized 临界区里, 避免调用方先 read 再逐个 write 时中间被并发调用者插入
      * 导致的 TOCTOU —— 两个协程 (例如详情页跃变判定 + 通知助手卡片点击几乎同时
      * 命中同一 taskId) 分别 read 到空集合、各自算出相同 targets、都发一遍, 就会在群里
-     * 出现重复提示, 与"claim-before-send: 同 taskId 同群不重发"这条不变量矛盾。
+     * 出现重复提示, 与"claim-before-send: 同 taskId+version 同群不重发"这条不变量矛盾。
+     *
+     * [version] 必须是这次判定对应的 [SummaryResult.version] (来自
+     * [com.chat.base.summary.model.SummaryDetail.result]), 不能只用 taskId —— 见类文档。
      *
      * 返回值是这次真正抢到、且已经记账过的 channelId 子集 —— 调用方对这些 id 发送即可。
      * 无回滚: SDK 的 send 是 fire-and-forget, 拿不到发送结果, 与"宁可漏发也不重发"一致。
      */
     @Synchronized
-    fun claimUnnotifiedChannels(taskId: Long, candidates: List<String>): List<String> {
-        val already = notifiedChannels(taskId)
+    fun claimUnnotifiedChannels(taskId: Long, version: Int, candidates: List<String>): List<String> {
+        val already = notifiedChannels(taskId, version)
         val claimed = candidates.filterNot { already.contains(it) }
         if (claimed.isEmpty()) return claimed
         val json = readObject(SENT_KEY)
         val merged = (already + claimed).toMutableSet()
-        json.put(taskId.toString(), JSONArray(merged.toList()))
-        writeObject(SENT_KEY, trimToCap(json, MAX_SENT_TASKS))
+        json.put(sentKeyOf(taskId, version), JSONArray(merged.toList()))
+        writeObject(SENT_KEY, trimSentToCap(json, MAX_SENT_TASKS))
         return claimed
     }
 
@@ -121,12 +139,32 @@ internal object SummaryNotifyStore {
 
     /**
      * 超出上限时按 taskId 从小到大丢弃 —— taskId 由后端自增, 数值小即更早创建,
-     * 这等价于"丢最旧的", 且不需要额外存时间戳。两份账本 (eligible / sent) 共用。
+     * 这等价于"丢最旧的", 且不需要额外存时间戳。给 [ELIGIBLE_KEY] (纯 taskId 键) 用。
      */
     private fun trimToCap(json: JSONObject, cap: Int): JSONObject {
         if (json.length() <= cap) return json
         val ordered = json.keys().asSequence().toList()
             .sortedByDescending { it.toLongOrNull() ?: 0L }
+            .take(cap)
+        val trimmed = JSONObject()
+        for (key in ordered) trimmed.put(key, json.get(key))
+        return trimmed
+    }
+
+    /**
+     * [SENT_KEY] 专用: 键是 "taskId:version" 复合字符串, 不能直接 toLongOrNull()
+     * (会因为带冒号解析失败全部退化成 0, 排序失效)。按 taskId 主序、version 次序
+     * 降序排, 语义仍是"丢最旧的" —— taskId 更大或同 taskId 下 version 更大都代表
+     * 更晚发生。
+     */
+    private fun trimSentToCap(json: JSONObject, cap: Int): JSONObject {
+        if (json.length() <= cap) return json
+        val ordered = json.keys().asSequence().toList()
+            .sortedWith(compareByDescending<String> { key ->
+                key.split(':', limit = 2).getOrNull(0)?.toLongOrNull() ?: 0L
+            }.thenByDescending { key ->
+                key.split(':', limit = 2).getOrNull(1)?.toIntOrNull() ?: 0
+            })
             .take(cap)
         val trimmed = JSONObject()
         for (key in ordered) trimmed.put(key, json.get(key))

--- a/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyStore.kt
+++ b/wkbase/src/main/java/com/chat/base/summary/notify/SummaryNotifyStore.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.base.summary.notify
+
+import com.chat.base.config.WKSharedPreferencesUtil
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * 群总结完成提示的持久化去重账本, 对齐 octo-web groupSummaryNotify.ts 的 localStorage 部分。
+ *
+ * 两份数据:
+ *   - [PENDING_KEY]  taskId → 登记时间戳。**只登记本机发起的任务** (创建 / 重新生成),
+ *     这是"谁创建谁负责发"这条不变量的载体 —— 一旦改成"把自己创建的所有在途任务都跟上",
+ *     多台设备会同时跟同一条任务, 立刻退化成必然重复。
+ *   - [SENT_KEY]     taskId → 已通知过的 channelId 集合。claim-before-send 的记账处。
+ *
+ * 全部走 [WKSharedPreferencesUtil.putSPWithUID] 按 uid 隔离, 多账号切换不串台。
+ * App 实质单进程 (只有腾讯 X5 的 :dexopt service 是独立进程, 不碰 SP), MODE_PRIVATE 够用。
+ *
+ * 写入是 best-effort: SP 异常时宁可漏发也不重发 —— 与 Web 同口径, 群里刷两条一样的
+ * 提示比偶尔少一条难受得多。
+ */
+internal object SummaryNotifyStore {
+
+    // 所有读改写方法都 @Synchronized: 轮询循环与多个 handleCompleted 协程跑在
+    // Dispatchers.IO 的不同线程上, 会并发读改写同一份 SP JSON。不加锁时两个任务同时
+    // markNotified 会丢更新 (各自读到旧集合、各自覆盖写回), 结果就是重复发送。
+
+    private const val PENDING_KEY = "summary_tip_pending_v1"
+    private const val SENT_KEY = "summary_tip_sent_v1"
+
+    /**
+     * 登记后超过这个时长仍未观测到完成, 直接丢弃不再发。
+     *
+     * 覆盖 "App 被杀 → 几小时后重启 → 翻出一条早已完成的旧任务" 这种场景: 那时再往群里
+     * 补一条提示只会让人莫名其妙。Web 的同类标记是 10 分钟, 这里放宽到 30 分钟, 因为
+     * Android 端更容易被切后台 / 回收, 需要更长的续跟窗口。
+     */
+    private const val PENDING_TTL_MILLIS = 30 * 60 * 1000L
+
+    /** 已通知账本保留的任务数上限, 防止 SP 无限增长。 */
+    private const val MAX_SENT_TASKS = 100
+
+    // ===== pending =====
+
+    /** 返回仍在 TTL 内的 pending taskId; 顺手把过期项清掉。 */
+    @Synchronized
+    fun activePendingTaskIds(nowMillis: Long): List<Long> {
+        val json = readObject(PENDING_KEY)
+        val alive = JSONObject()
+        val ids = ArrayList<Long>()
+        for (key in json.keys()) {
+            val trackedAt = json.optLong(key, 0L)
+            val taskId = key.toLongOrNull() ?: continue
+            if (trackedAt <= 0L || nowMillis - trackedAt > PENDING_TTL_MILLIS) continue
+            alive.put(key, trackedAt)
+            ids.add(taskId)
+        }
+        if (alive.length() != json.length()) writeObject(PENDING_KEY, alive)
+        return ids
+    }
+
+    @Synchronized
+    fun addPending(taskId: Long, nowMillis: Long) {
+        if (taskId <= 0L) return
+        val json = readObject(PENDING_KEY)
+        json.put(taskId.toString(), nowMillis)
+        writeObject(PENDING_KEY, json)
+    }
+
+    @Synchronized
+    fun removePending(taskId: Long) {
+        val json = readObject(PENDING_KEY)
+        if (!json.has(taskId.toString())) return
+        json.remove(taskId.toString())
+        writeObject(PENDING_KEY, json)
+    }
+
+    // ===== sent =====
+
+    @Synchronized
+    fun notifiedChannels(taskId: Long): Set<String> {
+        val arr = readObject(SENT_KEY).optJSONArray(taskId.toString()) ?: return emptySet()
+        val set = HashSet<String>(arr.length())
+        for (i in 0 until arr.length()) {
+            arr.optString(i).takeIf { it.isNotEmpty() }?.let(set::add)
+        }
+        return set
+    }
+
+    /** claim: 发送**之前**先记账。失败再调 [unmarkNotified] 回滚。 */
+    @Synchronized
+    fun markNotified(taskId: Long, channelId: String) {
+        val json = readObject(SENT_KEY)
+        val channels = notifiedChannels(taskId).toMutableSet()
+        if (!channels.add(channelId)) return
+        json.put(taskId.toString(), JSONArray(channels.toList()))
+        writeObject(SENT_KEY, trimToCap(json))
+    }
+
+    @Synchronized
+    fun unmarkNotified(taskId: Long, channelId: String) {
+        val json = readObject(SENT_KEY)
+        val channels = notifiedChannels(taskId).toMutableSet()
+        if (!channels.remove(channelId)) return
+        if (channels.isEmpty()) json.remove(taskId.toString())
+        else json.put(taskId.toString(), JSONArray(channels.toList()))
+        writeObject(SENT_KEY, json)
+    }
+
+    // ===== io =====
+
+    /**
+     * 超出上限时按 taskId 从小到大丢弃 —— taskId 由后端自增, 数值小即更早创建,
+     * 这等价于"丢最旧的", 且不需要额外存时间戳。
+     */
+    private fun trimToCap(json: JSONObject): JSONObject {
+        if (json.length() <= MAX_SENT_TASKS) return json
+        val ordered = json.keys().asSequence().toList()
+            .sortedByDescending { it.toLongOrNull() ?: 0L }
+            .take(MAX_SENT_TASKS)
+        val trimmed = JSONObject()
+        for (key in ordered) trimmed.put(key, json.get(key))
+        return trimmed
+    }
+
+    private fun readObject(key: String): JSONObject {
+        val raw = WKSharedPreferencesUtil.getInstance().getSPWithUID(key)
+        if (raw.isNullOrEmpty()) return JSONObject()
+        return try {
+            JSONObject(raw)
+        } catch (_: Exception) {
+            JSONObject()
+        }
+    }
+
+    private fun writeObject(key: String, json: JSONObject) {
+        try {
+            WKSharedPreferencesUtil.getInstance().putSPWithUID(key, json.toString())
+        } catch (_: Exception) {
+            // best-effort: 写失败最坏结果是重复一条, 不影响主流程
+        }
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/summary/notify/SummaryTipContent.kt
+++ b/wkbase/src/main/java/com/chat/base/summary/notify/SummaryTipContent.kt
@@ -14,14 +14,16 @@ import com.chat.base.msgitem.WKContentType
 import com.xinbida.wukongim.msgmodel.WKMessageContent
 import org.json.JSONArray
 import org.json.JSONObject
+import java.text.MessageFormat
 
 /**
  * 群总结完成提示的发送侧消息体, 1:1 对齐 octo-web [SummaryTipContent]。
  *
  * 走 WK_TIP(2000) 系统号段而不是自定义类型: 收端 (Web / iOS / Android) 都用各自
  * SDK 的系统提示占位替换路径渲染, 不需要为这条提示单独适配。Android 侧由
- * [com.chat.base.msgitem.WKSystemProvider] +
- * [com.chat.base.utils.StringUtils.getShowContent] 处理。
+ * [com.chat.base.msgitem.WKSystemProvider] 特化处理 (不走
+ * [com.chat.base.utils.StringUtils.getShowContent] 的通用"uid==自己显示你"逻辑 ——
+ * 总结提示不管是不是本人发的都要显示发起人姓名本身, 见 [resolveDisplayContent])。
  *
  * [TEMPLATE] 刻意不做多语言 —— 它是**跨端线格式**, 由收端 SDK 做 `{0}` 占位替换,
  * 按语言给不同变体会让各端认不出同一条协议 (octo-web d31a10c3 已把这条决策记录在
@@ -53,5 +55,28 @@ class SummaryTipContent(
     companion object {
         /** 与 octo-web SUMMARY_TIP_TEMPLATE 必须逐字一致, 改动即破坏跨端识别。 */
         const val TEMPLATE = "{0}总结了群聊内容"
+
+        /**
+         * 收端渲染: 直接取 `extra[0].name` 填进 [TEMPLATE], **不做**
+         * [com.chat.base.utils.StringUtils.getShowContent] 那种"uid==当前登录用户就
+         * 显示'你'"的替换 —— 总结提示无论是不是本机自己发起的, 都要显示发起人的姓名本身
+         * (对齐产品诉求: 自己在手机上发起总结, 群里看到的也应该是"张三总结了群聊内容"
+         * 而不是"你总结了群聊内容")。
+         *
+         * 解析失败 (JSON 非法 / extra 缺失) 返回 null, 调用方自行决定兜底文案。
+         */
+        @JvmStatic
+        fun resolveDisplayContent(contentJson: String?): String? {
+            if (contentJson.isNullOrEmpty()) return null
+            return try {
+                val obj = JSONObject(contentJson)
+                val template = obj.optString("content").ifEmpty { TEMPLATE }
+                val sender = obj.optJSONArray("extra")?.optJSONObject(0) ?: return null
+                val name = sender.optString("name")
+                MessageFormat.format(template, name)
+            } catch (_: Exception) {
+                null
+            }
+        }
     }
 }

--- a/wkbase/src/main/java/com/chat/base/summary/notify/SummaryTipContent.kt
+++ b/wkbase/src/main/java/com/chat/base/summary/notify/SummaryTipContent.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026-present OctoIM contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chat.base.summary.notify
+
+import com.chat.base.msgitem.WKContentType
+import com.xinbida.wukongim.msgmodel.WKMessageContent
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * 群总结完成提示的发送侧消息体, 1:1 对齐 octo-web [SummaryTipContent]。
+ *
+ * 走 WK_TIP(2000) 系统号段而不是自定义类型: 收端 (Web / iOS / Android) 都用各自
+ * SDK 的系统提示占位替换路径渲染, 不需要为这条提示单独适配。Android 侧由
+ * [com.chat.base.msgitem.WKSystemProvider] +
+ * [com.chat.base.utils.StringUtils.getShowContent] 处理。
+ *
+ * [TEMPLATE] 刻意不做多语言 —— 它是**跨端线格式**, 由收端 SDK 做 `{0}` 占位替换,
+ * 按语言给不同变体会让各端认不出同一条协议 (octo-web d31a10c3 已把这条决策记录在
+ * .i18n/scan-config.json)。因此英文环境下这条提示也显示中文, 与 Web 表现一致。
+ *
+ * `type` 字段不在 [encodeMsg] 里写: SDK 发送时由
+ * [com.xinbida.wukongim.message.WKProto.getSendPayload] 统一注入。
+ */
+class SummaryTipContent(
+    private val uid: String = "",
+    private val name: String = "",
+) : WKMessageContent() {
+
+    init {
+        type = WKContentType.summaryTip
+    }
+
+    override fun encodeMsg(): JSONObject {
+        val sender = JSONObject().apply {
+            put("uid", uid.trim())
+            put("name", name.trim())
+        }
+        return JSONObject().apply {
+            put("content", TEMPLATE)
+            put("extra", JSONArray().put(sender))
+        }
+    }
+
+    companion object {
+        /** 与 octo-web SUMMARY_TIP_TEMPLATE 必须逐字一致, 改动即破坏跨端识别。 */
+        const val TEMPLATE = "{0}总结了群聊内容"
+    }
+}

--- a/wkbase/src/main/java/com/chat/base/summary/repository/SummaryRepository.kt
+++ b/wkbase/src/main/java/com/chat/base/summary/repository/SummaryRepository.kt
@@ -49,6 +49,9 @@ interface SummaryRepository {
 
     suspend fun getSummaryDetail(taskId: Long): Result<SummaryDetail>
 
+    /** 通过 task_no (ST 开头字符串) 查详情, 后端详情接口支持字符串 id 反查。 */
+    suspend fun getSummaryDetailByNo(taskNo: String): Result<SummaryDetail>
+
     suspend fun deleteSummary(taskId: Long): Result<Unit>
 
     /** 返回新生成的 task_id (后端给新 id, 旧 id 终态). */

--- a/wkbase/src/main/java/com/chat/base/summary/repository/SummaryRepositoryImpl.kt
+++ b/wkbase/src/main/java/com/chat/base/summary/repository/SummaryRepositoryImpl.kt
@@ -206,6 +206,12 @@ class SummaryRepositoryImpl(
                 ?: throw SummaryException(httpStatus = 200, apiCode = 0, message = "empty detail")
         }
 
+    override suspend fun getSummaryDetailByNo(taskNo: String): Result<SummaryDetail> =
+        callEnvelope({ it.getSummaryDetailByNo(taskNo) }) { data ->
+            SummaryDetail.fromJson(asObject(data))
+                ?: throw SummaryException(httpStatus = 200, apiCode = 0, message = "empty detail")
+        }
+
     override suspend fun deleteSummary(taskId: Long): Result<Unit> =
         callEnvelope({ it.deleteSummary(taskId) }) { }
 

--- a/wkbase/src/main/res/values-en/strings.xml
+++ b/wkbase/src/main/res/values-en/strings.xml
@@ -232,6 +232,9 @@
     <string name="str_default_text_file_name">Message</string>
     <string name="str_send_message_hint">Leave a message</string>
     <string name="str_someone">The other party</string>
+    <string name="summary_notify_tip">%1$s summarized the chat</string>
+    <string name="summary_notify_you">You</string>
+    <string name="summary_notify_unknown">Someone</string>
     <string name="str_text_exceed_limit_tip">Text exceeds the limit. Send as a document instead?</string>
 
     <!-- i18n: Animated avatar -->

--- a/wkbase/src/main/res/values/strings.xml
+++ b/wkbase/src/main/res/values/strings.xml
@@ -173,6 +173,10 @@
     <string name="str_default_text_file_name">消息</string>
     <string name="screenshot_tip">%s在聊天中截屏了</string>
     <string name="str_someone">对方</string>
+    <!-- 群总结完成提示（消息 type=21，发送方为 Web 端）。文案与 octo-web 保持一致 -->
+    <string name="summary_notify_tip">%1$s总结了群聊内容</string>
+    <string name="summary_notify_you">你</string>
+    <string name="summary_notify_unknown">某用户</string>
     <string name="api_url_dialog_title">服务器配置</string>
     <string name="api_url_dialog_hint">修改后将重启应用并重新登录，请确认地址正确</string>
     <string name="api_url_dialog_preset_label">快速选择</string>

--- a/wkbase/src/test/java/com/chat/base/summary/repository/FakeSummaryApi.kt
+++ b/wkbase/src/test/java/com/chat/base/summary/repository/FakeSummaryApi.kt
@@ -90,6 +90,10 @@ class FakeSummaryApi : SummaryApiService {
         record("GET summaries/$taskId", taskId); return consume("GET summaries/$taskId")
     }
 
+    override suspend fun getSummaryDetailByNo(taskNo: String): Response<JSONObject> {
+        record("GET summaries/$taskNo", taskNo); return consume("GET summaries/$taskNo")
+    }
+
     override suspend fun deleteSummary(taskId: Long): Response<JSONObject> {
         record("DELETE summaries/$taskId", taskId); return consume("DELETE summaries/$taskId")
     }

--- a/wkbase/src/test/java/com/chat/base/summary/repository/SummaryRepositoryImplTest.kt
+++ b/wkbase/src/test/java/com/chat/base/summary/repository/SummaryRepositoryImplTest.kt
@@ -229,6 +229,31 @@ class SummaryRepositoryImplTest {
         assertEquals(true, d.permissions?.canEdit)
     }
 
+    /**
+     * 通知助手卡片深链 "/s/STxxx?sp=..." 走字符串 task_no 反查详情, 与数字 taskId
+     * 版本共用同一套 envelope 解析 (callEnvelope), 这里单独锁一次入参透传 + 解析结果,
+     * 覆盖 SummaryNotifyCoordinator.notifyByTaskNoIfEligible 依赖的这条路径。
+     */
+    @Test
+    fun `getSummaryDetailByNo forwards task_no path param and parses result`() = runTest {
+        api.stubSuccess(
+            "GET summaries/ST12345",
+            JSONObject().apply {
+                put("task_id", 42L)
+                put("title", "T")
+                put("summary_mode", 1)
+                put("status", 3)
+                put("trigger_type", 1)
+            },
+        )
+
+        val res = repo.getSummaryDetailByNo(taskNo = "ST12345")
+        assertTrue(res.isSuccess)
+        val d = res.getOrThrow()
+        assertEquals(42L, d.taskId)
+        assertEquals("ST12345", api.lastRequest("GET summaries/ST12345"))
+    }
+
     @Test
     fun `getTopicTemplates reads templates field`() = runTest {
         api.stubSuccess(

--- a/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
+++ b/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
@@ -203,10 +203,6 @@ public class WKUIKitApplication {
         // 避免与 ChatActivity 产生竞态导致 NPE
         initKitModuleListener();
 
-        // 群总结完成提示：从 SP 恢复上次进程没跟完的任务（进程被杀过）。
-        // 幂等；未登录 / 无在途任务时轮询循环会立刻退出，不占资源。
-        com.chat.base.summary.notify.SummaryNotifyCoordinator.start();
-
         //  (fixing  ReviewBot P1-#3) · 绑定 SpaceSyncCoordinator 到
         // wkim 层的 SyncGate，让 WKConnection 连接成功后的 sync 也走 debounce 守卫。
         // 必须在 WKIM 的首次连接成功回调之前完成——放到同步 init 段开头最安全。

--- a/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
+++ b/wkuikit/src/main/java/com/chat/uikit/WKUIKitApplication.java
@@ -203,6 +203,10 @@ public class WKUIKitApplication {
         // 避免与 ChatActivity 产生竞态导致 NPE
         initKitModuleListener();
 
+        // 群总结完成提示：从 SP 恢复上次进程没跟完的任务（进程被杀过）。
+        // 幂等；未登录 / 无在途任务时轮询循环会立刻退出，不占资源。
+        com.chat.base.summary.notify.SummaryNotifyCoordinator.start();
+
         //  (fixing  ReviewBot P1-#3) · 绑定 SpaceSyncCoordinator 到
         // wkim 层的 SyncGate，让 WKConnection 连接成功后的 sync 也走 debounce 守卫。
         // 必须在 WKIM 的首次连接成功回调之前完成——放到同步 init 段开头最安全。

--- a/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
@@ -56,6 +56,7 @@ import com.chat.base.entity.WKChannelState;
 import com.chat.base.msgitem.WKContentType;
 import com.chat.base.msgitem.WKMsgItemViewManager;
 import com.chat.base.msgitem.WKRevokeProvider;
+import com.chat.base.msgitem.WKSummaryNotifyProvider;
 import com.chat.base.ui.Theme;
 import com.chat.base.ui.components.AvatarView;
 import com.chat.base.ui.components.CounterView;
@@ -863,7 +864,8 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
         String fromName = "";
         if (msg != null && (WKContentType.isSystemMsg(msg.type)
                 || msg.type == WKContentType.revoke
-                || msg.remoteExtra.revoke == 1 || msg.type == WKContentType.screenshot)) {
+                || msg.remoteExtra.revoke == 1 || msg.type == WKContentType.screenshot
+                || msg.type == WKContentType.summaryNotify)) {
             return fromName;
         }
         if (channelType == WKChannelType.PERSONAL || channelType == WKChannelType.CUSTOMER_SERVICE || msg == null || TextUtils.isEmpty(msg.fromUID) || msg.fromUID.equals(WKConfig.getInstance().getUid())) {
@@ -920,6 +922,11 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
                 }
             }
             content = String.format(getContext().getString(R.string.screenshot_tip), name);
+        }
+        // 群总结完成提示（type=21）：content JSON 里没有 "content" 字段，上面的
+        // getShowContent() 会兜底成"未知消息"，这里覆盖成与聊天页气泡同一份文案。
+        if (msg.type == WKContentType.summaryNotify) {
+            content = WKSummaryNotifyProvider.showSummaryTip(getContext(), msg);
         }
         if (msg.remoteExtra.contentEditMsgModel != null) {
             content = msg.remoteExtra.contentEditMsgModel.getDisplayContent();

--- a/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/adapter/ChatConversationAdapter.java
@@ -928,6 +928,14 @@ public class ChatConversationAdapter extends BaseQuickAdapter<ChatConversationMs
         if (msg.type == WKContentType.summaryNotify) {
             content = WKSummaryNotifyProvider.showSummaryTip(getContext(), msg);
         }
+        // 新协议总结提示（type=2000/WK_TIP）：不走 getShowContent() 的通用
+        // "uid==自己显示你"替换 —— 无论是不是本机自己发起的，都要显示发起人姓名本身。
+        if (msg.type == WKContentType.summaryTip) {
+            String resolved = com.chat.base.summary.notify.SummaryTipContent.resolveDisplayContent(msg.content);
+            if (!TextUtils.isEmpty(resolved)) {
+                content = resolved;
+            }
+        }
         if (msg.remoteExtra.contentEditMsgModel != null) {
             content = msg.remoteExtra.contentEditMsgModel.getDisplayContent();
         }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKInteractiveCardProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKInteractiveCardProvider.kt
@@ -198,7 +198,7 @@ class WKInteractiveCardProvider : WKChatBaseProvider() {
                     context.startActivity(intent)
                     true
                 } catch (e: ActivityNotFoundException) {
-                    Log.w("InteractiveCard", "无法打开 URL: $url", e)
+                    Log.w(TAG, "无法打开 URL: $url", e)
                     false
                 }
             },

--- a/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKInteractiveCardProvider.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/provider/WKInteractiveCardProvider.kt
@@ -28,6 +28,9 @@ import com.chat.base.act.WKWebViewActivity
 import com.chat.base.base.WKBaseModel
 import com.chat.base.config.WKConfig
 import com.chat.base.msgitem.WKChatBaseProvider
+import com.chat.base.summary.SummaryDeps
+import com.chat.base.summary.model.TaskStatus
+import com.chat.base.summary.notify.SummaryNotifyCoordinator
 import com.chat.base.msgitem.WKChatIteMsgFromType
 import com.chat.base.msgitem.WKContentType
 import com.chat.base.msgitem.WKUIChatMsgItemEntity
@@ -173,6 +176,17 @@ class WKInteractiveCardProvider : WKChatBaseProvider() {
                 }.run()
             },
             webView = CardActionDispatcher.WebViewLauncher { url ->
+                // 通知助手 (u_10000) 总结完成卡片 "查看详情" 指向 "/s/STxxx?sp=..." 深链,
+                // WebView 内 octo-web JS 不会发群提示 (无独立 WKSDK 连接/eligible 标记),
+                // native 侧在打开 WebView 前做一次判定补上: 解析 taskNo 拉详情, 命中本机
+                // 发起 + eligible 标记在 + 状态已 Completed 时发提示; 不命中则静默忽略。
+                when (val lookup = SummaryNotifyCoordinator.extractSummaryLookup(url)) {
+                    is SummaryNotifyCoordinator.SummaryLookup.ById ->
+                        SummaryNotifyCoordinator.notifyByTaskIdIfEligible(lookup.taskId)
+                    is SummaryNotifyCoordinator.SummaryLookup.ByNo ->
+                        SummaryNotifyCoordinator.notifyByTaskNoIfEligible(lookup.taskNo)
+                    null -> Unit
+                }
                 // 走 App 内 WebView（对齐 WKTextProvider 链接预览卡、WKMarkwonProvider linkResolver
                 // 的处理路径）。FLAG_ACTIVITY_NEW_TASK：context 可能是 application context（Provider 由
                 // adapter 持有，而 adapter 可能在非 Activity context 下 bind），保守带 flag 兜底。
@@ -184,7 +198,7 @@ class WKInteractiveCardProvider : WKChatBaseProvider() {
                     context.startActivity(intent)
                     true
                 } catch (e: ActivityNotFoundException) {
-                    Log.w(TAG, "无法打开 URL: $url", e)
+                    Log.w("InteractiveCard", "无法打开 URL: $url", e)
                     false
                 }
             },

--- a/wkuikit/src/main/java/com/chat/uikit/summary/create/SmartSummaryCreateActivity.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/summary/create/SmartSummaryCreateActivity.kt
@@ -37,7 +37,6 @@ import com.chat.base.summary.model.TopicTemplate
 import com.chat.base.summary.model.TopicTemplatePlaceholder
 import com.chat.uikit.R
 import com.chat.uikit.databinding.ActSmartSummaryCreateBinding
-import com.chat.uikit.summary.SummaryActionToast
 import com.chat.uikit.summary.SummaryHud
 import com.xinbida.wukongim.entity.WKChannel
 import com.xinbida.wukongim.entity.WKChannelType
@@ -207,42 +206,19 @@ class SmartSummaryCreateActivity : WKBaseActivity<ActSmartSummaryCreateBinding>(
         state.effect?.let { effect ->
             when (effect) {
                 is CreateEffect.ToastRes -> SummaryHud.show(this, effect.resId)
-                CreateEffect.Done -> {
-                    // 入口区分 (1:1 对齐 iOS commit 045f8f0 OctoSummaryCreateVC.onSubmit 末尾):
-                    //   - sparkle 入口 (submitSuccessHudText 非空) → 底部 ActionToast +「查看」按钮
-                    //     点击 push SmartSummaryListActivity, 让用户直接进列表跟进度。
-                    //   - 列表 FAB 入口 (submitSuccessHudText 为空) → 维持中央 SummaryHud
-                    //     ("已创建总结任务"), 因为用户已经在列表页, 没必要再给"查看"。
-                    //
-                    // 关键: ActionToast 不能直接挂在 createActivity 的 contentView ——
-                    // finish() 后 createActivity 还没真正 onPause/onStop, 此刻 ActManagerUtils
-                    // 拿到的 currentActivity 仍是 createActivity, toast view 跟着 window 一起被
-                    // destroy, 用户只看到 "闪一下"。SummaryActionToast.show 内部用
-                    // ActivityLifecycleCallbacks 等下一个非 createActivity 的 activity onResumed,
-                    // 这条路径稳, 不依赖具体 finish→resume 时序窗口。
-                    //
-                    // SmartSummaryListActivity 是 main entry, 直接传 SmartSummaryListActivity::class
-                    // 给 callback; sparkle 入口下的目标 activity 一般是 ChatActivity, 但这里不需要
-                    // 强 typed —— 任何先回到前台的非 self activity 都行, 1:1 对齐 iOS topViewController。
-                    val sparkleEntry = !state.submitSuccessHudText.isNullOrBlank()
-                    val successMsg = state.submitSuccessHudText
-                        ?: getString(R.string.summary_create_success)
-                    val viewLabel = getString(R.string.summary_view_action)
-                    val app = application
-                    val self = this
-                    setResult(Activity.RESULT_OK)
+                is CreateEffect.Done -> {
+                    // 创建成功后直接跳原生详情页跟踪进度 (与详情页自身 8s 轮询对齐,
+                    // 详情页观测到 Processing→Completed 时会自动发群提示), 用户按返回
+                    // 自然回到发起前的页面 (聊天页 / 列表页), 不需要手动 finish。
+                    // 列表页入口 (submitSuccessHudText 为空) 也走同一条路径 —— 之前"用户
+                    // 已经在列表页没必要跳详情"的取舍不再成立: 跳详情让用户立刻看到进度,
+                    // 返回就直接回列表, 跟聊天页入口体感一致。
+                    val taskId = effect.taskId
+                    startActivity(
+                        com.chat.uikit.summary.detail.SmartSummaryDetailActivity
+                            .newIntent(this, taskId),
+                    )
                     finish()
-                    if (sparkleEntry) {
-                        SummaryActionToast.show(app, self, successMsg, viewLabel) {
-                            val act = com.chat.base.utils.ActManagerUtils.getInstance().currentActivity
-                                ?: return@show
-                            act.startActivity(
-                                Intent(act, com.chat.uikit.summary.list.SmartSummaryListActivity::class.java),
-                            )
-                        }
-                    } else {
-                        SummaryHud.show(app, successMsg)
-                    }
                 }
             }
             viewModel.consumeEffect()

--- a/wkuikit/src/main/java/com/chat/uikit/summary/create/SmartSummaryCreateActivity.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/summary/create/SmartSummaryCreateActivity.kt
@@ -213,6 +213,11 @@ class SmartSummaryCreateActivity : WKBaseActivity<ActSmartSummaryCreateBinding>(
                     // 列表页入口 (submitSuccessHudText 为空) 也走同一条路径 —— 之前"用户
                     // 已经在列表页没必要跳详情"的取舍不再成立: 跳详情让用户立刻看到进度,
                     // 返回就直接回列表, 跟聊天页入口体感一致。
+                    //
+                    // setResult(RESULT_OK) 必须保留: 列表页 (SmartSummaryListActivity)
+                    // 的 createLauncher 靠这个结果码触发 reloadAndScrollToTop(), 让用户
+                    // 从详情页按返回回到列表时能立刻看到新任务并跳到顶部, 不必手动下拉刷新。
+                    setResult(Activity.RESULT_OK)
                     val taskId = effect.taskId
                     startActivity(
                         com.chat.uikit.summary.detail.SmartSummaryDetailActivity

--- a/wkuikit/src/main/java/com/chat/uikit/summary/create/SmartSummaryCreateViewModel.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/summary/create/SmartSummaryCreateViewModel.kt
@@ -142,6 +142,9 @@ class SmartSummaryCreateViewModel(
                 }
                 return@launch
             }
+            // 登记进 notify coordinator: 任务完成后由本机往来源群发一条系统提示。
+            // 只登记本机发起的任务是"谁创建谁负责发"这条不变量的核心, 见 SummaryNotifyCoordinator。
+            com.chat.base.summary.notify.SummaryNotifyCoordinator.track(res.getOrThrow())
             _state.update { it.copy(submitting = false, effect = CreateEffect.Done) }
         }
     }

--- a/wkuikit/src/main/java/com/chat/uikit/summary/create/SmartSummaryCreateViewModel.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/summary/create/SmartSummaryCreateViewModel.kt
@@ -24,8 +24,8 @@ import kotlinx.coroutines.launch
 
 sealed interface CreateEffect {
     data class ToastRes(val resId: Int) : CreateEffect
-    /** 创建成功 → Activity 关闭 + 通知列表刷新. */
-    object Done : CreateEffect
+    /** 创建成功 → Activity 跳转到原生详情页跟踪进度, 返回回到调用方 (聊天页/列表页). */
+    data class Done(val taskId: Long) : CreateEffect
 }
 
 data class CreateUiState(
@@ -144,8 +144,9 @@ class SmartSummaryCreateViewModel(
             }
             // 登记进 notify coordinator: 任务完成后由本机往来源群发一条系统提示。
             // 只登记本机发起的任务是"谁创建谁负责发"这条不变量的核心, 见 SummaryNotifyCoordinator。
-            com.chat.base.summary.notify.SummaryNotifyCoordinator.track(res.getOrThrow())
-            _state.update { it.copy(submitting = false, effect = CreateEffect.Done) }
+            val taskId = res.getOrThrow()
+            com.chat.base.summary.notify.SummaryNotifyCoordinator.track(taskId)
+            _state.update { it.copy(submitting = false, effect = CreateEffect.Done(taskId)) }
         }
     }
 

--- a/wkuikit/src/main/java/com/chat/uikit/summary/detail/SmartSummaryDetailViewModel.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/summary/detail/SmartSummaryDetailViewModel.kt
@@ -81,8 +81,15 @@ class SmartSummaryDetailViewModel(
      * 失败弹 toast, 同样按 last-known status 继续轮询 (避免 onResume 时一拍失败后再也不刷新)。
      */
     fun loadDetail(silent: Boolean = false) {
+        // 本次调用发起时锁定 taskId: 若这次网络请求在飞行途中 performRegenerate 抢先完成并
+        // 切换了 trackedTaskId, 下面 resume 后必须能分辨"这个响应是不是还对应当前任务",
+        // 否则旧任务的响应会覆盖刚切换到的新任务状态 (detail/loading 被旧任务数据打回去)
+        // (pollJob?.cancel() 只能取消"排下一拍"的协程, 取消不了已经在飞行中的这次
+        // loadDetail 请求 —— 两者是不同的 Job)。
+        val requestedTaskId = trackedTaskId
         viewModelScope.launch {
-            val res = repository.getSummaryDetail(trackedTaskId)
+            val res = repository.getSummaryDetail(requestedTaskId)
+            if (requestedTaskId != trackedTaskId) return@launch
             if (res.isFailure) {
                 if (!silent) {
                     _state.update {
@@ -105,7 +112,28 @@ class SmartSummaryDetailViewModel(
                 )
             }
             _state.update { it.copy(loading = false, detail = detail) }
+            notifyGroupsIfCompleted(detail)
             schedulePollIfNeeded(detail.status)
+        }
+    }
+
+    /**
+     * 群总结完成提示的挂载点: 对齐 octo-web SummaryDetailPage.notifyGroupsOnCompletion,
+     * 但挂在这个详情页自身已有的 8s 轮询节奏上, 不单独起轮询协程 (见
+     * [com.chat.base.summary.notify.SummaryNotifyCoordinator] 类注释)。
+     *
+     * 放行判定完全交给 coordinator 内部的 eligible 账本 (taskId 是否本机 track 过),
+     * 这里不需要也不应该再用"是否观测到状态跃变"参与放行——那样会让"这台设备亲眼看到了
+     * Processing→Completed"跳过账本检查直接发, 挡不住"同一账号在别处创建、这台设备刚好
+     * 停留见证完成"的跨端重复场景。每次拿到 detail 都触发一次检查, isEligible 是幂等
+     * 只读操作, 重复调用无副作用。
+     */
+    private fun notifyGroupsIfCompleted(detail: SummaryDetail) {
+        if (detail.status != TaskStatus.Completed) return
+        viewModelScope.launch {
+            runCatching {
+                com.chat.base.summary.notify.SummaryNotifyCoordinator.notifyIfNeeded(detail)
+            }
         }
     }
 

--- a/wkuikit/src/main/java/com/chat/uikit/summary/detail/SmartSummaryDetailViewModel.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/summary/detail/SmartSummaryDetailViewModel.kt
@@ -140,6 +140,8 @@ class SmartSummaryDetailViewModel(
             // 后端给的新 task_id 必须切过去, 否则 loadDetail 一直拉旧任务的终态 (Cancelled),
             // 用户在详情页看不到新生成的任务从 Processing 走到 Completed (与 list VM 同思路)。
             val newId = res.getOrThrow()
+            // 重新生成同样是"本机发起了一次总结", 新 task_id 也要登记, 否则它完成时没人发提示。
+            com.chat.base.summary.notify.SummaryNotifyCoordinator.track(if (newId > 0) newId else tid)
             if (newId > 0 && newId != tid) {
                 trackedTaskId = newId
                 // 旧 detail 已无效, 立刻清空让 loading 卡显示, 避免短暂闪现旧 cancelled 内容。

--- a/wkuikit/src/main/java/com/chat/uikit/summary/list/SmartSummaryListViewModel.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/summary/list/SmartSummaryListViewModel.kt
@@ -259,20 +259,31 @@ class SmartSummaryListViewModel(
                 "applyStatusChanges: ${changes.entries.joinToString { "${it.key}->${it.value.status}" }}",
             )
         }
-        var anyNewlyCompleted = false
+        val newlyCompletedIds = mutableListOf<Long>()
         _uiState.update { state ->
             val newItems = state.items.map { it ->
                 val upd = changes[it.taskId] ?: return@map it
                 if (it.status == upd.status) return@map it
                 if (upd.status == TaskStatus.Completed && it.status != TaskStatus.Completed) {
-                    anyNewlyCompleted = true
+                    newlyCompletedIds += it.taskId
                 }
                 it.copy(status = upd.status)
             }
             state.copy(items = newItems)
         }
-        // processing -> completed 的 cell 立刻拉一次详情回填 preview, 不必等用户手动刷新
-        if (anyNewlyCompleted) hydratePreview()
+        if (newlyCompletedIds.isNotEmpty()) {
+            // processing -> completed 的 cell 立刻拉一次详情回填 preview, 不必等用户手动刷新
+            hydratePreview()
+            // 列表页 regenerate (performRegenerate) 登记的 eligible 标记, 唯一的消费入口
+            // 之前只有详情页的 loadDetail 轮询——用户重新生成后留在列表页不进详情页,
+            // 任务完成时这里的 poller 只更新了 UI 状态, 没人触发提示判定, eligible 标记
+            // 永远躺在账本里没人消费。notifyByTaskIdIfEligible 本身是 fire-and-forget +
+            // 内部拉详情判定, 不命中 eligible 也是安全的 no-op, 这里可以放心对每个新完成的
+            // 任务都调一次。
+            newlyCompletedIds.forEach {
+                com.chat.base.summary.notify.SummaryNotifyCoordinator.notifyByTaskIdIfEligible(it)
+            }
+        }
     }
 
     fun activeStatusTaskIds(): List<Long> = current.items

--- a/wkuikit/src/main/java/com/chat/uikit/summary/list/SmartSummaryListViewModel.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/summary/list/SmartSummaryListViewModel.kt
@@ -214,6 +214,10 @@ class SmartSummaryListViewModel(
             // 位置不变是因为 taskId/created_at 没变" — 这是 server-side 数据决定的, 客户
             // 端尊重这个排序). 与 iOS [OctoSummaryListVC performRegenerate:topic:] 同语义.
             val newId = res.getOrThrow()
+            // 与详情页 performRegenerate 同口径: 重新生成也是"本机发起", 登记进 notify
+            // coordinator; 后端没给新 id (原地重生成) 时登记原 taskId。
+            com.chat.base.summary.notify.SummaryNotifyCoordinator
+                .track(if (newId > 0) newId else origTaskId)
             if (newId > 0 && newId != origTaskId) {
                 replaceItem(origTaskId) {
                     it.copy(


### PR DESCRIPTION
## What

Android 端新增"群总结任务完成后往来源群发一条系统提示"的能力，并修复实现过程中
发现的并发竞态与跨端（Web/Native）同账号重复发送问题。

## Why

群总结任务完成后需要在来源群里发一条系统提示（"XXX总结了群聊内容"）。这条提示
本应由服务端在任务完成时统一下发，但受限于当前服务端排期，暂时由客户端自己
在观测到任务完成时补发一条 `WK_TIP(2000)` 系统消息。Web 端已有一套同样逻辑
（`groupSummaryNotify.ts`），本次改动是这条能力的 Android 实现。

Closes #（跨端重复发送问题，见下方 Issue）

## How

- 详情页 `SmartSummaryDetailViewModel` 复用自身已有的 8s 轮询节奏，在 `loadDetail`
  拿到详情后检测任务状态，命中 `Completed` 时触发一次提示判定，不新起常驻轮询协程。
- 列表页 `SmartSummaryListViewModel` 的 5s 轮询（`applyStatusChanges`）观测到同样的
  "非完成 → Completed" 跃变时也会触发一次判定——覆盖"在列表页点重新生成、不进
  详情页"这条路径，否则 `performRegenerate` 登记的 eligible 标记没有消费者，
  永远发不出去。
- 通知助手（`u_10000`）卡片消息里的"查看详情"深链（`/s/STxxx?sp=...`）在打开 WebView
  前，由 native 侧先做一次同样的判定补上——因为 WebView 内嵌的 web 页面没有独立的
  SDK 连接，无法自己判断是否该发。
- 新增 `SummaryNotifyCoordinator` / `SummaryNotifyStore`：前者负责判定逻辑和实际发送，
  后者是本地持久化的去重账本（谁创建的任务、哪些群已经通知过）。
- 创建总结成功后直接跳转到原生详情页跟踪进度（而不是回聊天页 toast），让主路径天然
  能观测到状态变化；沿用原来的 `setResult(Activity.RESULT_OK)` 通知列表页刷新。
- 新增后端详情接口的 `taskNo`（字符串 ID）反查支持，配合通知助手卡片深链场景。
- 去重账本的读写改为原子操作（`claimUnnotifiedChannels`），消除并发场景下的重复发送。
- 详情页 `performRegenerate` 切换任务时锁定 taskId，避免飞行中的旧任务网络响应
  覆盖刚切换好的新任务状态。
- 修复放行门禁的逻辑漏洞，解决同账号跨端（Web/Native）操作导致的重复提示（详见
  下方 Issue 的根因分析）。
- 修复 `extractSummaryLookup` 识别 hash 路由 URL（`.../#/summary/detail?taskId=...`）
  时的死代码——原实现假设 `#` 会保留在 `Uri.path` 里再手动截取，但 Android
  `Uri.parse` 已经把 `#` 之后内容整体划进 `fragment` 组件，`path` 本身不可能出现
  `#`，导致这条分支永远不可达，这类 URL 一律被误判成无法识别。改为显式读取
  `uri.fragment` 并重新解析。
- 修复"重新生成已完成的总结不会补发提示"：去重账本 `SENT_KEY` 原来只按 `taskId`
  记账，但后端 `POST /summaries/{id}/regenerate` 是原地复用同一 `taskId` 的
  UPDATE（已用 octo-smart-summary 服务端源码确认，返回体里的 `task_id` 恒等于
  请求时传入的值，不产生新任务记录）。第一次生成完成发过的提示会让"已通知"
  集合永久非空，重新生成完成后 `claimUnnotifiedChannels` 会把同一批 channelId
  全部误判成"已通知"直接跳过，提示发不出第二次。改为按 `"taskId:version"`
  复合键记账，`version` 取自 `getSummaryDetail` 响应里已有的 `result.version`
  字段——服务端 `saveLatestResultAndCompleteTask` 事务保证"新结果落库"严格先于
  "任务状态改为 Completed"提交，所以只要客户端读到 `status=Completed`，
  `result.version` 必然是这一轮生成的权威版本号，不存在取不到的窗口。

**不变量**：谁创建（本机发起创建/重新生成），谁负责发这条提示；同一
`taskId:version`（同一次生成结果）对同一个群不重复发送。

## Checklist

- [x] Code compiles with no new warnings
- [ ] Linter and formatter pass
- [ ] Tests added/updated for the changes
- [ ] All tests pass locally
- [ ] Rebased onto latest `main`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Self-reviewed the full diff from a reviewer's perspective

## Testing

- 真机验证：本机创建总结任务，停留在原生详情页观测到 Processing→Completed 跃变，
  正常发一条提示。
- 真机验证：通过通知助手卡片"查看详情"进入（任务此时已 Completed），正确解析
  `/s/STxxx?sp=...` 深链发一条提示，且只发一次。
- 真机验证：Web 端创建的任务在这台设备上打开原生详情页，无论是否观测到状态
  跃变都不再误发（跨端重复问题的核心验证场景）。
- 真机验证：卡片路径已发过提示后，原生详情页再次进入不重复发送。
- 真机验证：在列表页对某条任务点重新生成、留在列表页不进详情页，任务完成后
  正常收到提示（修复列表页轮询未接入判定的问题）。
- 真机验证：从列表页创建总结、进入详情页后按返回，列表页正确刷新并跳到顶部
  （修复 `setResult` 丢失导致的列表不刷新问题）。
- 真机验证：总结完成收到提示后，点"重新生成"，等新一轮结果完成，群里正确
  收到第二条提示（修复 `SENT_KEY` 仅按 `taskId` 记账导致重新生成不补发的问题）。
- `./gradlew :wkbase:compileDebugKotlin :wkbase:compileDebugUnitTestKotlin :wkuikit:compileDebugKotlin :wkuikit:compileDebugJavaWithJavac`
  编译通过，无新增警告；现有单元测试（`wkbase:testDebugUnitTest`）全部通过。

## Breaking Changes

N/A

---

# 重点问题：重新生成已完成的总结不会补发提示

## What

用户在总结完成、群里已收到一条提示后点击"重新生成"，等新一轮结果生成完成，
群里不会收到第二条提示——无论从详情页还是列表页触发重新生成，结果一致。

## Why

去重账本 `SummaryNotifyStore.SENT_KEY` 原来只按 `taskId` 记账（"这个 taskId
对应的这些群已经通知过了"）。第一次生成完成、提示发出后，这个 taskId 在
`SENT_KEY` 里的记录永久存在（除非达到账本容量上限被淘汰）。

关键在于后端 `POST /summaries/{id}/regenerate` 的语义：它是**原地复用同一个
`taskId` 的 UPDATE**，不会插入新的任务记录。已用 octo-smart-summary 服务端
源码逐行确认（`internal/api/handler/task.go` 的 `Regenerate` handler）：

- 事务里只对已存在的 `SummaryTask` 行执行 `Updates(...)` 把状态改回 `Pending`
  重新排队，从头到尾没有 `Create` 新任务记录。
- 返回体里的 `"task_id": task.ID` 就是入参 `taskID` 本身，恒等于请求时传入的值。

所以重新生成完成后，客户端再次判定"要不要发提示"时，taskId 没变，
`claimUnnotifiedChannels(taskId, channels)` 查到 `SENT_KEY` 里这个 taskId
对应的 channelId 早就记过"已通知"，直接把这次该发的目标全部过滤成空，
`handleCompleted` 提前返回，提示不会被发送第二次。

客户端 `SmartSummaryDetailViewModel.performRegenerate` 里其实已经写了
`if (newId > 0 && newId != tid)` 这样的判断，说明作者预留了"后端可能给新
taskId"这个分支，但实际后端从不会走这个分支，导致这条判断恒为 `false`、
`trackedTaskId` 从不切换——这本身没有错，错的是下游的 `SENT_KEY` 记账没有
考虑到"同一 taskId 可能对应多轮不同的生成结果"这件事。

## How

改用 `"taskId:version"` 复合键记账，`version` 直接读取 `getSummaryDetail`
响应体里已经存在的 `result.version` 字段（后端 `SummaryResult.Version`，由
`GetNextVersion` 查 `MAX(version)+1` 维护，每次生成落地的结果版本号严格递增）。

选择 `version` 而不是客户端自己生成一个本地标识（例如时间戳/UUID）的原因：
`version` 是服务端权威维护的值，且已经在响应体里现成下发，不需要新增字段、
不需要客户端在"点击重新生成"那一刻猜一个值，也不会在跨设备场景下出现
"这台设备造的键那台设备不认识"的问题。

正确性依据（避免"完成了但 version 还没写好"的窗口）：服务端
`saveLatestResultAndCompleteTask` 把"分配新版本号 + 写入新 `SummaryResult`
+ 更新任务当前结果指针 + 把任务状态改成 Completed"全部包在同一个数据库
事务里，且状态变更是事务里的最后一步。也就是说客户端只要读到
`status == Completed`，`result.version` 必然已经是这一轮生成的权威版本号，
不存在"读到 Completed 但 version 缺失/滞后"的中间态。

`ELIGIBLE_KEY`（"这个 taskId 是不是本机发起的"）保持不变，仍然只按
`taskId` 记，因为它的语义与"第几轮生成"无关，重新生成时 `track(taskId)`
重新登记一次即可。

## Testing

真机验证：本机创建总结，收到第一条提示后点重新生成，等新一轮完成，
群里正确收到第二条提示；`SENT_KEY` 里两轮的记录互不覆盖。

## Breaking Changes

N/A