### PR TITLE
fix(voice): 语音识别结果编辑发送链路修复

### DIFF
--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatActivity.java
@@ -627,7 +627,11 @@ public class ChatActivity extends SwipeBackActivity implements IConversationCont
                         @Override
                         public void onKeyboard() {
                             chatPanelManager.resetToolBar();
-                            SoftKeyboardUtils.getInstance().requestFocus(wkVBinding.editText);
+                            // 语音识别结果气泡展示期间，气泡自己的 EditText 可能正持有焦点；
+                            // 此处若照常抢回主输入框焦点，会把刚获得的气泡焦点冲掉。
+                            if (!chatPanelManager.isVoiceResultBubbleActive()) {
+                                SoftKeyboardUtils.getInstance().requestFocus(wkVBinding.editText);
+                            }
                         }
 
                         @Override

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -1715,10 +1715,17 @@ class ChatPanelManager(
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 this.start = start
                 this.count = count
+                // 🔴 语音模式下发送按钮显示异常：本 watcher 写 sendIV.visibility 时原先缺少
+                // isVoiceMode 判断（updateSendBtnForTray() 在 :4556 有对等的早返回，这里没有）。
+                // 语音模式下 onSendText 会用 editText.setText(text) 临时顶替文本去拼图文消息，
+                // 这个赋值本身会触发本 watcher，从而在语音模式下把 sendIV 错误置为可见——
+                // 用户看到的是「按住说话」条，但旁边多出一个可点的发送键，状态与实际输入模式不
+                // 一致。isShowSendBtn 仍照常更新（退出语音模式后据此正确恢复），只是可见性的
+                // 写入在语音模式下跳过，交由 toggleVoiceMode() 统一控制 sendIV 显隐。
                 if (!TextUtils.isEmpty(s.toString())) {
                     val content = StringUtils.replaceBlank(s.toString())
                     if (!TextUtils.isEmpty(content)) {
-                        if (!isShowSendBtn) {
+                        if (!isShowSendBtn && !isVoiceMode) {
                             sendIV.clearColorFilter()
                             sendIV.visibility = View.VISIBLE
                             CommonAnim.getInstance().animImageView(sendIV)
@@ -1728,10 +1735,10 @@ class ChatPanelManager(
                         // 文本为空白：托盘有图时仍保留发送键（Phase 2 纯图片托盘可发）。
                         if (!richTextTray.isEmpty()) {
                             isShowSendBtn = true
-                            sendIV.visibility = View.VISIBLE
+                            if (!isVoiceMode) sendIV.visibility = View.VISIBLE
                         } else {
                             isShowSendBtn = false
-                            sendIV.visibility = View.GONE
+                            if (!isVoiceMode) sendIV.visibility = View.GONE
                         }
                     }
                     if (flame == 1) {
@@ -1744,10 +1751,10 @@ class ChatPanelManager(
                     // 文本清空：托盘有图时仍保留发送键（Phase 2 纯图片托盘可发）。
                     if (!richTextTray.isEmpty()) {
                         isShowSendBtn = true
-                        sendIV.visibility = View.VISIBLE
+                        if (!isVoiceMode) sendIV.visibility = View.VISIBLE
                     } else {
                         isShowSendBtn = false
-                        sendIV.visibility = View.GONE
+                        if (!isVoiceMode) sendIV.visibility = View.GONE
                     }
                 }
                 // slash command detection for bot chats
@@ -2738,10 +2745,20 @@ class ChatPanelManager(
                         override fun onSendText(text: String) {
                             // 有 pending 图：STT 文本作 caption，与图聚合（或 caption 全空时纯图）。
                             // 对齐 iOS holdToTalkManager:sendText: → _commitPendingWithCaption。
+                            //
+                            // 🔴 已修复的草稿丢失问题：这里会把 editText 临时顶替成 STT 文本（下一行），
+                            // flushRichTextTraySend 内部又是从 editText 读文本去发送/判断是否清空的，
+                            // 它完全不知道"顶替前"用户还有一份没发出去的草稿 previous。旧实现只在
+                            // !handled（tray 未接管）时才把 previous 写回去；handled=true（tray 正常
+                            // 接管、走异步发送）时函数直接 return，previous 从此没有任何路径被恢复，
+                            // 而 flushRichTextTraySend 的 onEnqueued 回调随后会按"消费快照==当前内容"
+                            // 判定清空 editText——清掉的其实是 STT placeholder，用户原始草稿已经在
+                            // 被顶替的那一刻静默丢失。现在把 previous 传给 flushRichTextTraySend，
+                            // 由它在真正该清空 editText 的那一刻，改为写回 previous。
                             if (!richTextTray.isEmpty()) {
                                 val previous = editText.text?.toString() ?: ""
                                 editText.setText(text)
-                                if (!flushRichTextTraySend()) {
+                                if (!flushRichTextTraySend(restoreComposerText = previous)) {
                                     // tray 未接管（如 reply/edit 态）— 复原文本并按原文本路径发出。
                                     editText.setText(previous)
                                     sendVoiceTextDirect(text)
@@ -4345,7 +4362,14 @@ class ChatPanelManager(
      * @return true 表示本次点击已被托盘发送接管（含「超字节弹转文件框」）；false 表示未接管
      *         （如进入 reply/edit 态），调用方应继续走原有文本 / reply / edit 发送路径。
      */
-    private fun flushRichTextTraySend(): Boolean {
+    /**
+     * @param restoreComposerText 语音输入场景专用：调用前 editText 已被 STT 文本临时顶替
+     *        （见 onSendText 的 caption 聚合），这里保存的是被顶替前、用户真正在打的草稿。
+     *        消息入队后若 editText 按 shouldClearComposer 被清空，用这份草稿写回，而不是
+     *        placeholder 文本随手一清就把用户还没发的字丢了。null 表示无需还原（如普通点击
+     *        发送键，editText 本来就是要发的内容）。
+     */
+    private fun flushRichTextTraySend(restoreComposerText: String? = null): Boolean {
         // in-flight 防重入：上一次托盘发送还在上传图片期间，吞掉重复点击，避免重复 type=14。
         if (richTextTraySending) {
             return true
@@ -4374,7 +4398,13 @@ class ChatPanelManager(
             // （rawTextRaw，含空白）时才清，否则保留用户新打的内容，绝不擦新草稿。
             val current = editText.text?.toString() ?: ""
             if (WKRichTextSender.shouldClearComposer(rawTextRaw, current)) {
-                editText.text = null
+                if (!restoreComposerText.isNullOrEmpty()) {
+                    // 语音场景：清掉的是 STT placeholder，不是用户草稿——写回真正的草稿。
+                    editText.setText(restoreComposerText)
+                    editText.setSelection(restoreComposerText.length)
+                } else {
+                    editText.text = null
+                }
                 lastInputTime = 0
             }
             if (chatTopView?.visibility == View.VISIBLE) {
@@ -4551,21 +4581,33 @@ class ChatPanelManager(
      * 托盘非空时，即便输入框没有文本也应允许发送（纯图片托盘 → 发单条 RichText，
      * 或退化为逐张图片由发送路径决定）。文本存在与否的发送键显隐仍由 TextWatcher 管理，
      * 这里只在「有图无字」时把发送键补显出来；「无图无字」时不强制显示。
+     *
+     * 🔴 语音模式下发送键在切回键盘后消失（本分支曾修过一版，此次是同类问题的另一条触发
+     * 路径）：图文混排发送是异步的（WKRichTextSender 上传中），用户点发送键后若在上传完成
+     * 前切到语音模式，onEnqueued 回调会在语音模式期间才落地，调用本函数——旧实现在语音模式
+     * 下整函数早返回，导致 isShowSendBtn 停留在「进语音模式前」的旧值，没有跟着托盘被清空这
+     * 件事同步更新。等用户再切回键盘，updateSendBtnForTray 用这个失真的 isShowSendBtn 做防抖
+     * 判断（if (!isShowSendBtn) 才去设可见性），误判为「已经显示，不用再设」，实际 sendIV 早
+     * 已被 toggleVoiceMode 设成 GONE，于是发送键就此消失。修复：isShowSendBtn 这个状态量始终
+     * 正常计算更新，只把 sendIV.visibility 的写入放在语音模式判断之后跳过，两件事解耦。
      */
     private fun updateSendBtnForTray() {
-        if (isVoiceMode) {
-            return
-        }
         val hasText = !TextUtils.isEmpty(StringUtils.replaceBlank(editText.text?.toString() ?: ""))
         val hasTrayImages = !richTextTray.isEmpty()
-        if (hasTrayImages || hasText) {
-            if (!isShowSendBtn) {
+        val shouldShow = hasTrayImages || hasText
+        val wasShowing = isShowSendBtn
+        isShowSendBtn = shouldShow
+        if (isVoiceMode) {
+            // 语音模式下发送键本就应保持隐藏，交由 toggleVoiceMode() 统一控制；这里只同步
+            // isShowSendBtn 状态，避免退出语音模式后该状态与实际托盘/文本内容脱节。
+            return
+        }
+        if (shouldShow) {
+            if (!wasShowing) {
                 sendIV.clearColorFilter()
                 sendIV.visibility = View.VISIBLE
             }
-            isShowSendBtn = true
         } else {
-            isShowSendBtn = false
             sendIV.visibility = View.GONE
         }
     }

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -187,6 +187,14 @@ class ChatPanelManager(
     private var isVoiceMode = false
     private var holdToTalkManager: HoldToTalkManager? = null
     private var isResultMode = false
+
+    /**
+     * 语音结果气泡展示期间（含思考中/追加录音子状态），气泡里的 bubbleEt 可能正持有焦点。
+     * PanelSwitchLayout 监听主输入框 focus/window-insets 变化，一旦感知变化就会在
+     * ChatActivity.onKeyboard() 里强制把焦点拉回主输入框，与气泡抢焦点。此处供
+     * ChatActivity 查询以豁免这次抢焦点。
+     */
+    fun isVoiceResultBubbleActive(): Boolean = isResultMode
     private var resultBubbleEditText: android.widget.EditText? = null
     private var appendOverlay: View? = null
     private var appendWaveBars: List<View>? = null
@@ -2719,6 +2727,7 @@ class ChatPanelManager(
             editTextContainer.visibility = View.GONE
             holdToTalkBtn.visibility = View.VISIBLE
             sendIV.visibility = View.GONE
+            isShowSendBtn = false
             markdownIv.visibility = View.GONE
             SoftKeyboardUtils.getInstance().loseFocus(editText)
             SoftKeyboardUtils.getInstance().hideInput(iConversationContext.chatActivity, editText)
@@ -2762,10 +2771,6 @@ class ChatPanelManager(
                         override fun onRecordingStarted() {}
                         override fun onRecordingStopped() {}
 
-                        override fun getCurrentInputText(): String? {
-                            return editText.text?.toString()
-                        }
-
                         override fun getChatContext(): String? {
                             return com.chat.uikit.chat.face.WKVoiceViewManager.getInstance()
                                 .buildChatContext(iConversationContext)
@@ -2780,11 +2785,11 @@ class ChatPanelManager(
                         }
 
                         override fun onAppendText(text: String) {
+                            // text 是本次追加录音后、服务端基于已转写文本续接返回的完整文本，
+                            // 整体覆盖显示（对齐 iOS finishThinkingAndShowText），而非追加拼接。
                             resultBubbleEditText?.let { et ->
-                                val current = et.text?.toString() ?: ""
-                                val newText = if (current.isEmpty()) text else "$current$text"
-                                et.setText(newText)
-                                et.setSelection(newText.length)
+                                et.setText(text)
+                                et.setSelection(text.length)
                             }
                         }
 
@@ -2868,6 +2873,13 @@ class ChatPanelManager(
             gravity = android.view.Gravity.START or android.view.Gravity.TOP
             isFocusable = true
             isFocusableInTouchMode = true
+            addTextChangedListener(object : TextWatcher {
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+                override fun afterTextChanged(s: Editable?) {
+                    holdToTalkManager?.updateTranscribedText(s?.toString() ?: "")
+                }
+            })
         }
         bubble.addView(bubbleEt, FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT
@@ -3209,12 +3221,19 @@ class ChatPanelManager(
     }
 
     private fun dismissResultMode() {
-        isResultMode = false
         hideBubbleThinking()
         hideAppendRecordingUI()
+        // bubbleEt 移出视图树前主动把焦点转给面板根布局，避免系统把焦点自动转给主输入框
+        // （editText 一直保持可获焦状态），进而被 IME 感知为「有输入框获焦」而自动弹出主键盘。
+        resultBubbleEditText?.let { et ->
+            SoftKeyboardUtils.getInstance().hideInput(iConversationContext.chatActivity, et)
+            et.clearFocus()
+        }
+        SoftKeyboardUtils.getInstance().requestFocus(parentView)
         resultOverlay?.let {
             (it.parent as? ViewGroup)?.removeView(it)
         }
+        isResultMode = false
         resultOverlay = null
         resultBubbleEditText = null
         resultBubbleContainer = null

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -879,13 +879,24 @@ class ChatPanelManager(
     /**
      * 文本超出字节限制时弹窗提示，确认后转为 .txt 文件发送
      */
-    private fun showTextToFileAlert(text: String) {
+    /**
+     * @param restoreComposerText 语音场景专用：弹窗关闭后要写回 editText 的用户草稿（顶替前
+     *        暂存的内容）。null 表示无需还原（如手动发送键路径，text 本来就是用户在打的内容）。
+     *
+     * 🔴 R4 fix (review)：还原时机不能抢在用户点弹窗按钮之前——旧实现在弹窗弹出的同一时刻就
+     * 同步把 restoreComposerText 写回 editText，导致两个出口都把这次还原的价值抵消掉：点
+     * 「确认」，sendTextAsFile 内部无条件清空 editText，刚写回的草稿立刻被清没；点「取消」，
+     * STT 文本（此刻只存在于 editText，气泡已随 dismissResultMode 销毁）被草稿覆盖后无副本，
+     * 用户只能重录。现在把还原挪进各自的按钮回调：确认发送后才写回草稿；取消则保留 STT 文本
+     * 不还原，让用户能看到、能编辑重发，与空草稿子路径的行为一致。
+     */
+    private fun showTextToFileAlert(text: String, restoreComposerText: String? = null) {
         val context = iConversationContext.chatActivity
         AlertDialog.Builder(context)
             .setMessage(context.getString(com.chat.base.R.string.str_text_exceed_limit_tip))
             .setNegativeButton(context.getString(com.chat.base.R.string.cancel), null)
             .setPositiveButton(context.getString(com.chat.base.R.string.str_confirm_send)) { _, _ ->
-                sendTextAsFile(text)
+                sendTextAsFile(text, restoreComposerText)
             }
             .show()
     }
@@ -893,7 +904,7 @@ class ChatPanelManager(
     /**
      * 将文本内容生成 .txt 文件并以文件消息发送
      */
-    private fun sendTextAsFile(text: String) {
+    private fun sendTextAsFile(text: String, restoreComposerText: String? = null) {
         val context = iConversationContext.chatActivity
         // 用前10个字符作为文件名
         var namePrefix = if (text.length > 10) text.substring(0, 10) else text
@@ -919,8 +930,14 @@ class ChatPanelManager(
 
         iConversationContext.sendMessage(fileContent)
 
-        // 清空输入框
-        editText.text = null
+        // 语音场景：写回用户草稿，而不是无条件清空——editText 此刻仍是 STT 占位文本，
+        // 直接清空会把 restoreComposerText 的还原价值抵消掉（见 showTextToFileAlert 说明）。
+        if (!restoreComposerText.isNullOrEmpty()) {
+            editText.setText(restoreComposerText)
+            editText.setSelection(restoreComposerText.length)
+        } else {
+            editText.text = null
+        }
         lastInputTime = 0
         if (chatTopView?.visibility == View.VISIBLE) {
             CommonAnim.getInstance().animateClose(chatTopView)
@@ -4414,13 +4431,10 @@ class ChatPanelManager(
         // 🔴 R3 fix (review)：「转文件」弹窗针对的是 STT placeholder 文本本身超限（长语音
         // 识别结果超字节），托盘图片这次发送并未被接管。sendVoiceTextDirect 没有超字节兜底，
         // 不能靠返回 false 甩给调用方直接发出去（会绕过超限保护）；这里仍然弹提示、返回 true
-        // 表示「已处理」，但要先把 editText 还原成用户草稿，不能让草稿跟着 STT 占位文本一起清空。
+        // 表示「已处理」。还原草稿的时机交给 showTextToFileAlert 的两个按钮回调（见 R4 fix），
+        // 不能在弹窗弹出的同一刻同步还原——用户还没做选择，还原会被两个出口分别抵消或丢弹。
         if (!TextUtils.isEmpty(rawText) && isTextOverByteLimit(rawText)) {
-            showTextToFileAlert(rawText)
-            if (!restoreComposerText.isNullOrEmpty()) {
-                editText.setText(restoreComposerText)
-                editText.setSelection(restoreComposerText.length)
-            }
+            showTextToFileAlert(rawText, restoreComposerText)
             return true
         }
         richTextTraySending = true

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -4387,9 +4387,15 @@ class ChatPanelManager(
         // 用户原始草稿一起丢掉。返回 false 让调用方走原文本路径把语音结果单独发出去，同时
         // 把 editText 还原成草稿，不动本次未被接管的托盘状态（留给上一次 in-flight 发送收尾）。
         if (richTextTraySending) {
-            if (!restoreComposerText.isNullOrEmpty()) {
-                editText.setText(restoreComposerText)
-                editText.setSelection(restoreComposerText.length)
+            // 用 null 判空而非 isNullOrEmpty()：手动点发送键走默认参数 null，语音场景
+            // 永远传非 null 的 previous（即便用户没打草稿也是 ""）。isNullOrEmpty() 会把
+            // 「语音场景空草稿」误判成「手动重复点击」直接 return true，调用方因此认为
+            // 已接管、不再走 sendVoiceTextDirect，语音识别结果被静默丢弃。
+            if (restoreComposerText != null) {
+                if (restoreComposerText.isNotEmpty()) {
+                    editText.setText(restoreComposerText)
+                    editText.setSelection(restoreComposerText.length)
+                }
                 return false
             }
             return true

--- a/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/chat/ChatPanelManager.kt
@@ -1716,16 +1716,24 @@ class ChatPanelManager(
                 this.start = start
                 this.count = count
                 // 🔴 语音模式下发送按钮显示异常：本 watcher 写 sendIV.visibility 时原先缺少
-                // isVoiceMode 判断（updateSendBtnForTray() 在 :4556 有对等的早返回，这里没有）。
+                // isVoiceMode 判断（updateSendBtnForTray() 在 :4600 有对等的早返回，这里没有）。
                 // 语音模式下 onSendText 会用 editText.setText(text) 临时顶替文本去拼图文消息，
                 // 这个赋值本身会触发本 watcher，从而在语音模式下把 sendIV 错误置为可见——
                 // 用户看到的是「按住说话」条，但旁边多出一个可点的发送键，状态与实际输入模式不
                 // 一致。isShowSendBtn 仍照常更新（退出语音模式后据此正确恢复），只是可见性的
                 // 写入在语音模式下跳过，交由 toggleVoiceMode() 统一控制 sendIV 显隐。
+                //
+                // 🔴 R3 fix (review)：上一版用 !isShowSendBtn 做「已经显示就不用重设」的防抖，
+                // 但 isShowSendBtn 在语音模式期间会被正常同步更新（见下方/updateSendBtnForTray
+                // 的解耦逻辑），可能与 sendIV 的真实可见性脱节——例如语音模式期间图文托盘异步
+                // 发送完成，isShowSendBtn 被同步为 true，但 sendIV 因为语音模式早返回仍是 GONE；
+                // 退出语音模式或本 watcher 之后再被触发时，!isShowSendBtn 判断为 false，误判为
+                // 「已经在显示」而跳过重设，sendIV 卡在 GONE。改为直接看 sendIV.visibility 的
+                // 真实值，不依赖可能失真的缓存标记。
                 if (!TextUtils.isEmpty(s.toString())) {
                     val content = StringUtils.replaceBlank(s.toString())
                     if (!TextUtils.isEmpty(content)) {
-                        if (!isShowSendBtn && !isVoiceMode) {
+                        if (sendIV.visibility != View.VISIBLE && !isVoiceMode) {
                             sendIV.clearColorFilter()
                             sendIV.visibility = View.VISIBLE
                             CommonAnim.getInstance().animImageView(sendIV)
@@ -2758,7 +2766,8 @@ class ChatPanelManager(
                             if (!richTextTray.isEmpty()) {
                                 val previous = editText.text?.toString() ?: ""
                                 editText.setText(text)
-                                if (!flushRichTextTraySend(restoreComposerText = previous)) {
+                                val handled = flushRichTextTraySend(restoreComposerText = previous)
+                                if (!handled) {
                                     // tray 未接管（如 reply/edit 态）— 复原文本并按原文本路径发出。
                                     editText.setText(previous)
                                     sendVoiceTextDirect(text)
@@ -4359,19 +4368,30 @@ class ChatPanelManager(
      * 才做（onEnqueued）。上传未完成期间图片留在托盘、文本留在输入框。注：托盘仅内存态，
      * 进程死会丢失托盘图片（文本草稿另有持久化）——这是 accepted scope 的 UX 非对称，非发送原子性回归。
      *
-     * @return true 表示本次点击已被托盘发送接管（含「超字节弹转文件框」）；false 表示未接管
-     *         （如进入 reply/edit 态），调用方应继续走原有文本 / reply / edit 发送路径。
-     */
-    /**
      * @param restoreComposerText 语音输入场景专用：调用前 editText 已被 STT 文本临时顶替
      *        （见 onSendText 的 caption 聚合），这里保存的是被顶替前、用户真正在打的草稿。
      *        消息入队后若 editText 按 shouldClearComposer 被清空，用这份草稿写回，而不是
      *        placeholder 文本随手一清就把用户还没发的字丢了。null 表示无需还原（如普通点击
      *        发送键，editText 本来就是要发的内容）。
+     * @return true 表示本次点击已被托盘发送接管（含「超字节弹转文件框」）；false 表示未接管
+     *         （如进入 reply/edit 态，或语音场景下命中 in-flight 防重入），调用方应继续走
+     *         原有文本 / reply / edit / sendVoiceTextDirect 发送路径。
      */
     private fun flushRichTextTraySend(restoreComposerText: String? = null): Boolean {
         // in-flight 防重入：上一次托盘发送还在上传图片期间，吞掉重复点击，避免重复 type=14。
+        //
+        // 🔴 R3 fix (review)：这个分支和下面「超字节」分支原先都在 richTextTraySending=true
+        // 之前 return true——对着手动连续点发送键，「吞掉、不重复发」是对的；但语音场景传入
+        // restoreComposerText 时，这次调用代表的是一段新的语音识别结果，不是重复点击，如果
+        // 仍然返回 true，调用方会认为「已接管」而不再发送这段语音文本，等于把这次语音结果和
+        // 用户原始草稿一起丢掉。返回 false 让调用方走原文本路径把语音结果单独发出去，同时
+        // 把 editText 还原成草稿，不动本次未被接管的托盘状态（留给上一次 in-flight 发送收尾）。
         if (richTextTraySending) {
+            if (!restoreComposerText.isNullOrEmpty()) {
+                editText.setText(restoreComposerText)
+                editText.setSelection(restoreComposerText.length)
+                return false
+            }
             return true
         }
         val rawTextRaw = editText.text?.toString() ?: ""
@@ -4384,8 +4404,17 @@ class ChatPanelManager(
             return false
         }
         // 文本超字节上限：交回发送键转文件路径（与纯文本同源阈值），不发超限 payload。
+        //
+        // 🔴 R3 fix (review)：「转文件」弹窗针对的是 STT placeholder 文本本身超限（长语音
+        // 识别结果超字节），托盘图片这次发送并未被接管。sendVoiceTextDirect 没有超字节兜底，
+        // 不能靠返回 false 甩给调用方直接发出去（会绕过超限保护）；这里仍然弹提示、返回 true
+        // 表示「已处理」，但要先把 editText 还原成用户草稿，不能让草稿跟着 STT 占位文本一起清空。
         if (!TextUtils.isEmpty(rawText) && isTextOverByteLimit(rawText)) {
             showTextToFileAlert(rawText)
+            if (!restoreComposerText.isNullOrEmpty()) {
+                editText.setText(restoreComposerText)
+                editText.setSelection(restoreComposerText.length)
+            }
             return true
         }
         richTextTraySending = true
@@ -4590,12 +4619,19 @@ class ChatPanelManager(
      * 判断（if (!isShowSendBtn) 才去设可见性），误判为「已经显示，不用再设」，实际 sendIV 早
      * 已被 toggleVoiceMode 设成 GONE，于是发送键就此消失。修复：isShowSendBtn 这个状态量始终
      * 正常计算更新，只把 sendIV.visibility 的写入放在语音模式判断之后跳过，两件事解耦。
+     *
+     * 🔴 R3 fix (review)：上面这版解耦本身又引入了镜像缺陷——isShowSendBtn 在语音模式期间
+     * 被正常同步为 true 后，退出语音模式时 wasShowing 读到的正是这个「已经是 true」的值，
+     * if (!wasShowing) 判断为 false，误判为「已经在显示」而跳过 VISIBLE 写入；但 sendIV 从
+     * 进语音模式起一直是 GONE，从未被语音模式期间的早返回路径设置过——用户能看到恢复的草稿，
+     * 却没有发送键，且无法通过继续输入恢复（TextWatcher 同样用缓存标记做防抖）。根源是缓存
+     * 标记 isShowSendBtn 不能保证等于 sendIV 的真实可见性。改为直接判断 sendIV.visibility
+     * 本身，不再依赖可能与实际视图状态脱节的缓存值。
      */
     private fun updateSendBtnForTray() {
         val hasText = !TextUtils.isEmpty(StringUtils.replaceBlank(editText.text?.toString() ?: ""))
         val hasTrayImages = !richTextTray.isEmpty()
         val shouldShow = hasTrayImages || hasText
-        val wasShowing = isShowSendBtn
         isShowSendBtn = shouldShow
         if (isVoiceMode) {
             // 语音模式下发送键本就应保持隐藏，交由 toggleVoiceMode() 统一控制；这里只同步
@@ -4603,7 +4639,7 @@ class ChatPanelManager(
             return
         }
         if (shouldShow) {
-            if (!wasShowing) {
+            if (sendIV.visibility != View.VISIBLE) {
                 sendIV.clearColorFilter()
                 sendIV.visibility = View.VISIBLE
             }

--- a/wkuikit/src/main/java/com/chat/uikit/view/voice/HoldToTalkManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/view/voice/HoldToTalkManager.kt
@@ -85,6 +85,11 @@ class HoldToTalkManager(private val activity: Activity) {
     // 已转写出的文本（连续追加说话场景），与外部输入框草稿无关。
     private var transcribedText: String? = null
 
+    // 追加录音的会话世代号：每次开始新的一轮语音会话（含 startRecording/cancelResult/
+    // sendResultText）都递增，追加识别回调据此判断响应是否仍属于当前会话——纯 state 判断
+    // 不够，因为迟到响应落地时新会话可能同样合法地处于 State.RESULT。
+    private var appendSession = 0
+
     fun handleTouch(event: MotionEvent): Boolean {
         when (event.action) {
             MotionEvent.ACTION_DOWN -> {
@@ -153,6 +158,7 @@ class HoldToTalkManager(private val activity: Activity) {
         }
 
         transcribedText = null
+        appendSession++
         state = State.RECORDING
         recordDuration = 0
         smoothedPower = 0f
@@ -275,6 +281,7 @@ class HoldToTalkManager(private val activity: Activity) {
         listener?.onDismissResultUI()
         listener?.onSendText(text)
         transcribedText = null
+        appendSession++
         cleanupAudioFile()
     }
 
@@ -282,6 +289,7 @@ class HoldToTalkManager(private val activity: Activity) {
         state = State.IDLE
         listener?.onDismissResultUI()
         transcribedText = null
+        appendSession++
         cleanupAudioFile()
     }
 
@@ -320,6 +328,7 @@ class HoldToTalkManager(private val activity: Activity) {
         listener?.onAppendThinkingStart()
 
         val file = audioFile ?: return
+        val session = appendSession
         // context_text: 只用本次语音会话已转写的文本，不读外部输入框草稿（对齐 iOS）
         val contextText = transcribedText
         val fullContext = listener?.getChatContext()
@@ -340,6 +349,9 @@ class HoldToTalkManager(private val activity: Activity) {
 
         WKVoiceInputService.instance.getVoiceContext { personalContext ->
             WKVoiceInputService.instance.transcribeAudio(file, contextText, chatContext, personalContext, memberContext) { result, error ->
+                // session 校验：state==RESULT 不够，因为响应落地时新会话可能同样合法地
+                // 处于 RESULT——必须比对会话世代号，确保响应仍属于发起它的那一轮会话。
+                if (session != appendSession) return@transcribeAudio
                 listener?.onAppendThinkingEnd()
                 if (error != null || result == null || result.text.isEmpty()) {
                     WKToastUtils.getInstance().showToastNormal(activity.getString(R.string.voice_recognize_failed))

--- a/wkuikit/src/main/java/com/chat/uikit/view/voice/HoldToTalkManager.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/view/voice/HoldToTalkManager.kt
@@ -48,7 +48,6 @@ class HoldToTalkManager(private val activity: Activity) {
         fun onSendVoice(audioPath: String, seconds: Int, waveform: String)
         fun onRecordingStarted()
         fun onRecordingStopped()
-        fun getCurrentInputText(): String?
         fun getChatContext(): String?
         fun onShowResultUI(text: String)
         fun onDismissResultUI()
@@ -81,6 +80,10 @@ class HoldToTalkManager(private val activity: Activity) {
     @Volatile private var meteringAmplitude = 0
 
     private val waveformLevels = mutableListOf<Float>()
+
+    // 对齐 iOS WKHoldToTalkManager.transcribedText：context_text 只用本次语音会话
+    // 已转写出的文本（连续追加说话场景），与外部输入框草稿无关。
+    private var transcribedText: String? = null
 
     fun handleTouch(event: MotionEvent): Boolean {
         when (event.action) {
@@ -149,6 +152,7 @@ class HoldToTalkManager(private val activity: Activity) {
             return
         }
 
+        transcribedText = null
         state = State.RECORDING
         recordDuration = 0
         smoothedPower = 0f
@@ -216,7 +220,8 @@ class HoldToTalkManager(private val activity: Activity) {
             return
         }
 
-        val contextText = listener?.getCurrentInputText()
+        // context_text: 只用本次语音会话已转写的文本，不读外部输入框草稿（对齐 iOS）
+        val contextText = transcribedText
         val fullContext = listener?.getChatContext()
 
         // 拆分 fullContext：聊天成员：xxx\n[发送者]: yyy → memberContext + chatContext
@@ -245,6 +250,7 @@ class HoldToTalkManager(private val activity: Activity) {
                     return@transcribeAudio
                 }
 
+                transcribedText = result.text
                 dismissOverlay()
                 showResult(result.text)
             }
@@ -256,16 +262,26 @@ class HoldToTalkManager(private val activity: Activity) {
         listener?.onShowResultUI(text)
     }
 
+    /**
+     * 用户手动编辑结果气泡文本时调用，同步为下一次追加录音的 context_text（对齐 iOS
+     * textViewDidChange 回写 self.transcribedText）。
+     */
+    fun updateTranscribedText(text: String) {
+        transcribedText = text
+    }
+
     fun sendResultText(text: String) {
         state = State.IDLE
         listener?.onDismissResultUI()
         listener?.onSendText(text)
+        transcribedText = null
         cleanupAudioFile()
     }
 
     fun cancelResult() {
         state = State.IDLE
         listener?.onDismissResultUI()
+        transcribedText = null
         cleanupAudioFile()
     }
 
@@ -304,7 +320,8 @@ class HoldToTalkManager(private val activity: Activity) {
         listener?.onAppendThinkingStart()
 
         val file = audioFile ?: return
-        val contextText = listener?.getCurrentInputText()
+        // context_text: 只用本次语音会话已转写的文本，不读外部输入框草稿（对齐 iOS）
+        val contextText = transcribedText
         val fullContext = listener?.getChatContext()
 
         var memberContext: String? = null
@@ -329,6 +346,8 @@ class HoldToTalkManager(private val activity: Activity) {
                     cleanupAudioFile()
                     return@transcribeAudio
                 }
+                // 追加录音必带上下文，服务端已基于 transcribedText 续接返回，直接替换（对齐 iOS）
+                transcribedText = result.text
                 listener?.onAppendText(result.text)
                 cleanupAudioFile()
             }

--- a/wkuikit/src/main/java/com/chat/uikit/view/voice/HoldToTalkOverlayView.kt
+++ b/wkuikit/src/main/java/com/chat/uikit/view/voice/HoldToTalkOverlayView.kt
@@ -61,6 +61,9 @@ class HoldToTalkOverlayView(context: Context) : FrameLayout(context) {
     private val bubbleGreenColor = Color.argb(255, 77, 199, 102)
 
     init {
+        // 录音/转写期间需挡住底层消息列表的点击/长按穿透——拖拽手势由外部
+        // HoldToTalkManager.handleTouch 处理，这里只需拦截，不需要消费具体事件。
+        isClickable = true
         setBackgroundColor(Color.argb(166, 0, 0, 0)) // 65% black
 
         // Bottom area (theme color arc)


### PR DESCRIPTION
Closes #155 

## 背景

语音输入（按住说话 → 识别 → 结果气泡编辑 → 发送）链路存在若干问题，本 PR 做了一次整体修复。

## 改动内容

### 1. 语音识别上下文来源修正

追加录音场景下，发给识别服务的上下文文本改为只跟踪本次语音会话已转写出的文本，不再依赖外部主输入框的草稿内容。识别成功、结果被手动编辑、发送/取消时都会同步更新这份上下文；对齐 iOS 端的实现逻辑。

### 2. 追加录音结果展示方式修正

追加录音识别完成后，改为直接用服务端返回的完整文本整体覆盖显示（服务端已基于会话上下文做了续接），不再在本地做字符串拼接，避免重复内容或拼接错位。

### 3. 录音遮罩层触摸穿透修复

录音/转写期间的全屏遮罩层补充拦截触摸事件，避免手势穿透到底层消息列表造成误触（误点消息、误触长按菜单等）。拖拽手势仍由原有逻辑正常处理。

### 4. 修复退出语音结果气泡后主键盘被自动唤起的问题

排查发现：主输入框在语音模式期间始终保持"可获焦"状态，结果气泡的输入框被从视图树移除时，Android 焦点系统会隐式把焦点转移给主输入框，从而触发系统输入法自动弹出——这条路径独立于已有的"气泡展示期间豁免抢焦点"逻辑，因此没有被拦截。

修复方式：在移除气泡视图之前，主动让气泡输入框放弃焦点，并把焦点转交给一个不会触发输入法的容器，从而避免系统把焦点隐式转移给主输入框。原有的豁免逻辑保留，作为另一条路径的防护。

### 5. 修复追加录音的会话竞态：已取消会话的识别结果可能污染下一次会话

代码审查发现：用户取消一次语音会话后，如果该会话此前发出的"追加录音"识别请求的响应延迟到达，其转写文本会被错误地带入下一次全新的语音会话，最终作为已发出消息的一部分发给对方。

原因是追加录音的识别回调完全没有做"响应是否仍属于当前会话"的校验，而取消操作只清空本地状态、不会取消已在途的网络请求；改动 3（上下文来源修正）引入的会话内转写文本字段又是跨会话持久存在的，一旦被迟到响应写入，就会被下一轮全新会话直接当作上下文使用。仅靠录音状态机的状态判断不足以修复——响应延迟到达时，新会话可能同样合法地处于"结果展示"状态，两次会话状态相同但语义上并非同一次。

修复方式：引入一个单调递增的会话世代号，在每次开始新一轮语音会话、取消结果、发送结果时递增；发起追加识别请求时记录下当前世代号，识别回调返回时比对世代号是否仍与当前一致，不一致则说明响应已过期，直接丢弃，不再写入上下文、不再覆盖结果气泡。

### 6. 修复语音模式下发送按钮显示异常，导致隐藏草稿被静默丢弃

代码审查发现：语音模式下，输入框的文本变化监听器在写发送按钮可见性时缺少语音模式判断（与其他同类逻辑不一致），会在语音识别结果发送流程中被意外触发，导致发送按钮短暂错误可见，与当前"按住说话"的输入模式不符。

排查该问题过程中，进一步定位到一个更严重的关联问题：当输入框原本有未发送的草稿文字、且图片托盘里有待发图片时，语音识别结果确认发送后，图片会按预期一起发出，但用户原有的草稿文字会永久丢失，且用户对此毫无感知。

成因：语音结果发送时，为了把识别文本和托盘图片拼成一条图文消息，会把识别文本临时写入输入框顶替用户原有草稿；托盘发送成功交由异步流程处理后，函数直接返回，没有任何路径把被顶替的原始草稿写回，随后异步入队完成时输入框会被判定为"内容未变化"而清空——清掉的其实是识别文本这个占位内容，而用户真正的草稿在被顶替的那一刻起就已经无法恢复。已通过全链路日志复现验证。

修复方式：托盘发送函数新增一个用于恢复草稿的参数，语音发送路径把被顶替前的原始草稿传入；托盘发送异步完成、判定应清空输入框时，改为优先写回这份草稿，而不是直接清空。同时给输入框文本监听器补上语音模式判断，避免发送按钮在语音模式下被错误置为可见。

### 7. 修复图文混排异步发送期间切换到语音模式，导致切回键盘后发送键消失

代码审查确认：本分支之前已经修过一次"退出语音模式后发送键消失"的问题（纯图片托盘 + 空文本场景），但实机复现发现同一现象在另一条路径下依然存在，且该路径本分支之前未覆盖。

复现路径：输入框有草稿、托盘有图，点发送键触发图文混排消息发送（该发送是异步的，需要等待图片上传），在上传完成前用户点击语音图标切到语音模式；上传完成的回调在语音模式期间才触发，导致托盘被清空、发送按钮状态刷新函数被调用；该函数在语音模式下会整体跳过执行，不更新任何状态；用户随后切回键盘时，发送按钮该显示却没有显示。已通过全链路日志逐帧还原整个触发时序并确认根因。

成因：发送按钮状态刷新函数在语音模式下直接整体跳过，除了不更新按钮可见性（这是预期行为，语音模式下本就不该显示发送按钮），也连带跳过了内部状态标记的同步更新。当异步发送在语音模式期间完成、把托盘清空后，这个内部状态标记就停留在进入语音模式前的旧值，与实际情况脱节。用户切回键盘时，该函数依赖这个已经过期的状态标记做重复判断，误判为"已经在显示，不需要重新显示"，实际按钮当时是隐藏的，于是保持隐藏，未能恢复。

修复方式：把"更新内部状态标记"和"更新按钮可见性"两件事拆开——内部状态标记在任何模式下都按输入框内容和托盘状态正常计算更新，只有按钮可见性的实际写入才在语音模式下跳过。这样退出语音模式时读到的状态标记始终是准确的，不会再因为语音模式期间的跳过而失真。

### 8. 其他

补充退出语音模式时发送按钮显示状态的复位，避免退出语音模式后按钮显示状态与实际输入框内容不一致。

## 测试

- [x] 相关模块编译通过
- [x] 实机验证：识别结果编辑 → 退出语音状态，主键盘不再自动唤起
- [x] 实机验证：追加录音场景下上下文内容、展示内容符合预期
- [x] 实机验证：录音期间点击消息列表不再误触
- [x] 实机验证：追加录音请求在途时取消会话并立即开始新会话，确认旧响应不会污染新会话内容
- [x] 实机验证：语音模式下发送按钮不再错误显示