### PR TITLE
fix(chat): 完善表情面板 —— 补回删除键、修复状态错乱与高度空白

### DIFF
--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -632,7 +632,7 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
 
                         @Override
                         public void onNone() {
-                            chatPanelManager.resetToolBar();
+                            chatPanelManager.clearToolBarSelection();
                         }
 
                         @Override

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -619,6 +619,7 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                     .addKeyboardStateListener((visible, height) -> {
                         if (visible && height > 0) {
                             WKConstants.setKeyboardHeight(height);
+                            chatPanelManager.syncEmojiPanelHeightWithKeyboard();
                         }
                     })
                     //可选
@@ -632,6 +633,7 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
 
                         @Override
                         public void onNone() {
+                            chatPanelManager.resetToolBar();
                         }
 
                         @Override

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -619,7 +619,6 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                     .addKeyboardStateListener((visible, height) -> {
                         if (visible && height > 0) {
                             WKConstants.setKeyboardHeight(height);
-                            chatPanelManager.syncEmojiPanelHeightWithKeyboard();
                         }
                     })
                     //可选

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -2332,6 +2332,18 @@ class ChatPanelManager(
         toolBarAdapter!!.notifyItemRangeChanged(0, toolBarAdapter!!.itemCount)
     }
 
+    /**
+     * 面板/键盘真正收起（[helper] 回到 NONE）时用这个，只清选中态，不动 isDisable ——
+     * isDisable 的所有权归 [isDisableToolBar]，多选期间它会先禁用工具栏再收起面板，
+     * 如果这里也清 isDisable，收面板这个动作会把多选设的禁用状态顺手清掉。
+     */
+    fun clearToolBarSelection() {
+        for (index in toolBarAdapter!!.data.indices) {
+            toolBarAdapter!!.getItem(index).isSelected = false
+        }
+        toolBarAdapter!!.notifyItemRangeChanged(0, toolBarAdapter!!.itemCount)
+    }
+
     private fun getEmojiLayout(): View {
         val activity = iConversationContext.chatActivity
 

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -2332,6 +2332,50 @@ class ChatPanelManager(
         toolBarAdapter!!.notifyItemRangeChanged(0, toolBarAdapter!!.itemCount)
     }
 
+    /**
+     * emoji 面板内容区（tab bar 下面那块，[getEmojiLayout] 里的 contentContainer）的高度，
+     * 单位 px —— 跟 [syncEmojiPanelHeightWithKeyboard] 共享，用来判断键盘高度变化后要不要重新排布。
+     */
+    private var emojiPanelContentHeightPx = 0
+
+    /** [getEmojiLayout] 里的 contentContainer，供 [syncEmojiPanelHeightWithKeyboard] 重新设置高度。 */
+    private var emojiPanelContentContainer: View? = null
+
+    /**
+     * 面板内容高度：已知真实键盘高度就用它，否则（新设备/键盘从未弹出过）退化为屏幕高度的 1/3 估算。
+     *
+     * 唯一的高度来源 —— 以后新增面板要跟键盘对齐高度，也应该调这个方法，不要各自重复
+     * "读 WKConstants.getKeyboardHeight() + /3 兜底" 这段逻辑。
+     */
+    private fun resolvePanelContentHeightPx(): Int {
+        val height = WKConstants.getKeyboardHeight()
+        return if (height > 0) height else AndroidUtilities.getScreenHeight() / 3
+    }
+
+    /**
+     * 键盘高度第一次被真实记录（或后续变化，如切换输入法）时，由 [ChatActivity] 的
+     * addKeyboardStateListener 回调调用，把 emoji 面板内容区的高度同步过去。
+     *
+     * 面板此刻必然不可见（这个回调只在键盘正显示时触发，键盘和面板互斥），所以这里改
+     * LayoutParams 不会让用户看到面板跳动 —— 下次点表情按钮重新显示时用的就是新高度。
+     *
+     * 若目前面板还没建出来（[emojiPanelContentContainer] 为空）或高度没变化，直接跳过。
+     */
+    fun syncEmojiPanelHeightWithKeyboard() {
+        val container = emojiPanelContentContainer ?: return
+        val tabBarHeightDp = 36
+        val newContentHeightPx =
+            resolvePanelContentHeightPx() - AndroidUtilities.dp(tabBarHeightDp.toFloat())
+        if (newContentHeightPx == emojiPanelContentHeightPx) return
+        emojiPanelContentHeightPx = newContentHeightPx
+        // 注意单位：这里是 LayoutParams.height 本身，要填 px；跟 getEmojiLayout() 里传给
+        // LayoutHelper.createLinear(...) 的入参不同 —— 那个方法内部会把 int 参数当 dp 再转 px。
+        val params = container.layoutParams
+        params.height = newContentHeightPx
+        container.layoutParams = params
+        container.requestLayout()
+    }
+
     private fun getEmojiLayout(): View {
         val activity = iConversationContext.chatActivity
 
@@ -2381,12 +2425,11 @@ class ChatPanelManager(
         emojiTabBtn.setOnClickListener { selectTab(0) }
         stickerTabBtn.setOnClickListener { selectTab(1) }
 
-        var height = WKConstants.getKeyboardHeight()
-        if (height == 0) {
-            height = AndroidUtilities.getScreenHeight() / 3
-        }
         val tabBarHeightDp = 36
-        val contentHeightPx = height - AndroidUtilities.dp(tabBarHeightDp.toFloat())
+        val contentHeightPx =
+            resolvePanelContentHeightPx() - AndroidUtilities.dp(tabBarHeightDp.toFloat())
+        emojiPanelContentHeightPx = contentHeightPx
+        emojiPanelContentContainer = contentContainer
 
         val root = LinearLayout(activity).apply { orientation = LinearLayout.VERTICAL }
         root.addView(

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -160,6 +160,22 @@ class ChatPanelManager(
     val resetTitleViewListener: () -> Unit,
     val showNewImageListener: (path: String) -> Unit,
 ) {
+    private companion object {
+        /** 内置表情面板的工具栏 sid，见 initToolBar() 里兜底添加的那颗。 */
+        const val EMOJI_TOOL_BAR_SID = "emojiToolBar"
+
+        /** 外部模块自带表情面板时用的 sid —— 存在它就不再兜底加内置表情面板。 */
+        const val STICKER_TOOL_BAR_SID = "chat_toolbar_sticker"
+
+        /**
+         * emoji 网格底部要让出来的高度：悬浮删除键 5dp 下边距 + 5dp 阴影 + 36dp 视觉 + 5dp 阴影
+         * = 51dp，取 52dp。作为 RecyclerView 的 bottom padding，让最后一行能滚到按钮上方、点得到。
+         *
+         * 按钮尺寸改了（view_emoji_panel_delete_btn.xml）就要回来改这里。
+         */
+        const val EMOJI_PANEL_BOTTOM_INSET_DP = 52f
+    }
+
     private val eventKey = "InputPanel"
     private val loginUID = WKConfig.getInstance().uid
     private var isShowSendBtn: Boolean = false
@@ -927,6 +943,7 @@ class ChatPanelManager(
             timer = null
         }
         releaseHoldToTalk()
+        stopEmojiDeleteRepeat()
         EndpointManager.getInstance().remove("emoji_click")
         WKIM.getInstance().robotManager.removeRefreshRobotMenu(iConversationContext.chatChannelInfo.channelID)
         WKIM.getInstance().channelManager.removeRefreshChannelInfo(this.eventKey)
@@ -1095,7 +1112,7 @@ class ChatPanelManager(
         var isAddEmojiLayout = true
         for (menu in toolBarList) {
             if (menu != null) {
-                if (menu.sid.equals("chat_toolbar_sticker")) {
+                if (menu.sid.equals(STICKER_TOOL_BAR_SID)) {
                     isAddEmojiLayout = false
                 }
                 tempToolBarList.add(menu)
@@ -1103,7 +1120,7 @@ class ChatPanelManager(
         }
         if (isAddEmojiLayout) {
             val emojiToolBar = ChatToolBarMenu(
-                "emojiToolBar",
+                EMOJI_TOOL_BAR_SID,
                 R.mipmap.icon_chat_toolbar_emoji,
                 R.mipmap.icon_chat_toolbar_emoji,
                 getEmojiLayout()
@@ -2388,6 +2405,78 @@ class ChatPanelManager(
         return root
     }
 
+    /**
+     * 表情面板右下角的悬浮删除（退格）键。
+     *
+     * 旧表情面板 [com.chat.base.emoji.EmojiFragment] 本来就有这颗键（frag_emoji_layout.xml），
+     * 面板迁到本类纯代码搭建时漏掉了 —— 结果表情点错只能去点输入框调起系统键盘退格，
+     * 而点输入框又会把表情面板收起来。这里把它补回来。
+     *
+     * 单击退一格；长按按 [emojiDeleteRepeatIntervalMs] 连续退格，抬手即停。
+     */
+    @android.annotation.SuppressLint("ClickableViewAccessibility")
+    private fun buildEmojiDeleteButton(): View {
+        val activity = iConversationContext.chatActivity
+        val btn = android.view.LayoutInflater.from(activity)
+            .inflate(R.layout.view_emoji_panel_delete_btn, null, false)
+
+        // passcode_delete 是深色图标，跟主题染色否则深色模式下看不见（对齐 EmojiFragment.initView）
+        Theme.setColorFilter(
+            activity,
+            btn.findViewById<AppCompatImageView>(R.id.emojiDeleteIv),
+            R.color.popupTextColor
+        )
+
+        val hitArea = btn.findViewById<RelativeLayout>(R.id.emojiDeleteLayout)
+        hitArea.setOnClickListener { dispatchBackspace() }
+        hitArea.setOnLongClickListener {
+            startEmojiDeleteRepeat()
+            true  // 消费掉长按，系统不会再补一次 click，避免长按结束后多删一个
+        }
+        hitArea.setOnTouchListener { _, event ->
+            when (event.actionMasked) {
+                android.view.MotionEvent.ACTION_UP,
+                android.view.MotionEvent.ACTION_CANCEL -> stopEmojiDeleteRepeat()
+            }
+            false  // 不拦截，click / longClick 照常走
+        }
+        return btn
+    }
+
+    private val emojiDeleteRepeatIntervalMs = 80L
+
+    private val emojiDeleteRepeat = object : Runnable {
+        override fun run() {
+            // 删空了就自然收尾，不在空输入框上空转
+            if (!dispatchBackspace()) return
+            mainHandler.postDelayed(this, emojiDeleteRepeatIntervalMs)
+        }
+    }
+
+    private fun startEmojiDeleteRepeat() {
+        mainHandler.removeCallbacks(emojiDeleteRepeat)
+        mainHandler.post(emojiDeleteRepeat)
+    }
+
+    private fun stopEmojiDeleteRepeat() {
+        mainHandler.removeCallbacks(emojiDeleteRepeat)
+    }
+
+    /**
+     * 往输入框派发一次退格，与 initListener() 里 "emoji_click" 端点的删除分支同源。
+     *
+     * "[微笑]" 这类自定义表情由 [com.chat.base.emoji.MoonUtil.addEmojiSpan] 插入时带
+     * AlignImageSpan（ReplacementSpan 子类），系统 BaseKeyListener 退格会整体删掉，
+     * 不用在这里特殊处理。
+     *
+     * @return 是否真的删了 —— 输入框已空时返回 false，供长按连续删自行停下。
+     */
+    private fun dispatchBackspace(): Boolean {
+        if (editText.text.isNullOrEmpty()) return false
+        editText.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL))
+        return true
+    }
+
     private fun buildEmojiPanelTabButton(label: String): AppCompatTextView {
         val activity = iConversationContext.chatActivity
         return AppCompatTextView(activity).apply {
@@ -2430,6 +2519,11 @@ class ChatPanelManager(
         val recyclerView = RecyclerView(activity)
         recyclerView.layoutManager = GridLayoutManager(activity, 8)
         recyclerView.adapter = emojiAdapter
+        // 底部让出删除键的高度，否则最后一行被压住点不到。
+        // clipToPadding=false：滚动中表情照常从这块区域穿过，只有停在底部时
+        // 最后一行才停在按钮上方。
+        recyclerView.clipToPadding = false
+        recyclerView.setPadding(0, 0, 0, AndroidUtilities.dp(EMOJI_PANEL_BOTTOM_INSET_DP))
         emojiLayout.addView(
             recyclerView,
             LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT)
@@ -2451,7 +2545,30 @@ class ChatPanelManager(
             }
             recordRecentEmoji(emojiEntry.text)
         }
-        return emojiLayout
+
+        // 悬浮删除键只挂在「表情」tab —— 另一个 tab（自定义表情/贴图）点了直接发送、
+        // 全程不写输入框，退格键在那儿没有作用对象，挂上去还会白占一块防遮挡留白。
+        val emojiRoot = FrameLayout(activity)
+        emojiRoot.addView(
+            emojiLayout,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        )
+
+        emojiRoot.addView(
+            buildEmojiDeleteButton(),
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                Gravity.BOTTOM or Gravity.END
+            ).apply {
+                marginEnd = AndroidUtilities.dp(5f)
+                bottomMargin = AndroidUtilities.dp(5f)
+            }
+        )
+        return emojiRoot
     }
 
     /**
@@ -3294,6 +3411,19 @@ class ChatPanelManager(
                 SoftKeyboardUtils.getInstance().loseFocus(editText)
                 SoftKeyboardUtils.getInstance()
                     .hideInput(iConversationContext.chatActivity, editText)
+                // 表情面板要保留输入框光标：面板里点表情是往输入框插入、右下角退格键是往输入框删，
+                // 没有光标就看不出会插到哪 / 删掉哪。上面的 loseFocus 把焦点转交给了父容器
+                // （见 SoftKeyboardUtils.loseFocus），而 TextView 只在 isFocused() 时才画光标。
+                //
+                // 这里在原有 loseFocus + hideInput 之后再把焦点要回来，而不是直接不调 loseFocus ——
+                // 保留那套压键盘的顺序，避免动到它原本可能在兜的 OEM 键盘反弹。requestFocus 本身
+                // 不拉输入法，且 ChatActivity 是 stateAlwaysHidden，重新获焦也不会把系统键盘带出来。
+                // 其他工具栏面板（+ 更多等）不涉及输入框编辑，行为保持不变。
+                if (mChatToolBarMenu.sid == EMOJI_TOOL_BAR_SID ||
+                    mChatToolBarMenu.sid == STICKER_TOOL_BAR_SID
+                ) {
+                    SoftKeyboardUtils.getInstance().requestFocus(editText)
+                }
             }
         }
         if (mChatToolBarMenu.iChatToolBarListener != null) mChatToolBarMenu.iChatToolBarListener.onChecked(

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -2332,50 +2332,6 @@ class ChatPanelManager(
         toolBarAdapter!!.notifyItemRangeChanged(0, toolBarAdapter!!.itemCount)
     }
 
-    /**
-     * emoji 面板内容区（tab bar 下面那块，[getEmojiLayout] 里的 contentContainer）的高度，
-     * 单位 px —— 跟 [syncEmojiPanelHeightWithKeyboard] 共享，用来判断键盘高度变化后要不要重新排布。
-     */
-    private var emojiPanelContentHeightPx = 0
-
-    /** [getEmojiLayout] 里的 contentContainer，供 [syncEmojiPanelHeightWithKeyboard] 重新设置高度。 */
-    private var emojiPanelContentContainer: View? = null
-
-    /**
-     * 面板内容高度：已知真实键盘高度就用它，否则（新设备/键盘从未弹出过）退化为屏幕高度的 1/3 估算。
-     *
-     * 唯一的高度来源 —— 以后新增面板要跟键盘对齐高度，也应该调这个方法，不要各自重复
-     * "读 WKConstants.getKeyboardHeight() + /3 兜底" 这段逻辑。
-     */
-    private fun resolvePanelContentHeightPx(): Int {
-        val height = WKConstants.getKeyboardHeight()
-        return if (height > 0) height else AndroidUtilities.getScreenHeight() / 3
-    }
-
-    /**
-     * 键盘高度第一次被真实记录（或后续变化，如切换输入法）时，由 [ChatActivity] 的
-     * addKeyboardStateListener 回调调用，把 emoji 面板内容区的高度同步过去。
-     *
-     * 面板此刻必然不可见（这个回调只在键盘正显示时触发，键盘和面板互斥），所以这里改
-     * LayoutParams 不会让用户看到面板跳动 —— 下次点表情按钮重新显示时用的就是新高度。
-     *
-     * 若目前面板还没建出来（[emojiPanelContentContainer] 为空）或高度没变化，直接跳过。
-     */
-    fun syncEmojiPanelHeightWithKeyboard() {
-        val container = emojiPanelContentContainer ?: return
-        val tabBarHeightDp = 36
-        val newContentHeightPx =
-            resolvePanelContentHeightPx() - AndroidUtilities.dp(tabBarHeightDp.toFloat())
-        if (newContentHeightPx == emojiPanelContentHeightPx) return
-        emojiPanelContentHeightPx = newContentHeightPx
-        // 注意单位：这里是 LayoutParams.height 本身，要填 px；跟 getEmojiLayout() 里传给
-        // LayoutHelper.createLinear(...) 的入参不同 —— 那个方法内部会把 int 参数当 dp 再转 px。
-        val params = container.layoutParams
-        params.height = newContentHeightPx
-        container.layoutParams = params
-        container.requestLayout()
-    }
-
     private fun getEmojiLayout(): View {
         val activity = iConversationContext.chatActivity
 
@@ -2426,22 +2382,19 @@ class ChatPanelManager(
         stickerTabBtn.setOnClickListener { selectTab(1) }
 
         val tabBarHeightDp = 36
-        val contentHeightPx =
-            resolvePanelContentHeightPx() - AndroidUtilities.dp(tabBarHeightDp.toFloat())
-        emojiPanelContentHeightPx = contentHeightPx
-        emojiPanelContentContainer = contentContainer
 
         val root = LinearLayout(activity).apply { orientation = LinearLayout.VERTICAL }
         root.addView(
             tabBar,
             LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, tabBarHeightDp)
         )
+        // contentContainer 吃满 root 除 tabBar 外的剩余高度 —— root 本身会被 moreLayout 的
+        // 父级 PanelContainer 约束到面板的真实高度（由 PanelSwitchHelper 按键盘高度撑开），
+        // 这样 emoji 面板永远和面板容器一样高，不需要自己读键盘高度再算一遍、也不需要在键盘
+        // 高度变化时手动同步，从根上避免两套高度来源不一致导致的空白/裁切。
         root.addView(
             contentContainer,
-            LayoutHelper.createLinear(
-                LayoutHelper.MATCH_PARENT,
-                (contentHeightPx / AndroidUtilities.density).toInt()
-            )
+            LinearLayout.LayoutParams(LayoutHelper.MATCH_PARENT, 0, 1f)
         )
 
         selectTab(0)  // 默认 emoji tab

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -2420,7 +2420,9 @@ class ChatPanelManager(
      * 面板迁到本类纯代码搭建时漏掉了 —— 结果表情点错只能去点输入框调起系统键盘退格，
      * 而点输入框又会把表情面板收起来。这里把它补回来。
      *
-     * 单击退一格；长按按 [emojiDeleteRepeatIntervalMs] 连续退格，抬手即停。
+     * 单击退一格；触摸长按按 [emojiDeleteRepeatIntervalMs] 连续退格，抬手即停。
+     * 无障碍服务（TalkBack）、硬件键盘/D-pad 触发的长按不经过触摸事件，不会启动连续
+     * 退格，退化成一次单击，避免没有"抬手"信号可停的失控循环（见 [emojiDeleteTouchDown]）。
      */
     @android.annotation.SuppressLint("ClickableViewAccessibility")
     private fun buildEmojiDeleteButton(): View {
@@ -2437,25 +2439,43 @@ class ChatPanelManager(
 
         val hitArea = btn.findViewById<RelativeLayout>(R.id.emojiDeleteLayout)
         hitArea.setOnClickListener { dispatchBackspace() }
-        hitArea.setOnLongClickListener {
-            startEmojiDeleteRepeat()
-            true  // 消费掉长按，系统不会再补一次 click，避免长按结束后多删一个
-        }
         hitArea.setOnTouchListener { _, event ->
             when (event.actionMasked) {
+                android.view.MotionEvent.ACTION_DOWN -> emojiDeleteTouchDown = true
                 android.view.MotionEvent.ACTION_UP,
-                android.view.MotionEvent.ACTION_CANCEL -> stopEmojiDeleteRepeat()
+                android.view.MotionEvent.ACTION_CANCEL -> {
+                    emojiDeleteTouchDown = false
+                    stopEmojiDeleteRepeat()
+                }
             }
             false  // 不拦截，click / longClick 照常走
         }
+        hitArea.setOnLongClickListener {
+            // 长按连续删格只在真实触摸序列内启动。无障碍服务（TalkBack）的
+            // ACTION_LONG_CLICK、硬件键盘/D-pad 的长按都能直接触发 performLongClick()、
+            // 不经过任何 MotionEvent —— 这种情况下没有"抬手"这个信号能停下重复删除，
+            // 会一直删到输入框清空、无法撤销。emojiDeleteTouchDown 只由触摸事件维护，
+            // 这里没有真实触摸就不启动重复，返回 false 让框架继续走 performClick()，
+            // 退化成一次单击退格。
+            if (emojiDeleteTouchDown) {
+                startEmojiDeleteRepeat()
+                true  // 消费掉长按，系统不会再补一次 click，避免长按结束后多删一个
+            } else {
+                false
+            }
+        }
         return btn
     }
+
+    private var emojiDeleteTouchDown = false
 
     private val emojiDeleteRepeatIntervalMs = 80L
 
     private val emojiDeleteRepeat = object : Runnable {
         override fun run() {
-            // 删空了就自然收尾，不在空输入框上空转
+            // 按实际删掉的字符数判断要不要继续，而不是"输入框是否为空"——光标在开头时
+            // （比如打开面板前先把光标拖到最前面）退格不会删掉任何东西，若只看"是否为空"
+            // 会一直是非空、一直返回 true，在空转的输入框上无限重复下去。
             if (!dispatchBackspace()) return
             mainHandler.postDelayed(this, emojiDeleteRepeatIntervalMs)
         }
@@ -2477,12 +2497,15 @@ class ChatPanelManager(
      * AlignImageSpan（ReplacementSpan 子类），系统 BaseKeyListener 退格会整体删掉，
      * 不用在这里特殊处理。
      *
-     * @return 是否真的删了 —— 输入框已空时返回 false，供长按连续删自行停下。
+     * @return 是否真的删掉了字符 —— 按删除前后的文本长度判断，不是"输入框是否非空"。
+     * 光标在开头时非空文本也可能一格都删不掉，返回 false 供长按连续删自行停下，
+     * 避免在空转的输入框上无限重复。
      */
     private fun dispatchBackspace(): Boolean {
-        if (editText.text.isNullOrEmpty()) return false
+        val lengthBeforeDelete = editText.text?.length ?: return false
+        if (lengthBeforeDelete == 0) return false
         editText.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL))
-        return true
+        return (editText.text?.length ?: 0) < lengthBeforeDelete
     }
 
     private fun buildEmojiPanelTabButton(label: String): AppCompatTextView {

--- a/wkuikit/src/main/res/layout/view_emoji_panel_delete_btn.xml
+++ b/wkuikit/src/main/res/layout/view_emoji_panel_delete_btn.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  表情面板右下角的悬浮删除（退格）键。
+  样式 1:1 复刻旧表情面板 wkbase/res/layout/frag_emoji_layout.xml 的删除键块 —— 迁到
+  ChatPanelManager 纯代码搭面板时这颗键漏掉了，导致点错表情只能去点输入框调系统键盘退格。
+  由 ChatPanelManager.buildEmojiContentView() inflate 后叠在 emoji 网格右下角。只挂「表情」
+  tab —— 「自定义表情」tab 点了直接发送、全程不写输入框，退格键在那儿没有作用对象。
+
+  视觉尺寸 44×36dp = padding(10/9) + icon(24×18)，外面 ShadowLayout 再各撑 5dp 阴影。
+  改这里的尺寸要同步 ChatPanelManager.EMOJI_PANEL_BOTTOM_INSET_DP —— 网格底部留白是按
+  按钮总高算的。icon 用默认 fitCenter，24×18 不会把 passcode_delete 拉变形。
+-->
+<com.chat.base.views.ShadowLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/emojiDeleteShadowLayout"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:hl_cornerRadius="5dp"
+    app:hl_dx="0dp"
+    app:hl_dy="0dp"
+    app:hl_shadowBackColor="@color/colorDark"
+    app:hl_shadowColor="@color/colorDark"
+    app:hl_shadowLimit="5dp">
+
+    <RelativeLayout
+        android:id="@+id/emojiDeleteLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/white_bg"
+        android:clickable="true"
+        android:contentDescription="@string/str_delete"
+        android:focusable="true"
+        android:paddingStart="10dp"
+        android:paddingTop="9dp"
+        android:paddingEnd="10dp"
+        android:paddingBottom="9dp">
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/emojiDeleteIv"
+            android:layout_width="24dp"
+            android:layout_height="18dp"
+            android:src="@mipmap/passcode_delete" />
+    </RelativeLayout>
+</com.chat.base.views.ShadowLayout>


### PR DESCRIPTION
Closes #152 

## 背景

表情面板从旧版 `EmojiFragment` 迁移到 `ChatPanelManager` 纯代码搭建后，
存在功能缺失和两个显示 bug，本 PR 一并修复。

> 审查中有意见认为悬浮删除键（改动 #1）与 issue #150/#152 报告的两个
> 显示 bug（改动 #2、#3）范围不同，建议拆成两个 PR。这里保留合并提交：
> 删除键和显示 bug 都集中在 `toolBarClick()` / `getEmojiLayout()` 这同
> 一小块代码，拆开评审对读者反而更割裂，且删除键的问题已经在本轮修复，
> 不构成阻塞项。已知的非阻塞遗留问题记录在改动 #1 末尾，作为后续可选
> 跟进项。

## 改动内容

### 1. 补回表情面板悬浮删除键

旧版 `EmojiFragment`（`frag_emoji_layout.xml`）自带右下角悬浮删除（退格）键，
迁移到 `ChatPanelManager` 后被遗漏，导致表情点错后只能去点输入框唤起系统
键盘退格 —— 但点输入框又会把表情面板收起来，体验割裂。

- 新增 `view_emoji_panel_delete_btn.xml`，挂在"表情" tab 右下角悬浮；
  "自定义表情/贴图" tab 点击直接发送、不写输入框，故不挂此按钮。
- 单击退一格；触摸长按以 80ms 间隔连续退格，抬手即停，输入框删空自动
  收尾。
- emoji 网格底部让出 52dp padding（`clipToPadding=false`），避免最后一行
  被删除键遮住点不到。

**审查发现并已修复**：长按连续退格最初只由 `OnTouchListener` 的
`ACTION_UP`/`ACTION_CANCEL` 停止，但 `onLongClick` 能在没有任何
`MotionEvent` 的情况下被触发——无障碍服务（TalkBack）的
`ACTION_LONG_CLICK`、硬件键盘/D-pad 长按都能直接调用
`performLongClick()`，这些场景里"抬手"这个停止信号根本不会发生，会一直
连续退格到把整段草稿删空、无法撤销。另外 `dispatchBackspace()` 原来按
"输入框是否为空"判断要不要继续，光标停在开头时非空文本也可能一格都删
不掉，同样会导致重复删除的循环空转不停。现已修复：
- 新增 `emojiDeleteTouchDown` 标志，只由触摸事件维护；`onLongClick` 只
  在这个标志为真时才启动连续退格，否则返回 `false` 让框架走
  `performClick()`，无障碍/键盘长按退化成一次可预期的单击退格。
- `dispatchBackspace()` 改为比较删除前后的文本长度，只有真的删掉了字符
  才返回 `true` 继续下一轮，堵住光标在开头时的死循环。

**已知遗留问题（非阻塞，本轮不处理）**：
- 删除键可点击区域 44×36dp，小于 Android 48dp 最小触摸目标建议，也比
  旧版 `EmojiFragment` 的 55×50dp 小；`view_emoji_panel_delete_btn.xml`
  头部注释"1:1 复刻"与实际尺寸不符，需要修正措辞或放大触摸区域。
- 语音模式下 `toggleVoiceMode()` 只隐藏了输入框容器，没有隐藏表情按钮
  所在的工具栏，面板仍可打开、删除键仍可点，会静默修改用户看不到的
  草稿内容。
- `toolBarClick()` 里 `requestFocus` 的条件包含
  `STICKER_TOOL_BAR_SID`，但本仓库范围内没有任何模块注册这个 sid 的
  工具栏，这条分支目前无法在本仓库验证；如果确实有外部模块使用，需要
  补充说明来源，否则应该去掉。

### 2. 修复：键盘/表情面板都未显示时，点表情按钮误唤出键盘

**现象**：表情面板与键盘都未显示的情况下，点击表情按钮有时不会弹出表情
面板，反而唤出系统键盘。

**根因**：表情面板是否"已显示"这一状态由 `ChatToolBarMenu.isSelected`
手动维护，而不是实时查询 `PanelSwitchHelper` 的真实状态。若用户通过点击
聊天内容区域（`RelativeContentContainer` 的自动收起功能）把面板关闭，
`PanelSwitchHelper` 的状态回到 `NONE`，但 `isSelected` 未被同步清空，
仍停留在 `true`。下一次点表情按钮时，代码误判为"面板已显示"，走了
"收起面板、弹键盘"的分支。

**修复**：`ChatActivity` 的 `OnPanelChangeListener.onNone()` 回调补上
`chatPanelManager.clearToolBarSelection()`，保证面板真实关闭时同步清空
`isSelected`（只清选中态，不动 `isDisable`，原因见改动 #5）。

### 3. 修复：表情面板高度与面板容器不一致导致的空白/裁切

**现象**：新设备首次使用，先唤出键盘、再点表情按钮切换到表情面板，
面板下方会出现一块背景色空白条（或反过来内容被裁切，取决于机型）。

**根因**：表情面板内容高度曾经由 `ChatPanelManager` 自己读
`WKConstants.getKeyboardHeight()` 算一遍（未知时用"屏幕高度 / 3"估算）。
但表情面板实际显示的容器（`PanelContainer`）高度是由第三方库
`PanelSwitchHelper` 控制的：项目没有为该面板注册 `PanelHeightMeasurer`，
所以库会走它自己的 `PanelUtil.getKeyBoardHeight()`，读的是**另一套**
SharedPreferences（键盘高度未知时默认 230dp）。也就是"面板容器"和
"面板内容"两边各用一套互不相通的键盘高度兜底值，两者不一致时就会露出
空白或裁切内容——这个问题在键盘从未测量过的新设备上必然出现，此前的
"记录到真实键盘高度后同步一次"的方案无法覆盖这种情况，因为同步动作要
等键盘第一次真实弹出才会触发。

**修复**：不再让表情面板自己计算高度、也不再监听键盘高度做同步。
`getEmojiLayout()` 里 tab bar 固定 36dp，`contentContainer` 改用
`LinearLayout.LayoutParams(MATCH_PARENT, 0, weight = 1f)`，吃满 `root`
除 tab bar 外的剩余空间；`root` 本身会被 `moreLayout` 的父级
`PanelContainer` 约束到面板的真实高度。这样表情面板永远和面板容器
本身一样高，不管容器高度来自哪套兜底值、键盘是否已经测量过，都不会
产生不一致。

### 4. 面板展开后把焦点交还输入框，保留光标可见

**背景**：表情/贴图面板展开时，`toolBarClick()` 会依次调用
`loseFocus(editText)` 和 `hideInput(...)` 收起系统键盘。但表情面板里
点表情是往输入框插入内容、悬浮删除键是往输入框删内容，如果输入框没有
焦点，`TextView` 不会画光标，用户看不出下一次点击会插入/删除到哪个
位置。

**改动**：在原有 `loseFocus + hideInput` 之后，针对表情面板和贴图面板
（`EMOJI_TOOL_BAR_SID` / `STICKER_TOOL_BAR_SID`）再调一次
`requestFocus(editText)`，只把焦点要回来、不触发系统键盘弹出
（`ChatActivity` 的 `windowSoftInputMode` 是 `stateAlwaysHidden`）。
其他工具栏面板（"+更多"等）不涉及输入框编辑，行为不受影响。

### 5. 修复：多选模式下工具栏被意外重新启用

**背景**：改动 #2 最初直接复用了已有的 `resetToolBar()` 来清 `isSelected`，
但这个方法同时会把 `isDisable` 也清空。`isDisable` 的所有权本来完全归
`isDisableToolBar()`：多选模式 `showMultipleChoice()` 会先
`isDisableToolBar(true)` 禁用并置灰工具栏，再调 `helper.resetState()`
收起表情面板/键盘——而 `resetState()` 会同步触发 `onNone()` 回调。改动
#2 上线后，这条"收面板"的路径会顺带把刚设置好的 `isDisable = true`
清回 `false`，导致多选进行中，工具栏图标却恢复了完全不透明、可点击的
状态，点击还能再打开一个新的表情面板。

**修复**：新增 `clearToolBarSelection()`，只清 `isSelected`，不再动
`isDisable`。`onNone()` 改为调用这个新方法。`resetToolBar()`（连带清
`isDisable`）保留给原本就需要整体复位的场景（返回键、多选删除消息收尾、
切换频道），这些场景语义上本就要重置一切，不受影响。

## 测试

- [ ] 清空 App 数据模拟新设备，直接点表情按钮，面板正常显示无空白/裁切
- [ ] 点输入框唤出键盘 → 再点表情按钮切回面板，面板高度与容器一致，无空白
- [ ] 打开表情面板后点击聊天消息列表区域收起面板，再点表情按钮，应正常
      弹出表情面板而不是键盘
- [ ] 表情面板内单击/长按删除键，验证退格与连续退格行为
- [ ] 光标拖到草稿开头再长按删除键，应立即停止重复、不空转
- [ ] 开启 TalkBack，双击长按删除键，只应退一格，不应连续删除
- [ ] 深色模式下删除键图标可见
- [ ] 打开表情/贴图面板后，输入框光标可见，点表情/删除键能看到插入/
      删除的具体位置
- [ ] 打开表情面板后长按消息进入多选模式，工具栏图标应保持置灰、不可点击